### PR TITLE
perf(ci): use cache

### DIFF
--- a/.github/actions/setup-monorepo/action.yml
+++ b/.github/actions/setup-monorepo/action.yml
@@ -13,6 +13,9 @@ runs:
   using: composite
   steps:
     - name: 🏗 Setup Toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ inputs.toolchain }}
+
+    - name: 🔒 Cache
+      uses: swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  RUSTFLAGS: --deny warnings
+
 jobs:
   ci:
     name: CI
@@ -27,8 +30,12 @@ jobs:
 
       - name: 📦 Build
         id: build
-        run: cargo +nightly build
+        run: cargo build
+
+      - name: ⚡️ Check
+        id: check
+        run: cargo check
 
       - name: 🦺 Test
         id: test
-        run: cargo +nightly test
+        run: cargo test

--- a/xtask/src/flags.rs
+++ b/xtask/src/flags.rs
@@ -70,6 +70,8 @@ impl Install {
         if !self.client && self.server {
             return None;
         }
-        Some(ClientOpt { code_bin: self.code_bin.clone() })
+        Some(ClientOpt {
+            code_bin: self.code_bin.clone(),
+        })
     }
 }

--- a/xtask/src/install.rs
+++ b/xtask/src/install.rs
@@ -27,7 +27,13 @@ pub(crate) struct ClientOpt {
     pub(crate) code_bin: Option<String>,
 }
 
-const VS_CODES: &[&str] = &["code", "code-exploration", "code-insiders", "codium", "code-oss"];
+const VS_CODES: &[&str] = &[
+    "code",
+    "code-exploration",
+    "code-insiders",
+    "codium",
+    "code-oss",
+];
 
 fn fix_path_for_mac(sh: &Shell) -> anyhow::Result<()> {
     let mut vscode_path: Vec<PathBuf> = {
@@ -47,7 +53,9 @@ fn fix_path_for_mac(sh: &Shell) -> anyhow::Result<()> {
     };
 
     if !vscode_path.is_empty() {
-        let vars = sh.var_os("PATH").context("Could not get PATH variable from env.")?;
+        let vars = sh
+            .var_os("PATH")
+            .context("Could not get PATH variable from env.")?;
 
         let mut paths = env::split_paths(&vars).collect::<Vec<_>>();
         paths.append(&mut vscode_path);
@@ -63,7 +71,9 @@ fn install_client(sh: &Shell, client_opt: ClientOpt) -> anyhow::Result<()> {
 
     // Package extension.
     if cfg!(unix) {
-        cmd!(sh, "npm --version").run().context("`npm` is required to build the VS Code plugin")?;
+        cmd!(sh, "npm --version")
+            .run()
+            .context("`npm` is required to build the VS Code plugin")?;
         cmd!(sh, "npm ci").run()?;
 
         cmd!(sh, "npm run package --scripts-prepend-node-path").run()?;
@@ -96,7 +106,10 @@ fn install_client(sh: &Shell, client_opt: ClientOpt) -> anyhow::Result<()> {
             }
         })
         .ok_or_else(|| {
-            format_err!("Can't execute `{} --version`. Perhaps it is not in $PATH?", candidates[0])
+            format_err!(
+                "Can't execute `{} --version`. Perhaps it is not in $PATH?",
+                candidates[0]
+            )
         })?;
 
     // Install & verify.
@@ -104,7 +117,11 @@ fn install_client(sh: &Shell, client_opt: ClientOpt) -> anyhow::Result<()> {
         cmd!(sh, "{code} --install-extension postgres_lsp.vsix --force").run()?;
         cmd!(sh, "{code} --list-extensions").read()?
     } else {
-        cmd!(sh, "cmd.exe /c {code}.cmd --install-extension postgres_lsp.vsix --force").run()?;
+        cmd!(
+            sh,
+            "cmd.exe /c {code}.cmd --install-extension postgres_lsp.vsix --force"
+        )
+        .run()?;
         cmd!(sh, "cmd.exe /c {code}.cmd --list-extensions").read()?
     };
 
@@ -120,7 +137,10 @@ fn install_client(sh: &Shell, client_opt: ClientOpt) -> anyhow::Result<()> {
 }
 
 fn install_server(sh: &Shell) -> anyhow::Result<()> {
-    let cmd = cmd!(sh, "cargo install --path crates/postgres_lsp --locked --force");
+    let cmd = cmd!(
+        sh,
+        "cargo install --path crates/postgres_lsp --locked --force"
+    );
     cmd.run()?;
     Ok(())
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -8,7 +8,11 @@
 //! This binary is integrated into the `cargo` command line by using an alias in
 //! `.cargo/config`.
 
-#![warn(rust_2018_idioms, unused_lifetimes, semicolon_in_expressions_from_macros)]
+#![warn(
+    rust_2018_idioms,
+    unused_lifetimes,
+    semicolon_in_expressions_from_macros
+)]
 
 mod flags;
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add caching to speedup CI time

## What is the current behavior?

CI takes time due to `build-dependencies` like `libpg_query`

## What is the new behavior?

CI uses [rust-cache](https://github.com/Swatinem/rust-cache) to improve compile time, a sample before / after: `3m 22s -> 45s`

other minor fixes included:

- `+nightly` is implied by the `rust-toolchain` file
- `cargo check` was added a new step
- `cargo fmt` was ran (but not checked in CI)

## Additional context

To my surprise [actions-rs/toolchain](https://github.com/actions-rs/toolchain) was recently archived, but this can be reverted if not required