### PR TITLE
fix: use https path for libpg_query submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libpg_query"]
 	path = libpg_query
-	url = git@github.com:pganalyze/libpg_query.git
+	url = https://github.com/pganalyze/libpg_query.git


### PR DESCRIPTION
I was unable to checkout the submodule without the new https path.