### PR TITLE
add support for parsing "create domain" statement

### DIFF
--- a/crates/codegen/src/get_node_properties.rs
+++ b/crates/codegen/src/get_node_properties.rs
@@ -535,9 +535,6 @@ fn custom_handlers(node: &Node) -> TokenStream {
             if n.type_name.is_some() {
                 tokens.push(TokenProperty::from(Token::As));
             }
-            if n.constraints.len() > 0 {
-                tokens.push(TokenProperty::from(Token::Check));
-            }
         },
         _ => quote! {},
     }

--- a/crates/codegen/src/get_node_properties.rs
+++ b/crates/codegen/src/get_node_properties.rs
@@ -529,6 +529,16 @@ fn custom_handlers(node: &Node) -> TokenStream {
         "TypeCast" => quote! {
             tokens.push(TokenProperty::from(Token::Typecast));
         },
+        "CreateDomainStmt" => quote! {
+            tokens.push(TokenProperty::from(Token::Create));
+            tokens.push(TokenProperty::from(Token::DomainP));
+            if n.type_name.is_some() {
+                tokens.push(TokenProperty::from(Token::As));
+            }
+            if n.constraints.len() > 0 {
+                tokens.push(TokenProperty::from(Token::Check));
+            }
+        },
         _ => quote! {},
     }
 }

--- a/crates/parser/src/codegen.rs
+++ b/crates/parser/src/codegen.rs
@@ -91,4 +91,19 @@ mod tests {
             ],
         )
     }
+
+    #[test]
+    fn test_create_domain() {
+        test_get_node_properties(
+            "create domain us_postal_code as text check (value is not null);",
+            SyntaxKind::CreateDomainStmt,
+            vec![
+                TokenProperty::from(SyntaxKind::Create),
+                TokenProperty::from(SyntaxKind::DomainP),
+                TokenProperty::from(SyntaxKind::As),
+                TokenProperty::from(SyntaxKind::Check),
+                TokenProperty::from("us_postal_code".to_string()),
+            ],
+        )
+    }
 }

--- a/crates/parser/src/codegen.rs
+++ b/crates/parser/src/codegen.rs
@@ -101,7 +101,6 @@ mod tests {
                 TokenProperty::from(SyntaxKind::Create),
                 TokenProperty::from(SyntaxKind::DomainP),
                 TokenProperty::from(SyntaxKind::As),
-                TokenProperty::from(SyntaxKind::Check),
                 TokenProperty::from("us_postal_code".to_string()),
             ],
         )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature: try to add support for "create domain" statement as requested in #51

## What is the current behavior?

Parser panics:

```sh
could not find node for token Token { kind: Create, text: "CREATE", span: 0..6, token_type: ReservedKeyword } at depth 1
```

## What is the new behavior?

Parser returns:

```sh
  CreateDomainStmt@0..37
    Create@0..6 "CREATE"
    Whitespace@6..7 " "
    DomainP@7..13 "DOMAIN"
    Whitespace@13..14 " "
    Ident@14..28 "us_postal_code"
    Whitespace@28..29 " "
    As@29..31 "AS"
    Whitespace@31..32 " "
    TypeName@32..36
      TextP@32..36 "TEXT"
    Ascii59@36..37 ";"
```

## Additional context

Not sure of what exactly should go in the `CreateDomainStmt` branch, but I have tried with these variations and it worked:

```sql
CREATE DOMAIN name [ AS ] data_type [ constraint [ ... ] ]
```
