### PR TITLE
feat: add support for create index

### DIFF
--- a/crates/codegen/src/get_node_properties.rs
+++ b/crates/codegen/src/get_node_properties.rs
@@ -544,6 +544,53 @@ fn custom_handlers(node: &Node) -> TokenStream {
             tokens.push(TokenProperty::from(Token::As));
             tokens.push(TokenProperty::from(Token::Range));
         },
+        "IndexStmt" => quote! {
+            tokens.push(TokenProperty::from(Token::Create));
+            if n.unique {
+                tokens.push(TokenProperty::from(Token::Unique));
+            }
+            tokens.push(TokenProperty::from(Token::Index));
+            if n.concurrent {
+                tokens.push(TokenProperty::from(Token::Concurrently));
+            }
+            if n.if_not_exists {
+                tokens.push(TokenProperty::from(Token::IfP));
+                tokens.push(TokenProperty::from(Token::Not));
+                tokens.push(TokenProperty::from(Token::Exists));
+            }
+            tokens.push(TokenProperty::from(Token::On));
+            // access_method is btree by default
+            if n.access_method != "btree" {
+                tokens.push(TokenProperty::from(Token::Using));
+            }
+            if n.index_including_params.len() > 0 {
+                tokens.push(TokenProperty::from(Token::Include));
+            }
+            if n.options.len() > 0 {
+                tokens.push(TokenProperty::from(Token::With));
+            }
+            // table_space is an empty string by default
+            if !n.table_space.is_empty() {
+                tokens.push(TokenProperty::from(Token::Tablespace));
+            }
+        },
+        "IndexElem" => quote! {
+            if n.collation.len() > 0 {
+                tokens.push(TokenProperty::from(Token::Collate));
+            }
+            match n.nulls_ordering() {
+                protobuf::SortByNulls::SortbyNullsDefault => {},
+                protobuf::SortByNulls::SortbyNullsFirst => {
+                    tokens.push(TokenProperty::from(Token::NullsP));
+                    tokens.push(TokenProperty::from(Token::FirstP));
+                },
+                protobuf::SortByNulls::SortbyNullsLast => {
+                    tokens.push(TokenProperty::from(Token::NullsP));
+                    tokens.push(TokenProperty::from(Token::LastP));
+                },
+                _ => panic!("Unknown IndexElem {:#?}", n.nulls_ordering()),
+            }
+        },
         _ => quote! {},
     }
 }

--- a/crates/codegen/src/get_node_properties.rs
+++ b/crates/codegen/src/get_node_properties.rs
@@ -560,7 +560,7 @@ fn custom_handlers(node: &Node) -> TokenStream {
             }
             tokens.push(TokenProperty::from(Token::On));
             // access_method is btree by default
-            if n.access_method != "btree" {
+            if n.access_method.len() > 0 {
                 tokens.push(TokenProperty::from(Token::Using));
             }
             if n.index_including_params.len() > 0 {
@@ -570,7 +570,7 @@ fn custom_handlers(node: &Node) -> TokenStream {
                 tokens.push(TokenProperty::from(Token::With));
             }
             // table_space is an empty string by default
-            if !n.table_space.is_empty() {
+            if n.table_space.len() > 0 {
                 tokens.push(TokenProperty::from(Token::Tablespace));
             }
         },

--- a/crates/parser/src/codegen.rs
+++ b/crates/parser/src/codegen.rs
@@ -188,4 +188,20 @@ mod tests {
             ],
         )
     }
+
+    #[test]
+    fn test_create_index() {
+        test_get_node_properties(
+            "create unique index title_idx on films (title);",
+            SyntaxKind::IndexStmt,
+            vec![
+                TokenProperty::from(SyntaxKind::Create),
+                TokenProperty::from(SyntaxKind::Unique),
+                TokenProperty::from(SyntaxKind::Index),
+                TokenProperty::from(SyntaxKind::On),
+                TokenProperty::from("title_idx".to_string()),
+                TokenProperty::from("btree".to_string()),
+            ],
+        )
+    }
 }

--- a/crates/parser/src/codegen.rs
+++ b/crates/parser/src/codegen.rs
@@ -199,6 +199,7 @@ mod tests {
                 TokenProperty::from(SyntaxKind::Unique),
                 TokenProperty::from(SyntaxKind::Index),
                 TokenProperty::from(SyntaxKind::On),
+                TokenProperty::from(SyntaxKind::Using),
                 TokenProperty::from("title_idx".to_string()),
                 TokenProperty::from("btree".to_string()),
             ],

--- a/crates/parser/tests/data/statements/valid/0051.sql
+++ b/crates/parser/tests/data/statements/valid/0051.sql
@@ -1,0 +1,11 @@
+CREATE UNIQUE INDEX title_idx ON films (title);
+CREATE UNIQUE INDEX title_idx ON films (title) INCLUDE (director, rating);
+CREATE INDEX title_idx ON films (title) WITH (deduplicate_items = off);
+CREATE INDEX ON films ((lower(title)));
+CREATE INDEX title_idx_german ON films (title COLLATE "de_DE");
+CREATE INDEX title_idx_nulls_low ON films (title NULLS FIRST);
+CREATE UNIQUE INDEX title_idx ON films (title) WITH (fillfactor = 70);
+CREATE INDEX gin_idx ON documents_table USING GIN (locations) WITH (fastupdate = off);
+CREATE INDEX code_idx ON films (code) TABLESPACE indexspace;
+CREATE INDEX pointloc ON points USING gist (box(location,location));
+CREATE INDEX CONCURRENTLY sales_quantity_index ON sales_table (quantity);


### PR DESCRIPTION
## What kind of change does this PR introduce?

add support for `create index`

## What is the current behavior?

panics

## What is the new behavior?

<s>parser panics for index with `using btree` (the default) - it works if omitted</s>

parser returns with 5e1ef7b61b38f704b7f4f2af56c441ae9ebcdcfa, but as a side-note `Using` is always pushed

<details>
<summary>View log</summary>

```rust
IndexStmt {
    idxname: "title_idx",
    relation: Some(
        RangeVar {
            catalogname: "",
            schemaname: "",
            relname: "films",
            inh: true,
            relpersistence: "p",
            alias: None,
            location: 33,
        },
    ),
    access_method: "btree",
    table_space: "",
    index_params: [
        Node {
            node: Some(
                IndexElem(
                    IndexElem {
                        name: "title",
                        expr: None,
                        indexcolname: "",
                        collation: [],
                        opclass: [],
                        opclassopts: [],
                        ordering: SortbyDefault,
                        nulls_ordering: SortbyNullsDefault,
                    },
                ),
            ),
        },
    ],
    index_including_params: [],
    options: [],
    where_clause: None,
    exclude_op_names: [],
    idxcomment: "",
    index_oid: 0,
    old_node: 0,
    old_create_subid: 0,
    old_first_relfilenode_subid: 0,
    unique: true,
    nulls_not_distinct: false,
    primary: false,
    isconstraint: false,
    deferrable: false,
    initdeferred: false,
    transformed: false,
    concurrent: false,
    if_not_exists: false,
    reset_default_tblspc: false,
}
```

</details>

## Additional context

NOTE: since `access_method` is always set, `Using` is always pushed (even if absent in the original statement)