### PR TITLE
feat: pass `parent` to `get_node_properties` and add support for create aggregate with order by

### DIFF
--- a/crates/codegen/src/get_nodes.rs
+++ b/crates/codegen/src/get_nodes.rs
@@ -25,7 +25,7 @@ pub fn get_nodes_mod(proto_file: &ProtoFile) -> proc_macro2::TokenStream {
             let root_node_idx = g.add_node(Node {
                 kind: SyntaxKind::from(node),
                 depth: at_depth,
-                properties: get_node_properties(node),
+                properties: get_node_properties(node, None),
                 location: get_location(node),
             });
 
@@ -45,12 +45,12 @@ pub fn get_nodes_mod(proto_file: &ProtoFile) -> proc_macro2::TokenStream {
                         NodeEnum::BitString(n) => true,
                         _ => false
                     } {
-                        g[parent_idx].properties.extend(get_node_properties(&c));
+                        g[parent_idx].properties.extend(get_node_properties(&c, Some(&node)));
                     } else {
                         let node_idx = g.add_node(Node {
                             kind: SyntaxKind::from(&c),
                             depth: current_depth,
-                            properties: get_node_properties(&c),
+                            properties: get_node_properties(&c, Some(&node)),
                             location: get_location(&c),
                         });
                         g.add_edge(parent_idx, node_idx, ());

--- a/crates/parser/src/parse/libpg_query_node.rs
+++ b/crates/parser/src/parse/libpg_query_node.rs
@@ -52,6 +52,7 @@ impl<'p> LibpgQueryNodeParser<'p> {
     ) -> LibpgQueryNodeParser<'p> {
         let current_depth = parser.depth.clone();
         debug!("Parsing node {:#?}", node);
+        println!("Parsing node {:#?}", node);
         Self {
             parser,
             token_range,

--- a/crates/parser/tests/data/statements/valid/0039.sql
+++ b/crates/parser/tests/data/statements/valid/0039.sql
@@ -1,0 +1,10 @@
+CREATE AGGREGATE aggregate1 (int4) (sfunc = sfunc1, stype = stype1);
+CREATE AGGREGATE aggregate1 (int4, bool) (sfunc = sfunc1, stype = stype1);
+CREATE AGGREGATE aggregate1 (*) (sfunc = sfunc1, stype = stype1);
+CREATE AGGREGATE aggregate1 (int4) (sfunc = sfunc1, stype = stype1, finalfunc_extra, mfinalfuncextra);
+CREATE AGGREGATE aggregate1 (int4) (sfunc = sfunc1, stype = stype1, finalfunc_modify = read_only, parallel = restricted);
+CREATE AGGREGATE percentile_disc (float8 ORDER BY anyelement) (sfunc = ordered_set_transition, stype = internal, finalfunc = percentile_disc_final, finalfunc_extra);
+CREATE AGGREGATE custom_aggregate (float8 ORDER BY column1, column2) (sfunc = sfunc1, stype = stype1);
+
+
+


### PR DESCRIPTION
## What kind of change does this PR introduce?

adds support for `CREATE AGGREGATE`

## What is the current behavior?

panics

## What is the new behavior?

still panics for aggregates with `ORDER BY`

## Additional context

follow-up for #69 
