### PR TITLE
Override config from supabase/.github

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Feature request
+    url: https://github.com/supabase/postgres_lsp/discussions/categories/ideas
+    about: Request a new feature or example.
+  - name: Ask a question
+    url: https://github.com/supabase/postgres_lsp/discussions/categories/q-a
+    about: Ask questions and discuss with other community members.
+  - name: Want to work with us?
+    url: https://supabase.io/humans.txt
+    about: Want to work with us? Get in touch!


### PR DESCRIPTION
Override [the organization-level configuration](https://github.com/supabase/supabase/discussions/categories/feature-requests) which redirects Feature Requests to the main `supabase/supabase` discussions page

This may be unwanted, according to this comment by @kiwicopple:

- https://github.com/orgs/supabase/discussions/16286#discussioncomment-6657204
