### PR TITLE
minor fixes for easier contrib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crates/*",
     "xtask/"
 ]
+resolver = "2"
 
 [workspace.package]
 rust-version = "1.71"
@@ -17,4 +18,3 @@ triomphe = { version = "0.1.8", default-features = false, features = ["std"] }
 [profile.dev.package]
 insta.opt-level = 3
 similar.opt-level = 3
-

--- a/crates/codegen/src/parser.rs
+++ b/crates/codegen/src/parser.rs
@@ -1,5 +1,6 @@
 use pg_query_proto_parser::ProtoParser;
 use quote::quote;
+use std::{env, path, path::Path};
 
 use crate::{
     get_location::get_location_mod, get_node_properties::get_node_properties_mod,
@@ -7,7 +8,7 @@ use crate::{
 };
 
 pub fn parser_mod(_item: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
-    let parser = ProtoParser::new("libpg_query/protobuf/pg_query.proto");
+    let parser = ProtoParser::new(&proto_file_path());
     let proto_file = parser.parse();
 
     let syntax_kind = syntax_kind_mod(&proto_file);
@@ -31,4 +32,13 @@ pub fn parser_mod(_item: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
         #get_node_properties
         #get_nodes
     }
+}
+
+fn proto_file_path() -> path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .unwrap()
+        .join("libpg_query/protobuf/pg_query.proto")
+        .to_path_buf()
 }

--- a/crates/pg_query_proto_parser/src/proto_parser.rs
+++ b/crates/pg_query_proto_parser/src/proto_parser.rs
@@ -1,7 +1,7 @@
 use convert_case::{Case, Casing};
 use protobuf::descriptor::{field_descriptor_proto::Label, FileDescriptorProto};
 use protobuf_parse::Parser;
-use std::path::Path;
+use std::{ffi::OsStr, path::Path};
 
 use crate::proto_file::{Field, FieldType, Node, ProtoFile, Token};
 
@@ -11,7 +11,7 @@ pub struct ProtoParser {
 }
 
 impl ProtoParser {
-    pub fn new(file_path: &str) -> Self {
+    pub fn new(file_path: &impl AsRef<OsStr>) -> Self {
         let proto_file = Path::new(file_path);
         let proto_dir = proto_file.parent().unwrap();
 

--- a/crates/postgres_lsp/src/main.rs
+++ b/crates/postgres_lsp/src/main.rs
@@ -189,7 +189,7 @@ impl LanguageServer for Backend {
 
     async fn semantic_tokens_range(
         &self,
-        params: SemanticTokensRangeParams,
+        _: SemanticTokensRangeParams,
     ) -> Result<Option<SemanticTokensRangeResult>> {
         return Ok(None);
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes various warnings encountered when trying to run the project

## What is the current behavior?

- testing requires `cargo +nightly test`
- warnings with `cargo check`
- `parser` lib cannot be used a `dependencies` (proto file path is relative)

## What is the new behavior?

- testing with `cargo test`
- no warnings
- `parser` lib can be used a `dependencies`

## Additional context

This PR can be split into multiple PRs if you see fit @psteinroe 
