### PR TITLE
feat: support "create schema"

### DIFF
--- a/crates/codegen/src/get_node_properties.rs
+++ b/crates/codegen/src/get_node_properties.rs
@@ -536,6 +536,18 @@ fn custom_handlers(node: &Node) -> TokenStream {
                 tokens.push(TokenProperty::from(Token::As));
             }
         },
+        "CreateSchemaStmt" => quote! {
+            tokens.push(TokenProperty::from(Token::Create));
+            tokens.push(TokenProperty::from(Token::Schema));
+            if n.if_not_exists {
+                tokens.push(TokenProperty::from(Token::IfP));
+                tokens.push(TokenProperty::from(Token::Not));
+                tokens.push(TokenProperty::from(Token::Exists));
+            }
+            if n.authrole.is_some() {
+                tokens.push(TokenProperty::from(Token::Authorization));
+            }
+        },
         _ => quote! {},
     }
 }

--- a/crates/parser/src/codegen.rs
+++ b/crates/parser/src/codegen.rs
@@ -107,4 +107,21 @@ mod tests {
             ],
         )
     }
+
+    #[test]
+    fn test_create_schema() {
+        test_get_node_properties(
+            "create schema if not exists test authorization joe;",
+            SyntaxKind::CreateSchemaStmt,
+            vec![
+                TokenProperty::from(SyntaxKind::Create),
+                TokenProperty::from(SyntaxKind::Schema),
+                TokenProperty::from(SyntaxKind::IfP),
+                TokenProperty::from(SyntaxKind::Not),
+                TokenProperty::from(SyntaxKind::Exists),
+                TokenProperty::from(SyntaxKind::Authorization),
+                TokenProperty::from("test".to_string()),
+            ],
+        )
+    }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

In the continuation of #61 & #51. Ultimately, being able to parse most of the DDL statements would be nice

## What is the current behavior?

Parser panics:

```sh
could not find node for token Token { kind: Create, text: "CREATE", span: 0..6, token_type: ReservedKeyword } at depth 1
```

## What is the new behavior?

Parser returns:

```rust
        CreateSchemaStmt(
            CreateSchemaStmt {
                schemaname: "test",
                authrole: Some(
                    RoleSpec {
                        roletype: RolespecCstring,
                        rolename: "joe",
                        location: 47,
                    },
                ),
                schema_elts: [],
                if_not_exists: true,
            },
        ),
```

## Additional context

Add any other context or screenshots.
