### PR TITLE
feat: support "create view" with relpersistence

### DIFF
--- a/crates/codegen/src/get_node_properties.rs
+++ b/crates/codegen/src/get_node_properties.rs
@@ -439,6 +439,17 @@ fn custom_handlers(node: &Node) -> TokenStream {
                 tokens.push(TokenProperty::from(Token::Or));
                 tokens.push(TokenProperty::from(Token::Replace));
             }
+            if let Some(n) = &n.view {
+                match n.relpersistence.as_str() {
+                    // Permanent
+                    "p" => {},
+                    // Unlogged
+                    "u" => tokens.push(TokenProperty::from(Token::Unlogged)),
+                    // Temporary
+                    "t" => tokens.push(TokenProperty::from(Token::Temporary)),
+                    _ => panic!("Unknown ViewStmt {:#?}", n),
+                }
+            }
         },
         "CreateStmt" => quote! {
             tokens.push(TokenProperty::from(Token::Create));

--- a/crates/parser/src/codegen.rs
+++ b/crates/parser/src/codegen.rs
@@ -124,4 +124,20 @@ mod tests {
             ],
         )
     }
+
+    #[test]
+    fn test_create_view() {
+        test_get_node_properties(
+            "create or replace temporary view comedies as select * from films;",
+            SyntaxKind::ViewStmt,
+            vec![
+                TokenProperty::from(SyntaxKind::Create),
+                TokenProperty::from(SyntaxKind::View),
+                TokenProperty::from(SyntaxKind::As),
+                TokenProperty::from(SyntaxKind::Or),
+                TokenProperty::from(SyntaxKind::Replace),
+                TokenProperty::from(SyntaxKind::Temporary),
+            ],
+        )
+    }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Follow-up for #63, #51

## What is the current behavior?

Parser panics

## What is the new behavior?

Parser returns:

```rust
        ViewStmt(
            ViewStmt {
                view: Some(
                    RangeVar {
                        catalogname: "",
                        schemaname: "",
                        relname: "comedies",
                        inh: true,
                        relpersistence: "t",
                        alias: None,
                        location: 33,
                    },
                ),
                aliases: [],
                query: Some(
                    Node {
                        node: Some(
                            SelectStmt(
                                SelectStmt {
                                    distinct_clause: [],
                                    into_clause: None,
                                    target_list: [
                                        Node {
                                            node: Some(
                                                ResTarget(
                                                    ResTarget {
                                                        name: "",
                                                        indirection: [],
                                                        val: Some(
                                                            Node {
                                                                node: Some(
                                                                    ColumnRef(
                                                                        ColumnRef {
                                                                            fields: [
                                                                                Node {
                                                                                    node: Some(
                                                                                        AStar(
                                                                                            AStar,
                                                                                        ),
                                                                                    ),
                                                                                },
                                                                            ],
                                                                            location: 52,
                                                                        },
                                                                    ),
                                                                ),
                                                            },
                                                        ),
                                                        location: 52,
                                                    },
                                                ),
                                            ),
                                        },
                                    ],
                                    from_clause: [
                                        Node {
                                            node: Some(
                                                RangeVar(
                                                    RangeVar {
                                                        catalogname: "",
                                                        schemaname: "",
                                                        relname: "films",
                                                        inh: true,
                                                        relpersistence: "p",
                                                        alias: None,
                                                        location: 59,
                                                    },
                                                ),
                                            ),
                                        },
                                    ],
                                    where_clause: None,
                                    group_clause: [],
                                    group_distinct: false,
                                    having_clause: None,
                                    window_clause: [],
                                    values_lists: [],
                                    sort_clause: [],
                                    limit_offset: None,
                                    limit_count: None,
                                    limit_option: Default,
                                    locking_clause: [],
                                    with_clause: None,
                                    op: SetopNone,
                                    all: false,
                                    larg: None,
                                    rarg: None,
                                },
                            ),
                        ),
                    },
                ),
                replace: true,
                options: [],
                with_check_option: NoCheckOption,
            },
        ),
```

## Additional context

I would expect `Temporary` token to be part of `RangeVar` node but parser still panics so I had to make it part of `ViewStmt`, very similar to what we had with the `As` token being part of `CreateDomainStmt` in #61
