### PR TITLE
feat: support `CreateEnumStmt`

### DIFF
--- a/crates/codegen/src/get_node_properties.rs
+++ b/crates/codegen/src/get_node_properties.rs
@@ -559,6 +559,12 @@ fn custom_handlers(node: &Node) -> TokenStream {
                 tokens.push(TokenProperty::from(Token::Authorization));
             }
         },
+        "CreateEnumStmt" => quote! {
+            tokens.push(TokenProperty::from(Token::Create));
+            tokens.push(TokenProperty::from(Token::TypeP));
+            tokens.push(TokenProperty::from(Token::As));
+            tokens.push(TokenProperty::from(Token::EnumP));
+        },
         _ => quote! {},
     }
 }

--- a/crates/parser/src/codegen.rs
+++ b/crates/parser/src/codegen.rs
@@ -66,6 +66,8 @@ mod tests {
 
         debug!("selected node: {:#?}", node_graph[node_index]);
 
+        // note: even though we test for strict equality of the two vectors the order
+        // of the properties does not have to match the order of the tokens in the string
         assert_eq!(node_graph[node_index].properties, expected);
         assert_eq!(node_graph[node_index].properties.len(), expected.len());
     }

--- a/crates/parser/src/codegen.rs
+++ b/crates/parser/src/codegen.rs
@@ -66,10 +66,7 @@ mod tests {
 
         debug!("selected node: {:#?}", node_graph[node_index]);
 
-        assert!(node_graph[node_index]
-            .properties
-            .iter()
-            .all(|p| { expected.contains(p) }));
+        assert_eq!(node_graph[node_index].properties, expected);
         assert_eq!(node_graph[node_index].properties.len(), expected.len());
     }
 
@@ -137,6 +134,23 @@ mod tests {
                 TokenProperty::from(SyntaxKind::Or),
                 TokenProperty::from(SyntaxKind::Replace),
                 TokenProperty::from(SyntaxKind::Temporary),
+            ],
+        )
+    }
+
+    #[test]
+    fn test_create_enum() {
+        test_get_node_properties(
+            "create type status as enum ('open', 'closed');",
+            SyntaxKind::CreateEnumStmt,
+            vec![
+                TokenProperty::from(SyntaxKind::Create),
+                TokenProperty::from(SyntaxKind::TypeP),
+                TokenProperty::from(SyntaxKind::As),
+                TokenProperty::from(SyntaxKind::EnumP),
+                TokenProperty::from("status".to_string()),
+                TokenProperty::from("open".to_string()),
+                TokenProperty::from("closed".to_string()),
             ],
         )
     }

--- a/crates/parser/tests/data/statements/valid/0037.sql
+++ b/crates/parser/tests/data/statements/valid/0037.sql
@@ -1,0 +1,1 @@
+CREATE TYPE bug_status AS ENUM ('new', 'open', 'closed');


### PR DESCRIPTION
## What kind of change does this PR introduce?

feat: support `CreateEnumStmt`

## What is the current behavior?

Parser panics

## What is the new behavior?

```rust
[2023-12-13T14:27:17Z DEBUG parser::codegen::tests] pg_query_root: Some(
        CreateEnumStmt(
            CreateEnumStmt {
                type_name: [
                    Node {
                        node: Some(
                            String(
                                String {
                                    sval: "status",
                                },
                            ),
                        ),
                    },
                ],
                vals: [
                    Node {
                        node: Some(
                            String(
                                String {
                                    sval: "open",
                                },
                            ),
                        ),
                    },
                    Node {
                        node: Some(
                            String(
                                String {
                                    sval: "closed",
                                },
                            ),
                        ),
                    },
                ],
            },
        ),
    )
```

## Additional context

Add any other context or screenshots.
