### PR TITLE
feat: add snapshots test back

### DIFF
--- a/crates/parser/tests/snapshots/statements/valid/0001@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0001@1.snap
@@ -1,0 +1,330 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "SELECT city, count(*) FILTER (WHERE temp_lo < 45), max(temp_lo)\n    FROM weather\n    GROUP BY city;"
+---
+Parse {
+    cst: SourceFile@0..99
+      SelectStmt@0..99
+        Select@0..6 "SELECT"
+        Whitespace@6..7 " "
+        ResTarget@7..11
+          ColumnRef@7..11
+            Ident@7..11 "city"
+        Ascii44@11..12 ","
+        Whitespace@12..13 " "
+        ResTarget@13..48
+          FuncCall@13..48
+            Ident@13..18 "count"
+            Ascii40@18..19 "("
+            Ascii42@19..20 "*"
+            Ascii41@20..21 ")"
+            Whitespace@21..22 " "
+            Filter@22..28 "FILTER"
+            Whitespace@28..29 " "
+            Ascii40@29..30 "("
+            Where@30..35 "WHERE"
+            Whitespace@35..36 " "
+            AExpr@36..48
+              ColumnRef@36..43
+                Ident@36..43 "temp_lo"
+              Whitespace@43..44 " "
+              Ascii60@44..45 "<"
+              Whitespace@45..46 " "
+              AConst@46..48
+                Iconst@46..48 "45"
+        Ascii41@48..49 ")"
+        Ascii44@49..50 ","
+        Whitespace@50..51 " "
+        ResTarget@51..62
+          FuncCall@51..62
+            Ident@51..54 "max"
+            Ascii40@54..55 "("
+            ColumnRef@55..62
+              Ident@55..62 "temp_lo"
+        Ascii41@62..63 ")"
+        Newline@63..64 "\n"
+        Whitespace@64..68 "    "
+        From@68..72 "FROM"
+        Whitespace@72..73 " "
+        RangeVar@73..80
+          Ident@73..80 "weather"
+        Newline@80..81 "\n"
+        Whitespace@81..85 "    "
+        GroupP@85..90 "GROUP"
+        Whitespace@90..91 " "
+        By@91..93 "BY"
+        Whitespace@93..94 " "
+        ColumnRef@94..98
+          Ident@94..98 "city"
+        Ascii59@98..99 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "city",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 7,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "count",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [],
+                                                            agg_order: [],
+                                                            agg_filter: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        AExpr(
+                                                                            AExpr {
+                                                                                kind: AexprOp,
+                                                                                name: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: "<",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                lexpr: Some(
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            ColumnRef(
+                                                                                                ColumnRef {
+                                                                                                    fields: [
+                                                                                                        Node {
+                                                                                                            node: Some(
+                                                                                                                String(
+                                                                                                                    String {
+                                                                                                                        sval: "temp_lo",
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ],
+                                                                                                    location: 36,
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                rexpr: Some(
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            AConst(
+                                                                                                AConst {
+                                                                                                    isnull: false,
+                                                                                                    location: 46,
+                                                                                                    val: Some(
+                                                                                                        Ival(
+                                                                                                            Integer {
+                                                                                                                ival: 45,
+                                                                                                            },
+                                                                                                        ),
+                                                                                                    ),
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                location: 44,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: true,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 13,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 13,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "max",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        ColumnRef(
+                                                                            ColumnRef {
+                                                                                fields: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: "temp_lo",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                location: 55,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 51,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 51,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [
+                        Node {
+                            node: Some(
+                                RangeVar(
+                                    RangeVar {
+                                        catalogname: "",
+                                        schemaname: "",
+                                        relname: "weather",
+                                        inh: true,
+                                        relpersistence: "p",
+                                        alias: None,
+                                        location: 73,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    where_clause: None,
+                    group_clause: [
+                        Node {
+                            node: Some(
+                                ColumnRef(
+                                    ColumnRef {
+                                        fields: [
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "city",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        location: 94,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..98,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0002@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0002@1.snap
@@ -1,0 +1,46 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "COPY weather FROM '/home/user/weather.txt';"
+---
+Parse {
+    cst: SourceFile@0..43
+      CopyStmt@0..43
+        Copy@0..4 "COPY"
+        Whitespace@4..5 " "
+        RangeVar@5..12
+          Ident@5..12 "weather"
+        Whitespace@12..13 " "
+        From@13..17 "FROM"
+        Whitespace@17..18 " "
+        Sconst@18..42 "'/home/user/weather.txt'"
+        Ascii59@42..43 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CopyStmt(
+                CopyStmt {
+                    relation: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "weather",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 5,
+                        },
+                    ),
+                    query: None,
+                    attlist: [],
+                    is_from: true,
+                    is_program: false,
+                    filename: "/home/user/weather.txt",
+                    options: [],
+                    where_clause: None,
+                },
+            ),
+            range: 0..42,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0003@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0003@1.snap
@@ -1,0 +1,453 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "CREATE TABLE weather (\n        city      varchar(80) references cities(name),\n        temp_lo   int,\n        temp_hi   int,\n        prcp      real,\n        date      date\n);"
+---
+Parse {
+    cst: SourceFile@0..173
+      CreateStmt@0..173
+        Create@0..6 "CREATE"
+        Whitespace@6..7 " "
+        Table@7..12 "TABLE"
+        Whitespace@12..13 " "
+        RangeVar@13..20
+          Ident@13..20 "weather"
+        Whitespace@20..21 " "
+        Ascii40@21..22 "("
+        Newline@22..23 "\n"
+        Whitespace@23..31 "        "
+        ColumnDef@31..75
+          Ident@31..35 "city"
+          Whitespace@35..41 "      "
+          TypeName@41..51
+            Varchar@41..48 "varchar"
+            Ascii40@48..49 "("
+            AConst@49..51
+              Iconst@49..51 "80"
+          Ascii41@51..52 ")"
+          Whitespace@52..53 " "
+          Constraint@53..75
+            References@53..63 "references"
+            Whitespace@63..64 " "
+            RangeVar@64..70
+              Ident@64..70 "cities"
+            Ascii40@70..71 "("
+            NameP@71..75 "name"
+        Ascii41@75..76 ")"
+        Ascii44@76..77 ","
+        Newline@77..78 "\n"
+        Whitespace@78..86 "        "
+        ColumnDef@86..99
+          Ident@86..93 "temp_lo"
+          Whitespace@93..96 "   "
+          TypeName@96..99
+            IntP@96..99 "int"
+        Ascii44@99..100 ","
+        Newline@100..101 "\n"
+        Whitespace@101..109 "        "
+        ColumnDef@109..122
+          Ident@109..116 "temp_hi"
+          Whitespace@116..119 "   "
+          TypeName@119..122
+            IntP@119..122 "int"
+        Ascii44@122..123 ","
+        Newline@123..124 "\n"
+        Whitespace@124..132 "        "
+        ColumnDef@132..146
+          Ident@132..136 "prcp"
+          Whitespace@136..142 "      "
+          TypeName@142..146
+            Real@142..146 "real"
+        Ascii44@146..147 ","
+        Newline@147..148 "\n"
+        Whitespace@148..156 "        "
+        ColumnDef@156..170
+          Ident@156..160 "date"
+          Whitespace@160..166 "      "
+          TypeName@166..170
+            Ident@166..170 "date"
+        Newline@170..171 "\n"
+        Ascii41@171..172 ")"
+        Ascii59@172..173 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateStmt(
+                CreateStmt {
+                    relation: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "weather",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 13,
+                        },
+                    ),
+                    table_elts: [
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "city",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "varchar",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [
+                                                    Node {
+                                                        node: Some(
+                                                            AConst(
+                                                                AConst {
+                                                                    isnull: false,
+                                                                    location: 49,
+                                                                    val: Some(
+                                                                        Ival(
+                                                                            Integer {
+                                                                                ival: 80,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 41,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [
+                                            Node {
+                                                node: Some(
+                                                    Constraint(
+                                                        Constraint {
+                                                            contype: ConstrForeign,
+                                                            conname: "",
+                                                            deferrable: false,
+                                                            initdeferred: false,
+                                                            location: 53,
+                                                            is_no_inherit: false,
+                                                            raw_expr: None,
+                                                            cooked_expr: "",
+                                                            generated_when: "",
+                                                            nulls_not_distinct: false,
+                                                            keys: [],
+                                                            including: [],
+                                                            exclusions: [],
+                                                            options: [],
+                                                            indexname: "",
+                                                            indexspace: "",
+                                                            reset_default_tblspc: false,
+                                                            access_method: "",
+                                                            where_clause: None,
+                                                            pktable: Some(
+                                                                RangeVar {
+                                                                    catalogname: "",
+                                                                    schemaname: "",
+                                                                    relname: "cities",
+                                                                    inh: true,
+                                                                    relpersistence: "p",
+                                                                    alias: None,
+                                                                    location: 64,
+                                                                },
+                                                            ),
+                                                            fk_attrs: [],
+                                                            pk_attrs: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "name",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            fk_matchtype: "s",
+                                                            fk_upd_action: "a",
+                                                            fk_del_action: "a",
+                                                            fk_del_set_cols: [],
+                                                            old_conpfeqop: [],
+                                                            old_pktable_oid: 0,
+                                                            skip_validation: false,
+                                                            initially_valid: true,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        fdwoptions: [],
+                                        location: 31,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "temp_lo",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "int4",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 96,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [],
+                                        fdwoptions: [],
+                                        location: 86,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "temp_hi",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "int4",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 119,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [],
+                                        fdwoptions: [],
+                                        location: 109,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "prcp",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "float4",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 142,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [],
+                                        fdwoptions: [],
+                                        location: 132,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "date",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "date",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 166,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [],
+                                        fdwoptions: [],
+                                        location: 156,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    inh_relations: [],
+                    partbound: None,
+                    partspec: None,
+                    of_typename: None,
+                    constraints: [],
+                    options: [],
+                    oncommit: OncommitNoop,
+                    tablespacename: "",
+                    access_method: "",
+                    if_not_exists: false,
+                },
+            ),
+            range: 0..172,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0004@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0004@1.snap
@@ -1,0 +1,253 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "CREATE VIEW myview AS\n    SELECT name, location\n        FROM weather, cities\n        WHERE city = name;"
+---
+Parse {
+    cst: SourceFile@0..99
+      Create@0..6 "CREATE"
+      Whitespace@6..7 " "
+      View@7..11 "VIEW"
+      Whitespace@11..12 " "
+      Ident@12..18 "myview"
+      Whitespace@18..19 " "
+      As@19..21 "AS"
+      Newline@21..22 "\n"
+      SelectStmt@22..99
+        Select@22..28 "SELECT"
+        Whitespace@28..29 " "
+        ResTarget@29..33
+          ColumnRef@29..33
+            NameP@29..33 "name"
+        Ascii44@33..34 ","
+        Whitespace@34..35 " "
+        ResTarget@35..43
+          ColumnRef@35..43
+            Location@35..43 "location"
+        Newline@43..44 "\n"
+        Whitespace@44..52 "        "
+        From@52..56 "FROM"
+        Whitespace@56..57 " "
+        RangeVar@57..64
+          Ident@57..64 "weather"
+        Ascii44@64..65 ","
+        Whitespace@65..66 " "
+        RangeVar@66..72
+          Ident@66..72 "cities"
+        Newline@72..73 "\n"
+        Whitespace@73..81 "        "
+        Where@81..86 "WHERE"
+        Whitespace@86..87 " "
+        AExpr@87..98
+          ColumnRef@87..91
+            Ident@87..91 "city"
+          Whitespace@91..92 " "
+          Ascii61@92..93 "="
+          Whitespace@93..94 " "
+          ColumnRef@94..98
+            NameP@94..98 "name"
+        Ascii59@98..99 ";"
+    ,
+    errors: [
+        SyntaxError(
+            "Expected Ascii59, found Whitespace",
+            22..22,
+        ),
+        SyntaxError(
+            "Invalid statement: syntax error at end of input",
+            0..8,
+        ),
+    ],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "name",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 7,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "location",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 13,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 13,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [
+                        Node {
+                            node: Some(
+                                RangeVar(
+                                    RangeVar {
+                                        catalogname: "",
+                                        schemaname: "",
+                                        relname: "weather",
+                                        inh: true,
+                                        relpersistence: "p",
+                                        alias: None,
+                                        location: 35,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                RangeVar(
+                                    RangeVar {
+                                        catalogname: "",
+                                        schemaname: "",
+                                        relname: "cities",
+                                        inh: true,
+                                        relpersistence: "p",
+                                        alias: None,
+                                        location: 44,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    where_clause: Some(
+                        Node {
+                            node: Some(
+                                AExpr(
+                                    AExpr {
+                                        kind: AexprOp,
+                                        name: [
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "=",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        lexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "city",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 65,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        rexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "name",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 72,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 70,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 25..102,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0005@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0005@1.snap
@@ -1,0 +1,115 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "DELETE FROM weather WHERE city = 'Hayward';"
+---
+Parse {
+    cst: SourceFile@0..43
+      DeleteStmt@0..43
+        DeleteP@0..6 "DELETE"
+        Whitespace@6..7 " "
+        From@7..11 "FROM"
+        Whitespace@11..12 " "
+        RangeVar@12..19
+          Ident@12..19 "weather"
+        Whitespace@19..20 " "
+        Where@20..25 "WHERE"
+        Whitespace@25..26 " "
+        AExpr@26..42
+          ColumnRef@26..30
+            Ident@26..30 "city"
+          Whitespace@30..31 " "
+          Ascii61@31..32 "="
+          Whitespace@32..33 " "
+          AConst@33..42
+            Sconst@33..42 "'Hayward'"
+        Ascii59@42..43 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: DeleteStmt(
+                DeleteStmt {
+                    relation: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "weather",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 12,
+                        },
+                    ),
+                    using_clause: [],
+                    where_clause: Some(
+                        Node {
+                            node: Some(
+                                AExpr(
+                                    AExpr {
+                                        kind: AexprOp,
+                                        name: [
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "=",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        lexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "city",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 26,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        rexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    AConst(
+                                                        AConst {
+                                                            isnull: false,
+                                                            location: 33,
+                                                            val: Some(
+                                                                Sval(
+                                                                    String {
+                                                                        sval: "Hayward",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 31,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    returning_list: [],
+                    with_clause: None,
+                },
+            ),
+            range: 0..42,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0006@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0006@1.snap
@@ -1,0 +1,16 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: DROP TABLE tablename;
+---
+Parse {
+    cst: SourceFile@0..21
+      Drop@0..4 "DROP"
+      Whitespace@4..5 " "
+      Table@5..10 "TABLE"
+      Whitespace@10..11 " "
+      Ident@11..20 "tablename"
+      Ascii59@20..21 ";"
+    ,
+    errors: [],
+    stmts: [],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0007@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0007@1.snap
@@ -1,0 +1,237 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "CREATE TABLE cities (\n  name       text,\n  population real,\n  elevation  int     -- (in ft)\n);"
+---
+Parse {
+    cst: SourceFile@0..94
+      CreateStmt@0..94
+        Create@0..6 "CREATE"
+        Whitespace@6..7 " "
+        Table@7..12 "TABLE"
+        Whitespace@12..13 " "
+        RangeVar@13..19
+          Ident@13..19 "cities"
+        Whitespace@19..20 " "
+        Ascii40@20..21 "("
+        Newline@21..22 "\n"
+        Whitespace@22..24 "  "
+        ColumnDef@24..39
+          NameP@24..28 "name"
+          Whitespace@28..35 "       "
+          TypeName@35..39
+            TextP@35..39 "text"
+        Ascii44@39..40 ","
+        Newline@40..41 "\n"
+        Whitespace@41..43 "  "
+        ColumnDef@43..58
+          Ident@43..53 "population"
+          Whitespace@53..54 " "
+          TypeName@54..58
+            Real@54..58 "real"
+        Ascii44@58..59 ","
+        Newline@59..60 "\n"
+        Whitespace@60..62 "  "
+        ColumnDef@62..76
+          Ident@62..71 "elevation"
+          Whitespace@71..73 "  "
+          TypeName@73..76
+            IntP@73..76 "int"
+        Whitespace@76..81 "     "
+        SqlComment@81..91 "-- (in ft)"
+        Newline@91..92 "\n"
+        Ascii41@92..93 ")"
+        Ascii59@93..94 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateStmt(
+                CreateStmt {
+                    relation: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "cities",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 13,
+                        },
+                    ),
+                    table_elts: [
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "name",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "text",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 35,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [],
+                                        fdwoptions: [],
+                                        location: 24,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "population",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "float4",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 54,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [],
+                                        fdwoptions: [],
+                                        location: 43,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "elevation",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "int4",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 73,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [],
+                                        fdwoptions: [],
+                                        location: 62,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    inh_relations: [],
+                    partbound: None,
+                    partspec: None,
+                    of_typename: None,
+                    constraints: [],
+                    options: [],
+                    oncommit: OncommitNoop,
+                    tablespacename: "",
+                    access_method: "",
+                    if_not_exists: false,
+                },
+            ),
+            range: 0..93,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0008@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0008@1.snap
@@ -1,0 +1,239 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "INSERT INTO weather (date, city, temp_hi, temp_lo)\n    VALUES ('1994-11-29', 'Hayward', 54, 37);"
+---
+Parse {
+    cst: SourceFile@0..96
+      InsertStmt@0..96
+        Insert@0..6 "INSERT"
+        Whitespace@6..7 " "
+        Into@7..11 "INTO"
+        Whitespace@11..12 " "
+        RangeVar@12..19
+          Ident@12..19 "weather"
+        Whitespace@19..20 " "
+        Ascii40@20..21 "("
+        ResTarget@21..25
+          Ident@21..25 "date"
+        Ascii44@25..26 ","
+        Whitespace@26..27 " "
+        ResTarget@27..31
+          Ident@27..31 "city"
+        Ascii44@31..32 ","
+        Whitespace@32..33 " "
+        ResTarget@33..40
+          Ident@33..40 "temp_hi"
+        Ascii44@40..41 ","
+        Whitespace@41..42 " "
+        ResTarget@42..49
+          Ident@42..49 "temp_lo"
+        Ascii41@49..50 ")"
+        Newline@50..51 "\n"
+        Whitespace@51..55 "    "
+        SelectStmt@55..94
+          Values@55..61 "VALUES"
+          Whitespace@61..62 " "
+          Ascii40@62..63 "("
+          List@63..94
+            AConst@63..75
+              Sconst@63..75 "'1994-11-29'"
+            Ascii44@75..76 ","
+            Whitespace@76..77 " "
+            AConst@77..86
+              Sconst@77..86 "'Hayward'"
+            Ascii44@86..87 ","
+            Whitespace@87..88 " "
+            AConst@88..90
+              Iconst@88..90 "54"
+            Ascii44@90..91 ","
+            Whitespace@91..92 " "
+            AConst@92..94
+              Iconst@92..94 "37"
+        Ascii41@94..95 ")"
+        Ascii59@95..96 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: InsertStmt(
+                InsertStmt {
+                    relation: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "weather",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 12,
+                        },
+                    ),
+                    cols: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "date",
+                                        indirection: [],
+                                        val: None,
+                                        location: 21,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "city",
+                                        indirection: [],
+                                        val: None,
+                                        location: 27,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "temp_hi",
+                                        indirection: [],
+                                        val: None,
+                                        location: 33,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "temp_lo",
+                                        indirection: [],
+                                        val: None,
+                                        location: 42,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    select_stmt: Some(
+                        Node {
+                            node: Some(
+                                SelectStmt(
+                                    SelectStmt {
+                                        distinct_clause: [],
+                                        into_clause: None,
+                                        target_list: [],
+                                        from_clause: [],
+                                        where_clause: None,
+                                        group_clause: [],
+                                        group_distinct: false,
+                                        having_clause: None,
+                                        window_clause: [],
+                                        values_lists: [
+                                            Node {
+                                                node: Some(
+                                                    List(
+                                                        List {
+                                                            items: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 63,
+                                                                                val: Some(
+                                                                                    Sval(
+                                                                                        String {
+                                                                                            sval: "1994-11-29",
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 77,
+                                                                                val: Some(
+                                                                                    Sval(
+                                                                                        String {
+                                                                                            sval: "Hayward",
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 88,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 54,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 92,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 37,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        sort_clause: [],
+                                        limit_offset: None,
+                                        limit_count: None,
+                                        limit_option: Default,
+                                        locking_clause: [],
+                                        with_clause: None,
+                                        op: SetopNone,
+                                        all: false,
+                                        larg: None,
+                                        rarg: None,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    on_conflict_clause: None,
+                    returning_list: [],
+                    with_clause: None,
+                    r#override: OverridingNotSet,
+                },
+            ),
+            range: 0..95,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0009@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0009@1.snap
@@ -1,0 +1,642 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "SELECT w1.city, w1.temp_lo AS low, w1.temp_hi AS high,\n       w2.city, w2.temp_lo AS low, w2.temp_hi AS high\n    FROM weather w1 JOIN weather w2\n        ON w1.temp_lo < w2.temp_lo AND w1.temp_hi > w2.temp_hi;"
+---
+Parse {
+    cst: SourceFile@0..208
+      SelectStmt@0..208
+        Select@0..6 "SELECT"
+        Whitespace@6..7 " "
+        ResTarget@7..14
+          ColumnRef@7..14
+            Ident@7..9 "w1"
+            Ascii46@9..10 "."
+            Ident@10..14 "city"
+        Ascii44@14..15 ","
+        Whitespace@15..16 " "
+        ResTarget@16..33
+          ColumnRef@16..26
+            Ident@16..18 "w1"
+            Ascii46@18..19 "."
+            Ident@19..26 "temp_lo"
+          Whitespace@26..27 " "
+          As@27..29 "AS"
+          Whitespace@29..30 " "
+          Ident@30..33 "low"
+        Ascii44@33..34 ","
+        Whitespace@34..35 " "
+        ResTarget@35..53
+          ColumnRef@35..45
+            Ident@35..37 "w1"
+            Ascii46@37..38 "."
+            Ident@38..45 "temp_hi"
+          Whitespace@45..46 " "
+          As@46..48 "AS"
+          Whitespace@48..49 " "
+          Ident@49..53 "high"
+        Ascii44@53..54 ","
+        Newline@54..55 "\n"
+        Whitespace@55..62 "       "
+        ResTarget@62..69
+          ColumnRef@62..69
+            Ident@62..64 "w2"
+            Ascii46@64..65 "."
+            Ident@65..69 "city"
+        Ascii44@69..70 ","
+        Whitespace@70..71 " "
+        ResTarget@71..88
+          ColumnRef@71..81
+            Ident@71..73 "w2"
+            Ascii46@73..74 "."
+            Ident@74..81 "temp_lo"
+          Whitespace@81..82 " "
+          As@82..84 "AS"
+          Whitespace@84..85 " "
+          Ident@85..88 "low"
+        Ascii44@88..89 ","
+        Whitespace@89..90 " "
+        ResTarget@90..108
+          ColumnRef@90..100
+            Ident@90..92 "w2"
+            Ascii46@92..93 "."
+            Ident@93..100 "temp_hi"
+          Whitespace@100..101 " "
+          As@101..103 "AS"
+          Whitespace@103..104 " "
+          Ident@104..108 "high"
+        Newline@108..109 "\n"
+        Whitespace@109..113 "    "
+        From@113..117 "FROM"
+        Whitespace@117..118 " "
+        JoinExpr@118..207
+          RangeVar@118..128
+            Ident@118..125 "weather"
+            Whitespace@125..126 " "
+            Alias@126..128
+              Ident@126..128 "w1"
+          Whitespace@128..129 " "
+          Join@129..133 "JOIN"
+          Whitespace@133..134 " "
+          RangeVar@134..144
+            Ident@134..141 "weather"
+            Whitespace@141..142 " "
+            Alias@142..144
+              Ident@142..144 "w2"
+          Newline@144..145 "\n"
+          Whitespace@145..153 "        "
+          On@153..155 "ON"
+          Whitespace@155..156 " "
+          BoolExpr@156..207
+            AExpr@156..179
+              ColumnRef@156..166
+                Ident@156..158 "w1"
+                Ascii46@158..159 "."
+                Ident@159..166 "temp_lo"
+              Whitespace@166..167 " "
+              Ascii60@167..168 "<"
+              Whitespace@168..169 " "
+              ColumnRef@169..179
+                Ident@169..171 "w2"
+                Ascii46@171..172 "."
+                Ident@172..179 "temp_lo"
+            Whitespace@179..180 " "
+            And@180..183 "AND"
+            Whitespace@183..184 " "
+            AExpr@184..207
+              ColumnRef@184..194
+                Ident@184..186 "w1"
+                Ascii46@186..187 "."
+                Ident@187..194 "temp_hi"
+              Whitespace@194..195 " "
+              Ascii62@195..196 ">"
+              Whitespace@196..197 " "
+              ColumnRef@197..207
+                Ident@197..199 "w2"
+                Ascii46@199..200 "."
+                Ident@200..207 "temp_hi"
+        Ascii59@207..208 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "w1",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "city",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 7,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "low",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "w1",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "temp_lo",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 16,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 16,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "high",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "w1",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "temp_hi",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 35,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 35,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "w2",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "city",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 62,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 62,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "low",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "w2",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "temp_lo",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 71,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 71,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "high",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "w2",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "temp_hi",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 90,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 90,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [
+                        Node {
+                            node: Some(
+                                JoinExpr(
+                                    JoinExpr {
+                                        jointype: JoinInner,
+                                        is_natural: false,
+                                        larg: Some(
+                                            Node {
+                                                node: Some(
+                                                    RangeVar(
+                                                        RangeVar {
+                                                            catalogname: "",
+                                                            schemaname: "",
+                                                            relname: "weather",
+                                                            inh: true,
+                                                            relpersistence: "p",
+                                                            alias: Some(
+                                                                Alias {
+                                                                    aliasname: "w1",
+                                                                    colnames: [],
+                                                                },
+                                                            ),
+                                                            location: 118,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        rarg: Some(
+                                            Node {
+                                                node: Some(
+                                                    RangeVar(
+                                                        RangeVar {
+                                                            catalogname: "",
+                                                            schemaname: "",
+                                                            relname: "weather",
+                                                            inh: true,
+                                                            relpersistence: "p",
+                                                            alias: Some(
+                                                                Alias {
+                                                                    aliasname: "w2",
+                                                                    colnames: [],
+                                                                },
+                                                            ),
+                                                            location: 134,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        using_clause: [],
+                                        join_using_alias: None,
+                                        quals: Some(
+                                            Node {
+                                                node: Some(
+                                                    BoolExpr(
+                                                        BoolExpr {
+                                                            xpr: None,
+                                                            boolop: AndExpr,
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AExpr(
+                                                                            AExpr {
+                                                                                kind: AexprOp,
+                                                                                name: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: "<",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                lexpr: Some(
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            ColumnRef(
+                                                                                                ColumnRef {
+                                                                                                    fields: [
+                                                                                                        Node {
+                                                                                                            node: Some(
+                                                                                                                String(
+                                                                                                                    String {
+                                                                                                                        sval: "w1",
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                        Node {
+                                                                                                            node: Some(
+                                                                                                                String(
+                                                                                                                    String {
+                                                                                                                        sval: "temp_lo",
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ],
+                                                                                                    location: 156,
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                rexpr: Some(
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            ColumnRef(
+                                                                                                ColumnRef {
+                                                                                                    fields: [
+                                                                                                        Node {
+                                                                                                            node: Some(
+                                                                                                                String(
+                                                                                                                    String {
+                                                                                                                        sval: "w2",
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                        Node {
+                                                                                                            node: Some(
+                                                                                                                String(
+                                                                                                                    String {
+                                                                                                                        sval: "temp_lo",
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ],
+                                                                                                    location: 169,
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                location: 167,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AExpr(
+                                                                            AExpr {
+                                                                                kind: AexprOp,
+                                                                                name: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: ">",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                lexpr: Some(
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            ColumnRef(
+                                                                                                ColumnRef {
+                                                                                                    fields: [
+                                                                                                        Node {
+                                                                                                            node: Some(
+                                                                                                                String(
+                                                                                                                    String {
+                                                                                                                        sval: "w1",
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                        Node {
+                                                                                                            node: Some(
+                                                                                                                String(
+                                                                                                                    String {
+                                                                                                                        sval: "temp_hi",
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ],
+                                                                                                    location: 184,
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                rexpr: Some(
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            ColumnRef(
+                                                                                                ColumnRef {
+                                                                                                    fields: [
+                                                                                                        Node {
+                                                                                                            node: Some(
+                                                                                                                String(
+                                                                                                                    String {
+                                                                                                                        sval: "w2",
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                        Node {
+                                                                                                            node: Some(
+                                                                                                                String(
+                                                                                                                    String {
+                                                                                                                        sval: "temp_hi",
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ],
+                                                                                                    location: 197,
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                location: 195,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 180,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        alias: None,
+                                        rtindex: 0,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    where_clause: None,
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..207,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0010@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0010@1.snap
@@ -1,0 +1,193 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "INSERT INTO weather VALUES ('San Francisco', 46, 50, 0.25, '1994-11-27');"
+---
+Parse {
+    cst: SourceFile@0..73
+      InsertStmt@0..73
+        Insert@0..6 "INSERT"
+        Whitespace@6..7 " "
+        Into@7..11 "INTO"
+        Whitespace@11..12 " "
+        RangeVar@12..19
+          Ident@12..19 "weather"
+        Whitespace@19..20 " "
+        SelectStmt@20..71
+          Values@20..26 "VALUES"
+          Whitespace@26..27 " "
+          Ascii40@27..28 "("
+          List@28..71
+            AConst@28..43
+              Sconst@28..43 "'San Francisco'"
+            Ascii44@43..44 ","
+            Whitespace@44..45 " "
+            AConst@45..47
+              Iconst@45..47 "46"
+            Ascii44@47..48 ","
+            Whitespace@48..49 " "
+            AConst@49..51
+              Iconst@49..51 "50"
+            Ascii44@51..52 ","
+            Whitespace@52..53 " "
+            AConst@53..57
+              Fconst@53..57 "0.25"
+            Ascii44@57..58 ","
+            Whitespace@58..59 " "
+            AConst@59..71
+              Sconst@59..71 "'1994-11-27'"
+        Ascii41@71..72 ")"
+        Ascii59@72..73 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: InsertStmt(
+                InsertStmt {
+                    relation: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "weather",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 12,
+                        },
+                    ),
+                    cols: [],
+                    select_stmt: Some(
+                        Node {
+                            node: Some(
+                                SelectStmt(
+                                    SelectStmt {
+                                        distinct_clause: [],
+                                        into_clause: None,
+                                        target_list: [],
+                                        from_clause: [],
+                                        where_clause: None,
+                                        group_clause: [],
+                                        group_distinct: false,
+                                        having_clause: None,
+                                        window_clause: [],
+                                        values_lists: [
+                                            Node {
+                                                node: Some(
+                                                    List(
+                                                        List {
+                                                            items: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 28,
+                                                                                val: Some(
+                                                                                    Sval(
+                                                                                        String {
+                                                                                            sval: "San Francisco",
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 45,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 46,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 49,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 50,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 53,
+                                                                                val: Some(
+                                                                                    Fval(
+                                                                                        Float {
+                                                                                            fval: "0.25",
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 59,
+                                                                                val: Some(
+                                                                                    Sval(
+                                                                                        String {
+                                                                                            sval: "1994-11-27",
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        sort_clause: [],
+                                        limit_offset: None,
+                                        limit_count: None,
+                                        limit_option: Default,
+                                        locking_clause: [],
+                                        with_clause: None,
+                                        op: SetopNone,
+                                        all: false,
+                                        larg: None,
+                                        rarg: None,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    on_conflict_clause: None,
+                    returning_list: [],
+                    with_clause: None,
+                    r#override: OverridingNotSet,
+                },
+            ),
+            range: 0..72,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0011@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0011@1.snap
@@ -1,0 +1,151 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "SELECT DISTINCT city\n    FROM weather\n    ORDER BY city;"
+---
+Parse {
+    cst: SourceFile@0..56
+      SelectStmt@0..56
+        Select@0..6 "SELECT"
+        Whitespace@6..7 " "
+        Distinct@7..15 "DISTINCT"
+        Whitespace@15..16 " "
+        ResTarget@16..20
+          ColumnRef@16..20
+            Ident@16..20 "city"
+        Newline@20..21 "\n"
+        Whitespace@21..25 "    "
+        From@25..29 "FROM"
+        Whitespace@29..30 " "
+        RangeVar@30..37
+          Ident@30..37 "weather"
+        Newline@37..38 "\n"
+        Whitespace@38..42 "    "
+        SortBy@42..55
+          Order@42..47 "ORDER"
+          Whitespace@47..48 " "
+          By@48..50 "BY"
+          Whitespace@50..51 " "
+          ColumnRef@51..55
+            Ident@51..55 "city"
+        Ascii59@55..56 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [
+                        Node {
+                            node: None,
+                        },
+                    ],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "city",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 16,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 16,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [
+                        Node {
+                            node: Some(
+                                RangeVar(
+                                    RangeVar {
+                                        catalogname: "",
+                                        schemaname: "",
+                                        relname: "weather",
+                                        inh: true,
+                                        relpersistence: "p",
+                                        alias: None,
+                                        location: 30,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    where_clause: None,
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [
+                        Node {
+                            node: Some(
+                                SortBy(
+                                    SortBy {
+                                        node: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "city",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 51,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        sortby_dir: SortbyDefault,
+                                        sortby_nulls: SortbyNullsDefault,
+                                        use_op: [],
+                                        location: -1,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..55,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0012@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0012@1.snap
@@ -1,0 +1,179 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "CREATE TABLE measurement_y2008m01 PARTITION OF measurement\n    FOR VALUES FROM ('2008-01-01') TO ('2008-02-01')\n    WITH (parallel_workers = 4)\n    TABLESPACE fasttablespace;"
+---
+Parse {
+    cst: SourceFile@0..174
+      CreateStmt@0..174
+        Create@0..6 "CREATE"
+        Whitespace@6..7 " "
+        Table@7..12 "TABLE"
+        Whitespace@12..13 " "
+        RangeVar@13..33
+          Ident@13..33 "measurement_y2008m01"
+        Whitespace@33..34 " "
+        Partition@34..43 "PARTITION"
+        Whitespace@43..44 " "
+        Of@44..46 "OF"
+        Whitespace@46..47 " "
+        RangeVar@47..58
+          Ident@47..58 "measurement"
+        Newline@58..59 "\n"
+        Whitespace@59..63 "    "
+        For@63..66 "FOR"
+        Whitespace@66..67 " "
+        Values@67..73 "VALUES"
+        Whitespace@73..74 " "
+        PartitionBoundSpec@74..110
+          From@74..78 "FROM"
+          Whitespace@78..79 " "
+          Ascii40@79..80 "("
+          AConst@80..92
+            Sconst@80..92 "'2008-01-01'"
+          Ascii41@92..93 ")"
+          Whitespace@93..94 " "
+          To@94..96 "TO"
+          Whitespace@96..97 " "
+          Ascii40@97..98 "("
+          AConst@98..110
+            Sconst@98..110 "'2008-02-01'"
+        Ascii41@110..111 ")"
+        Newline@111..112 "\n"
+        Whitespace@112..116 "    "
+        With@116..120 "WITH"
+        Whitespace@120..121 " "
+        Ascii40@121..122 "("
+        DefElem@122..142
+          Ident@122..138 "parallel_workers"
+          Whitespace@138..139 " "
+          Ascii61@139..140 "="
+          Whitespace@140..141 " "
+          Iconst@141..142 "4"
+        Ascii41@142..143 ")"
+        Newline@143..144 "\n"
+        Whitespace@144..148 "    "
+        Tablespace@148..158 "TABLESPACE"
+        Whitespace@158..159 " "
+        Ident@159..173 "fasttablespace"
+        Ascii59@173..174 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateStmt(
+                CreateStmt {
+                    relation: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "measurement_y2008m01",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 13,
+                        },
+                    ),
+                    table_elts: [],
+                    inh_relations: [
+                        Node {
+                            node: Some(
+                                RangeVar(
+                                    RangeVar {
+                                        catalogname: "",
+                                        schemaname: "",
+                                        relname: "measurement",
+                                        inh: true,
+                                        relpersistence: "p",
+                                        alias: None,
+                                        location: 47,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    partbound: Some(
+                        PartitionBoundSpec {
+                            strategy: "r",
+                            is_default: false,
+                            modulus: 0,
+                            remainder: 0,
+                            listdatums: [],
+                            lowerdatums: [
+                                Node {
+                                    node: Some(
+                                        AConst(
+                                            AConst {
+                                                isnull: false,
+                                                location: 80,
+                                                val: Some(
+                                                    Sval(
+                                                        String {
+                                                            sval: "2008-01-01",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ],
+                            upperdatums: [
+                                Node {
+                                    node: Some(
+                                        AConst(
+                                            AConst {
+                                                isnull: false,
+                                                location: 98,
+                                                val: Some(
+                                                    Sval(
+                                                        String {
+                                                            sval: "2008-02-01",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ],
+                            location: 74,
+                        },
+                    ),
+                    partspec: None,
+                    of_typename: None,
+                    constraints: [],
+                    options: [
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "parallel_workers",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    Integer(
+                                                        Integer {
+                                                            ival: 4,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 122,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    oncommit: OncommitNoop,
+                    tablespacename: "fasttablespace",
+                    access_method: "",
+                    if_not_exists: false,
+                },
+            ),
+            range: 0..173,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0013@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0013@1.snap
@@ -1,0 +1,59 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "UPDATE weather\n    SET temp_hi = temp_hi - 2,  temp_lo = temp_lo - 2\n    WHERE date > '1994-11-28';"
+---
+Parse {
+    cst: SourceFile@0..95
+      Update@0..6 "UPDATE"
+      Whitespace@6..7 " "
+      Ident@7..14 "weather"
+      Newline@14..15 "\n"
+      Set@15..18 "SET"
+      Whitespace@18..19 " "
+      Ident@19..26 "temp_hi"
+      Whitespace@26..27 " "
+      Ascii61@27..28 "="
+      Whitespace@28..29 " "
+      Ident@29..36 "temp_hi"
+      Whitespace@36..37 " "
+      Ascii45@37..38 "-"
+      Whitespace@38..39 " "
+      Iconst@39..40 "2"
+      Ascii44@40..41 ","
+      Whitespace@41..43 "  "
+      Ident@43..50 "temp_lo"
+      Whitespace@50..51 " "
+      Ascii61@51..52 "="
+      Whitespace@52..53 " "
+      Ident@53..60 "temp_lo"
+      Whitespace@60..61 " "
+      Ascii45@61..62 "-"
+      Whitespace@62..63 " "
+      Iconst@63..64 "2"
+      Newline@64..65 "\n"
+      Whitespace@65..69 "    "
+      Where@69..74 "WHERE"
+      Whitespace@74..75 " "
+      Ident@75..79 "date"
+      Whitespace@79..80 " "
+      Ascii62@80..81 ">"
+      Whitespace@81..82 " "
+      Sconst@82..94 "'1994-11-28'"
+      Ascii59@94..95 ";"
+    ,
+    errors: [
+        SyntaxError(
+            "Expected Ascii59, found Whitespace",
+            15..15,
+        ),
+        SyntaxError(
+            "Invalid statement: syntax error at end of input",
+            0..4,
+        ),
+        SyntaxError(
+            "Invalid statement: syntax error at or near \"-\"",
+            5..37,
+        ),
+    ],
+    stmts: [],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0014@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0014@1.snap
@@ -1,0 +1,339 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "SELECT sum(salary) OVER w, avg(salary) OVER w\n  FROM empsalary\n  WINDOW w AS (PARTITION BY depname ORDER BY salary DESC);"
+---
+Parse {
+    cst: SourceFile@0..121
+      SelectStmt@0..121
+        Select@0..6 "SELECT"
+        Whitespace@6..7 " "
+        ResTarget@7..25
+          FuncCall@7..25
+            Ident@7..10 "sum"
+            Ascii40@10..11 "("
+            ColumnRef@11..17
+              Ident@11..17 "salary"
+            Ascii41@17..18 ")"
+            Whitespace@18..19 " "
+            Over@19..23 "OVER"
+            Whitespace@23..24 " "
+            WindowDef@24..25
+              Ident@24..25 "w"
+        Ascii44@25..26 ","
+        Whitespace@26..27 " "
+        ResTarget@27..45
+          FuncCall@27..45
+            Ident@27..30 "avg"
+            Ascii40@30..31 "("
+            ColumnRef@31..37
+              Ident@31..37 "salary"
+            Ascii41@37..38 ")"
+            Whitespace@38..39 " "
+            Over@39..43 "OVER"
+            Whitespace@43..44 " "
+            WindowDef@44..45
+              Ident@44..45 "w"
+        Newline@45..46 "\n"
+        Whitespace@46..48 "  "
+        From@48..52 "FROM"
+        Whitespace@52..53 " "
+        RangeVar@53..62
+          Ident@53..62 "empsalary"
+        Newline@62..63 "\n"
+        Whitespace@63..65 "  "
+        WindowDef@65..119
+          Window@65..71 "WINDOW"
+          Whitespace@71..72 " "
+          Ident@72..73 "w"
+          Whitespace@73..74 " "
+          As@74..76 "AS"
+          Whitespace@76..77 " "
+          Ascii40@77..78 "("
+          Partition@78..87 "PARTITION"
+          Whitespace@87..88 " "
+          By@88..90 "BY"
+          Whitespace@90..91 " "
+          ColumnRef@91..98
+            Ident@91..98 "depname"
+          Whitespace@98..99 " "
+          SortBy@99..119
+            Order@99..104 "ORDER"
+            Whitespace@104..105 " "
+            By@105..107 "BY"
+            Whitespace@107..108 " "
+            ColumnRef@108..114
+              Ident@108..114 "salary"
+            Whitespace@114..115 " "
+            Desc@115..119 "DESC"
+        Ascii41@119..120 ")"
+        Ascii59@120..121 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "sum",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        ColumnRef(
+                                                                            ColumnRef {
+                                                                                fields: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: "salary",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                location: 11,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: Some(
+                                                                WindowDef {
+                                                                    name: "w",
+                                                                    refname: "",
+                                                                    partition_clause: [],
+                                                                    order_clause: [],
+                                                                    frame_options: 1058,
+                                                                    start_offset: None,
+                                                                    end_offset: None,
+                                                                    location: 24,
+                                                                },
+                                                            ),
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 7,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "avg",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        ColumnRef(
+                                                                            ColumnRef {
+                                                                                fields: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: "salary",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                location: 31,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: Some(
+                                                                WindowDef {
+                                                                    name: "w",
+                                                                    refname: "",
+                                                                    partition_clause: [],
+                                                                    order_clause: [],
+                                                                    frame_options: 1058,
+                                                                    start_offset: None,
+                                                                    end_offset: None,
+                                                                    location: 44,
+                                                                },
+                                                            ),
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 27,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 27,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [
+                        Node {
+                            node: Some(
+                                RangeVar(
+                                    RangeVar {
+                                        catalogname: "",
+                                        schemaname: "",
+                                        relname: "empsalary",
+                                        inh: true,
+                                        relpersistence: "p",
+                                        alias: None,
+                                        location: 53,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    where_clause: None,
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [
+                        Node {
+                            node: Some(
+                                WindowDef(
+                                    WindowDef {
+                                        name: "w",
+                                        refname: "",
+                                        partition_clause: [
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "depname",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 91,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        order_clause: [
+                                            Node {
+                                                node: Some(
+                                                    SortBy(
+                                                        SortBy {
+                                                            node: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        ColumnRef(
+                                                                            ColumnRef {
+                                                                                fields: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: "salary",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                location: 108,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            sortby_dir: SortbyDesc,
+                                                            sortby_nulls: SortbyNullsDefault,
+                                                            use_op: [],
+                                                            location: -1,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        frame_options: 1058,
+                                        start_offset: None,
+                                        end_offset: None,
+                                        location: 77,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..120,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0015@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0015@1.snap
@@ -1,0 +1,359 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "SELECT\n    count(*) AS unfiltered,\n    count(*) FILTER (WHERE i < 5) AS filtered\nFROM generate_series(1,10) AS s(i);"
+---
+Parse {
+    cst: SourceFile@0..116
+      SelectStmt@0..116
+        Select@0..6 "SELECT"
+        Newline@6..7 "\n"
+        Whitespace@7..11 "    "
+        ResTarget@11..33
+          FuncCall@11..18
+            Ident@11..16 "count"
+            Ascii40@16..17 "("
+            Ascii42@17..18 "*"
+          Ascii41@18..19 ")"
+          Whitespace@19..20 " "
+          As@20..22 "AS"
+          Whitespace@22..23 " "
+          Ident@23..33 "unfiltered"
+        Ascii44@33..34 ","
+        Newline@34..35 "\n"
+        Whitespace@35..39 "    "
+        ResTarget@39..80
+          FuncCall@39..67
+            Ident@39..44 "count"
+            Ascii40@44..45 "("
+            Ascii42@45..46 "*"
+            Ascii41@46..47 ")"
+            Whitespace@47..48 " "
+            Filter@48..54 "FILTER"
+            Whitespace@54..55 " "
+            Ascii40@55..56 "("
+            Where@56..61 "WHERE"
+            Whitespace@61..62 " "
+            AExpr@62..67
+              ColumnRef@62..63
+                Ident@62..63 "i"
+              Whitespace@63..64 " "
+              Ascii60@64..65 "<"
+              Whitespace@65..66 " "
+              AConst@66..67
+                Iconst@66..67 "5"
+          Ascii41@67..68 ")"
+          Whitespace@68..69 " "
+          As@69..71 "AS"
+          Whitespace@71..72 " "
+          Ident@72..80 "filtered"
+        Newline@80..81 "\n"
+        From@81..85 "FROM"
+        Whitespace@85..86 " "
+        RangeFunction@86..114
+          List@86..106
+            FuncCall@86..106
+              Ident@86..101 "generate_series"
+              Ascii40@101..102 "("
+              AConst@102..103
+                Iconst@102..103 "1"
+              Ascii44@103..104 ","
+              AConst@104..106
+                Iconst@104..106 "10"
+          Ascii41@106..107 ")"
+          Whitespace@107..108 " "
+          Alias@108..114
+            As@108..110 "AS"
+            Whitespace@110..111 " "
+            Ident@111..112 "s"
+            Ascii40@112..113 "("
+            Ident@113..114 "i"
+        Ascii41@114..115 ")"
+        Ascii59@115..116 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "unfiltered",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "count",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: true,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 11,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 11,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "filtered",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "count",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [],
+                                                            agg_order: [],
+                                                            agg_filter: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        AExpr(
+                                                                            AExpr {
+                                                                                kind: AexprOp,
+                                                                                name: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: "<",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                lexpr: Some(
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            ColumnRef(
+                                                                                                ColumnRef {
+                                                                                                    fields: [
+                                                                                                        Node {
+                                                                                                            node: Some(
+                                                                                                                String(
+                                                                                                                    String {
+                                                                                                                        sval: "i",
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ],
+                                                                                                    location: 62,
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                rexpr: Some(
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            AConst(
+                                                                                                AConst {
+                                                                                                    isnull: false,
+                                                                                                    location: 66,
+                                                                                                    val: Some(
+                                                                                                        Ival(
+                                                                                                            Integer {
+                                                                                                                ival: 5,
+                                                                                                            },
+                                                                                                        ),
+                                                                                                    ),
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                location: 64,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: true,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 39,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 39,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [
+                        Node {
+                            node: Some(
+                                RangeFunction(
+                                    RangeFunction {
+                                        lateral: false,
+                                        ordinality: false,
+                                        is_rowsfrom: false,
+                                        functions: [
+                                            Node {
+                                                node: Some(
+                                                    List(
+                                                        List {
+                                                            items: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        FuncCall(
+                                                                            FuncCall {
+                                                                                funcname: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: "generate_series",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                args: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            AConst(
+                                                                                                AConst {
+                                                                                                    isnull: false,
+                                                                                                    location: 102,
+                                                                                                    val: Some(
+                                                                                                        Ival(
+                                                                                                            Integer {
+                                                                                                                ival: 1,
+                                                                                                            },
+                                                                                                        ),
+                                                                                                    ),
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            AConst(
+                                                                                                AConst {
+                                                                                                    isnull: false,
+                                                                                                    location: 104,
+                                                                                                    val: Some(
+                                                                                                        Ival(
+                                                                                                            Integer {
+                                                                                                                ival: 10,
+                                                                                                            },
+                                                                                                        ),
+                                                                                                    ),
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                agg_order: [],
+                                                                                agg_filter: None,
+                                                                                over: None,
+                                                                                agg_within_group: false,
+                                                                                agg_star: false,
+                                                                                agg_distinct: false,
+                                                                                func_variadic: false,
+                                                                                funcformat: CoerceExplicitCall,
+                                                                                location: 86,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: None,
+                                                                },
+                                                            ],
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        alias: Some(
+                                            Alias {
+                                                aliasname: "s",
+                                                colnames: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "i",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                            },
+                                        ),
+                                        coldeflist: [],
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    where_clause: None,
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..115,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0016@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0016@1.snap
@@ -1,0 +1,200 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "SELECT * FROM tbl WHERE a COLLATE \"C\" > 'foo';"
+---
+Parse {
+    cst: SourceFile@0..46
+      SelectStmt@0..46
+        Select@0..6 "SELECT"
+        Whitespace@6..7 " "
+        ResTarget@7..8
+          ColumnRef@7..8
+            AStar@7..8
+              Ascii42@7..8 "*"
+        Whitespace@8..9 " "
+        From@9..13 "FROM"
+        Whitespace@13..14 " "
+        RangeVar@14..17
+          Ident@14..17 "tbl"
+        Whitespace@17..18 " "
+        Where@18..23 "WHERE"
+        Whitespace@23..24 " "
+        AExpr@24..45
+          CollateClause@24..37
+            ColumnRef@24..25
+              Ident@24..25 "a"
+            Whitespace@25..26 " "
+            Collate@26..33 "COLLATE"
+            Whitespace@33..34 " "
+            Ident@34..37 "\"C\""
+          Whitespace@37..38 " "
+          Ascii62@38..39 ">"
+          Whitespace@39..40 " "
+          AConst@40..45
+            Sconst@40..45 "'foo'"
+        Ascii59@45..46 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AStar(
+                                                                            AStar,
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 7,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [
+                        Node {
+                            node: Some(
+                                RangeVar(
+                                    RangeVar {
+                                        catalogname: "",
+                                        schemaname: "",
+                                        relname: "tbl",
+                                        inh: true,
+                                        relpersistence: "p",
+                                        alias: None,
+                                        location: 14,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    where_clause: Some(
+                        Node {
+                            node: Some(
+                                AExpr(
+                                    AExpr {
+                                        kind: AexprOp,
+                                        name: [
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: ">",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        lexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    CollateClause(
+                                                        CollateClause {
+                                                            arg: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        ColumnRef(
+                                                                            ColumnRef {
+                                                                                fields: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: "a",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                location: 24,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            collname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "C",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 26,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        rexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    AConst(
+                                                        AConst {
+                                                            isnull: false,
+                                                            location: 40,
+                                                            val: Some(
+                                                                Sval(
+                                                                    String {
+                                                                        sval: "foo",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 38,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..45,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0017@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0017@1.snap
@@ -1,0 +1,358 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "SELECT name, (SELECT max(pop) FROM cities WHERE cities.state = states.name)\n    FROM states;"
+---
+Parse {
+    cst: SourceFile@0..92
+      SelectStmt@0..92
+        Select@0..6 "SELECT"
+        Whitespace@6..7 " "
+        ResTarget@7..11
+          ColumnRef@7..11
+            NameP@7..11 "name"
+        Ascii44@11..12 ","
+        Whitespace@12..13 " "
+        ResTarget@13..74
+          SubLink@13..74
+            SelectStmt@13..74
+              Ascii40@13..14 "("
+              Select@14..20 "SELECT"
+              Whitespace@20..21 " "
+              ResTarget@21..28
+                FuncCall@21..28
+                  Ident@21..24 "max"
+                  Ascii40@24..25 "("
+                  ColumnRef@25..28
+                    Ident@25..28 "pop"
+              Ascii41@28..29 ")"
+              Whitespace@29..30 " "
+              From@30..34 "FROM"
+              Whitespace@34..35 " "
+              RangeVar@35..41
+                Ident@35..41 "cities"
+              Whitespace@41..42 " "
+              Where@42..47 "WHERE"
+              Whitespace@47..48 " "
+              AExpr@48..74
+                ColumnRef@48..60
+                  Ident@48..54 "cities"
+                  Ascii46@54..55 "."
+                  Ident@55..60 "state"
+                Whitespace@60..61 " "
+                Ascii61@61..62 "="
+                Whitespace@62..63 " "
+                ColumnRef@63..74
+                  Ident@63..69 "states"
+                  Ascii46@69..70 "."
+                  NameP@70..74 "name"
+        Ascii41@74..75 ")"
+        Newline@75..76 "\n"
+        Whitespace@76..80 "    "
+        From@80..84 "FROM"
+        Whitespace@84..85 " "
+        RangeVar@85..91
+          Ident@85..91 "states"
+        Ascii59@91..92 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "name",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 7,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    SubLink(
+                                                        SubLink {
+                                                            xpr: None,
+                                                            sub_link_type: ExprSublink,
+                                                            sub_link_id: 0,
+                                                            testexpr: None,
+                                                            oper_name: [],
+                                                            subselect: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        SelectStmt(
+                                                                            SelectStmt {
+                                                                                distinct_clause: [],
+                                                                                into_clause: None,
+                                                                                target_list: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            ResTarget(
+                                                                                                ResTarget {
+                                                                                                    name: "",
+                                                                                                    indirection: [],
+                                                                                                    val: Some(
+                                                                                                        Node {
+                                                                                                            node: Some(
+                                                                                                                FuncCall(
+                                                                                                                    FuncCall {
+                                                                                                                        funcname: [
+                                                                                                                            Node {
+                                                                                                                                node: Some(
+                                                                                                                                    String(
+                                                                                                                                        String {
+                                                                                                                                            sval: "max",
+                                                                                                                                        },
+                                                                                                                                    ),
+                                                                                                                                ),
+                                                                                                                            },
+                                                                                                                        ],
+                                                                                                                        args: [
+                                                                                                                            Node {
+                                                                                                                                node: Some(
+                                                                                                                                    ColumnRef(
+                                                                                                                                        ColumnRef {
+                                                                                                                                            fields: [
+                                                                                                                                                Node {
+                                                                                                                                                    node: Some(
+                                                                                                                                                        String(
+                                                                                                                                                            String {
+                                                                                                                                                                sval: "pop",
+                                                                                                                                                            },
+                                                                                                                                                        ),
+                                                                                                                                                    ),
+                                                                                                                                                },
+                                                                                                                                            ],
+                                                                                                                                            location: 25,
+                                                                                                                                        },
+                                                                                                                                    ),
+                                                                                                                                ),
+                                                                                                                            },
+                                                                                                                        ],
+                                                                                                                        agg_order: [],
+                                                                                                                        agg_filter: None,
+                                                                                                                        over: None,
+                                                                                                                        agg_within_group: false,
+                                                                                                                        agg_star: false,
+                                                                                                                        agg_distinct: false,
+                                                                                                                        func_variadic: false,
+                                                                                                                        funcformat: CoerceExplicitCall,
+                                                                                                                        location: 21,
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    location: 21,
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                from_clause: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            RangeVar(
+                                                                                                RangeVar {
+                                                                                                    catalogname: "",
+                                                                                                    schemaname: "",
+                                                                                                    relname: "cities",
+                                                                                                    inh: true,
+                                                                                                    relpersistence: "p",
+                                                                                                    alias: None,
+                                                                                                    location: 35,
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                where_clause: Some(
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            AExpr(
+                                                                                                AExpr {
+                                                                                                    kind: AexprOp,
+                                                                                                    name: [
+                                                                                                        Node {
+                                                                                                            node: Some(
+                                                                                                                String(
+                                                                                                                    String {
+                                                                                                                        sval: "=",
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ],
+                                                                                                    lexpr: Some(
+                                                                                                        Node {
+                                                                                                            node: Some(
+                                                                                                                ColumnRef(
+                                                                                                                    ColumnRef {
+                                                                                                                        fields: [
+                                                                                                                            Node {
+                                                                                                                                node: Some(
+                                                                                                                                    String(
+                                                                                                                                        String {
+                                                                                                                                            sval: "cities",
+                                                                                                                                        },
+                                                                                                                                    ),
+                                                                                                                                ),
+                                                                                                                            },
+                                                                                                                            Node {
+                                                                                                                                node: Some(
+                                                                                                                                    String(
+                                                                                                                                        String {
+                                                                                                                                            sval: "state",
+                                                                                                                                        },
+                                                                                                                                    ),
+                                                                                                                                ),
+                                                                                                                            },
+                                                                                                                        ],
+                                                                                                                        location: 48,
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    rexpr: Some(
+                                                                                                        Node {
+                                                                                                            node: Some(
+                                                                                                                ColumnRef(
+                                                                                                                    ColumnRef {
+                                                                                                                        fields: [
+                                                                                                                            Node {
+                                                                                                                                node: Some(
+                                                                                                                                    String(
+                                                                                                                                        String {
+                                                                                                                                            sval: "states",
+                                                                                                                                        },
+                                                                                                                                    ),
+                                                                                                                                ),
+                                                                                                                            },
+                                                                                                                            Node {
+                                                                                                                                node: Some(
+                                                                                                                                    String(
+                                                                                                                                        String {
+                                                                                                                                            sval: "name",
+                                                                                                                                        },
+                                                                                                                                    ),
+                                                                                                                                ),
+                                                                                                                            },
+                                                                                                                        ],
+                                                                                                                        location: 63,
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    location: 61,
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                group_clause: [],
+                                                                                group_distinct: false,
+                                                                                having_clause: None,
+                                                                                window_clause: [],
+                                                                                values_lists: [],
+                                                                                sort_clause: [],
+                                                                                limit_offset: None,
+                                                                                limit_count: None,
+                                                                                limit_option: Default,
+                                                                                locking_clause: [],
+                                                                                with_clause: None,
+                                                                                op: SetopNone,
+                                                                                all: false,
+                                                                                larg: None,
+                                                                                rarg: None,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            location: 13,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 13,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [
+                        Node {
+                            node: Some(
+                                RangeVar(
+                                    RangeVar {
+                                        catalogname: "",
+                                        schemaname: "",
+                                        relname: "states",
+                                        inh: true,
+                                        relpersistence: "p",
+                                        alias: None,
+                                        location: 85,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    where_clause: None,
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..91,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0018@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0018@1.snap
@@ -1,0 +1,189 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "SELECT ARRAY[1,2,22.7]::integer[];"
+---
+Parse {
+    cst: SourceFile@0..34
+      SelectStmt@0..34
+        Select@0..6 "SELECT"
+        Whitespace@6..7 " "
+        ResTarget@7..31
+          TypeCast@7..31
+            AArrayExpr@7..21
+              Array@7..12 "ARRAY"
+              Ascii91@12..13 "["
+              AConst@13..14
+                Iconst@13..14 "1"
+              Ascii44@14..15 ","
+              AConst@15..16
+                Iconst@15..16 "2"
+              Ascii44@16..17 ","
+              AConst@17..21
+                Fconst@17..21 "22.7"
+            Ascii93@21..22 "]"
+            Typecast@22..24 "::"
+            TypeName@24..31
+              Integer@24..31 "integer"
+        Ascii91@31..32 "["
+        Ascii93@32..33 "]"
+        Ascii59@33..34 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    TypeCast(
+                                                        TypeCast {
+                                                            arg: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        AArrayExpr(
+                                                                            AArrayExpr {
+                                                                                elements: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            AConst(
+                                                                                                AConst {
+                                                                                                    isnull: false,
+                                                                                                    location: 13,
+                                                                                                    val: Some(
+                                                                                                        Ival(
+                                                                                                            Integer {
+                                                                                                                ival: 1,
+                                                                                                            },
+                                                                                                        ),
+                                                                                                    ),
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            AConst(
+                                                                                                AConst {
+                                                                                                    isnull: false,
+                                                                                                    location: 15,
+                                                                                                    val: Some(
+                                                                                                        Ival(
+                                                                                                            Integer {
+                                                                                                                ival: 2,
+                                                                                                            },
+                                                                                                        ),
+                                                                                                    ),
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            AConst(
+                                                                                                AConst {
+                                                                                                    isnull: false,
+                                                                                                    location: 17,
+                                                                                                    val: Some(
+                                                                                                        Fval(
+                                                                                                            Float {
+                                                                                                                fval: "22.7",
+                                                                                                            },
+                                                                                                        ),
+                                                                                                    ),
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                location: 7,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            type_name: Some(
+                                                                TypeName {
+                                                                    names: [
+                                                                        Node {
+                                                                            node: Some(
+                                                                                String(
+                                                                                    String {
+                                                                                        sval: "pg_catalog",
+                                                                                    },
+                                                                                ),
+                                                                            ),
+                                                                        },
+                                                                        Node {
+                                                                            node: Some(
+                                                                                String(
+                                                                                    String {
+                                                                                        sval: "int4",
+                                                                                    },
+                                                                                ),
+                                                                            ),
+                                                                        },
+                                                                    ],
+                                                                    type_oid: 0,
+                                                                    setof: false,
+                                                                    pct_type: false,
+                                                                    typmods: [],
+                                                                    typemod: -1,
+                                                                    array_bounds: [
+                                                                        Node {
+                                                                            node: Some(
+                                                                                Integer(
+                                                                                    Integer {
+                                                                                        ival: -1,
+                                                                                    },
+                                                                                ),
+                                                                            ),
+                                                                        },
+                                                                    ],
+                                                                    location: 24,
+                                                                },
+                                                            ),
+                                                            location: 22,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [],
+                    where_clause: None,
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..33,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0019@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0019@1.snap
@@ -1,0 +1,333 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "SELECT CASE WHEN min(employees) > 0\n            THEN avg(expenses / employees)\n       END\n    FROM departments;"
+---
+Parse {
+    cst: SourceFile@0..111
+      SelectStmt@0..111
+        Select@0..6 "SELECT"
+        Whitespace@6..7 " "
+        ResTarget@7..89
+          CaseExpr@7..89
+            Case@7..11 "CASE"
+            Whitespace@11..12 " "
+            CaseWhen@12..77
+              When@12..16 "WHEN"
+              Whitespace@16..17 " "
+              AExpr@17..35
+                FuncCall@17..30
+                  Ident@17..20 "min"
+                  Ascii40@20..21 "("
+                  ColumnRef@21..30
+                    Ident@21..30 "employees"
+                Ascii41@30..31 ")"
+                Whitespace@31..32 " "
+                Ascii62@32..33 ">"
+                Whitespace@33..34 " "
+                AConst@34..35
+                  Iconst@34..35 "0"
+              Newline@35..36 "\n"
+              Whitespace@36..48 "            "
+              Then@48..52 "THEN"
+              Whitespace@52..53 " "
+              FuncCall@53..77
+                Ident@53..56 "avg"
+                Ascii40@56..57 "("
+                AExpr@57..77
+                  ColumnRef@57..65
+                    Ident@57..65 "expenses"
+                  Whitespace@65..66 " "
+                  Ascii47@66..67 "/"
+                  Whitespace@67..68 " "
+                  ColumnRef@68..77
+                    Ident@68..77 "employees"
+            Ascii41@77..78 ")"
+            Newline@78..79 "\n"
+            Whitespace@79..86 "       "
+            EndP@86..89 "END"
+        Newline@89..90 "\n"
+        Whitespace@90..94 "    "
+        From@94..98 "FROM"
+        Whitespace@98..99 " "
+        RangeVar@99..110
+          Ident@99..110 "departments"
+        Ascii59@110..111 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    CaseExpr(
+                                                        CaseExpr {
+                                                            xpr: None,
+                                                            casetype: 0,
+                                                            casecollid: 0,
+                                                            arg: None,
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        CaseWhen(
+                                                                            CaseWhen {
+                                                                                xpr: None,
+                                                                                expr: Some(
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            AExpr(
+                                                                                                AExpr {
+                                                                                                    kind: AexprOp,
+                                                                                                    name: [
+                                                                                                        Node {
+                                                                                                            node: Some(
+                                                                                                                String(
+                                                                                                                    String {
+                                                                                                                        sval: ">",
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ],
+                                                                                                    lexpr: Some(
+                                                                                                        Node {
+                                                                                                            node: Some(
+                                                                                                                FuncCall(
+                                                                                                                    FuncCall {
+                                                                                                                        funcname: [
+                                                                                                                            Node {
+                                                                                                                                node: Some(
+                                                                                                                                    String(
+                                                                                                                                        String {
+                                                                                                                                            sval: "min",
+                                                                                                                                        },
+                                                                                                                                    ),
+                                                                                                                                ),
+                                                                                                                            },
+                                                                                                                        ],
+                                                                                                                        args: [
+                                                                                                                            Node {
+                                                                                                                                node: Some(
+                                                                                                                                    ColumnRef(
+                                                                                                                                        ColumnRef {
+                                                                                                                                            fields: [
+                                                                                                                                                Node {
+                                                                                                                                                    node: Some(
+                                                                                                                                                        String(
+                                                                                                                                                            String {
+                                                                                                                                                                sval: "employees",
+                                                                                                                                                            },
+                                                                                                                                                        ),
+                                                                                                                                                    ),
+                                                                                                                                                },
+                                                                                                                                            ],
+                                                                                                                                            location: 21,
+                                                                                                                                        },
+                                                                                                                                    ),
+                                                                                                                                ),
+                                                                                                                            },
+                                                                                                                        ],
+                                                                                                                        agg_order: [],
+                                                                                                                        agg_filter: None,
+                                                                                                                        over: None,
+                                                                                                                        agg_within_group: false,
+                                                                                                                        agg_star: false,
+                                                                                                                        agg_distinct: false,
+                                                                                                                        func_variadic: false,
+                                                                                                                        funcformat: CoerceExplicitCall,
+                                                                                                                        location: 17,
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    rexpr: Some(
+                                                                                                        Node {
+                                                                                                            node: Some(
+                                                                                                                AConst(
+                                                                                                                    AConst {
+                                                                                                                        isnull: false,
+                                                                                                                        location: 34,
+                                                                                                                        val: Some(
+                                                                                                                            Ival(
+                                                                                                                                Integer {
+                                                                                                                                    ival: 0,
+                                                                                                                                },
+                                                                                                                            ),
+                                                                                                                        ),
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    location: 32,
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                result: Some(
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            FuncCall(
+                                                                                                FuncCall {
+                                                                                                    funcname: [
+                                                                                                        Node {
+                                                                                                            node: Some(
+                                                                                                                String(
+                                                                                                                    String {
+                                                                                                                        sval: "avg",
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ],
+                                                                                                    args: [
+                                                                                                        Node {
+                                                                                                            node: Some(
+                                                                                                                AExpr(
+                                                                                                                    AExpr {
+                                                                                                                        kind: AexprOp,
+                                                                                                                        name: [
+                                                                                                                            Node {
+                                                                                                                                node: Some(
+                                                                                                                                    String(
+                                                                                                                                        String {
+                                                                                                                                            sval: "/",
+                                                                                                                                        },
+                                                                                                                                    ),
+                                                                                                                                ),
+                                                                                                                            },
+                                                                                                                        ],
+                                                                                                                        lexpr: Some(
+                                                                                                                            Node {
+                                                                                                                                node: Some(
+                                                                                                                                    ColumnRef(
+                                                                                                                                        ColumnRef {
+                                                                                                                                            fields: [
+                                                                                                                                                Node {
+                                                                                                                                                    node: Some(
+                                                                                                                                                        String(
+                                                                                                                                                            String {
+                                                                                                                                                                sval: "expenses",
+                                                                                                                                                            },
+                                                                                                                                                        ),
+                                                                                                                                                    ),
+                                                                                                                                                },
+                                                                                                                                            ],
+                                                                                                                                            location: 57,
+                                                                                                                                        },
+                                                                                                                                    ),
+                                                                                                                                ),
+                                                                                                                            },
+                                                                                                                        ),
+                                                                                                                        rexpr: Some(
+                                                                                                                            Node {
+                                                                                                                                node: Some(
+                                                                                                                                    ColumnRef(
+                                                                                                                                        ColumnRef {
+                                                                                                                                            fields: [
+                                                                                                                                                Node {
+                                                                                                                                                    node: Some(
+                                                                                                                                                        String(
+                                                                                                                                                            String {
+                                                                                                                                                                sval: "employees",
+                                                                                                                                                            },
+                                                                                                                                                        ),
+                                                                                                                                                    ),
+                                                                                                                                                },
+                                                                                                                                            ],
+                                                                                                                                            location: 68,
+                                                                                                                                        },
+                                                                                                                                    ),
+                                                                                                                                ),
+                                                                                                                            },
+                                                                                                                        ),
+                                                                                                                        location: 66,
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ],
+                                                                                                    agg_order: [],
+                                                                                                    agg_filter: None,
+                                                                                                    over: None,
+                                                                                                    agg_within_group: false,
+                                                                                                    agg_star: false,
+                                                                                                    agg_distinct: false,
+                                                                                                    func_variadic: false,
+                                                                                                    funcformat: CoerceExplicitCall,
+                                                                                                    location: 53,
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                location: 12,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            defresult: None,
+                                                            location: 7,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [
+                        Node {
+                            node: Some(
+                                RangeVar(
+                                    RangeVar {
+                                        catalogname: "",
+                                        schemaname: "",
+                                        relname: "departments",
+                                        inh: true,
+                                        relpersistence: "p",
+                                        alias: None,
+                                        location: 99,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    where_clause: None,
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..110,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0020@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0020@1.snap
@@ -1,0 +1,341 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "CREATE FUNCTION concat_lower_or_upper(a text, b text, uppercase boolean DEFAULT false)\nRETURNS text\nAS\n$$\n SELECT CASE\n        WHEN $3 THEN UPPER($1 || ' ' || $2)\n        ELSE LOWER($1 || ' ' || $2)\n        END;\n$$\nLANGUAGE SQL IMMUTABLE STRICT;"
+---
+Parse {
+    cst: SourceFile@0..245
+      CreateFunctionStmt@0..245
+        Create@0..6 "CREATE"
+        Whitespace@6..7 " "
+        Function@7..15 "FUNCTION"
+        Whitespace@15..16 " "
+        Ident@16..37 "concat_lower_or_upper"
+        Ascii40@37..38 "("
+        FunctionParameter@38..44
+          Ident@38..39 "a"
+          Whitespace@39..40 " "
+          TypeName@40..44
+            TextP@40..44 "text"
+        Ascii44@44..45 ","
+        Whitespace@45..46 " "
+        FunctionParameter@46..52
+          Ident@46..47 "b"
+          Whitespace@47..48 " "
+          TypeName@48..52
+            TextP@48..52 "text"
+        Ascii44@52..53 ","
+        Whitespace@53..54 " "
+        FunctionParameter@54..85
+          Ident@54..63 "uppercase"
+          Whitespace@63..64 " "
+          TypeName@64..71
+            BooleanP@64..71 "boolean"
+          Whitespace@71..72 " "
+          Default@72..79 "DEFAULT"
+          Whitespace@79..80 " "
+          AConst@80..85
+            FalseP@80..85 "false"
+        Ascii41@85..86 ")"
+        Newline@86..87 "\n"
+        Returns@87..94 "RETURNS"
+        Whitespace@94..95 " "
+        TypeName@95..99
+          TextP@95..99 "text"
+        Newline@99..100 "\n"
+        DefElem@100..214
+          As@100..102 "AS"
+          Newline@102..103 "\n"
+          List@103..214
+            Sconst@103..214 "$$\n SELECT CASE\n      ..."
+        Newline@214..215 "\n"
+        DefElem@215..227
+          Language@215..223 "LANGUAGE"
+          Whitespace@223..224 " "
+          SqlP@224..227 "SQL"
+        Whitespace@227..228 " "
+        DefElem@228..237
+          Immutable@228..237 "IMMUTABLE"
+        Whitespace@237..238 " "
+        DefElem@238..244
+          StrictP@238..244 "STRICT"
+        Ascii59@244..245 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateFunctionStmt(
+                CreateFunctionStmt {
+                    is_procedure: false,
+                    replace: false,
+                    funcname: [
+                        Node {
+                            node: Some(
+                                String(
+                                    String {
+                                        sval: "concat_lower_or_upper",
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    parameters: [
+                        Node {
+                            node: Some(
+                                FunctionParameter(
+                                    FunctionParameter {
+                                        name: "a",
+                                        arg_type: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "text",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 40,
+                                            },
+                                        ),
+                                        mode: FuncParamDefault,
+                                        defexpr: None,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                FunctionParameter(
+                                    FunctionParameter {
+                                        name: "b",
+                                        arg_type: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "text",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 48,
+                                            },
+                                        ),
+                                        mode: FuncParamDefault,
+                                        defexpr: None,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                FunctionParameter(
+                                    FunctionParameter {
+                                        name: "uppercase",
+                                        arg_type: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "bool",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 64,
+                                            },
+                                        ),
+                                        mode: FuncParamDefault,
+                                        defexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    AConst(
+                                                        AConst {
+                                                            isnull: false,
+                                                            location: 80,
+                                                            val: Some(
+                                                                Boolval(
+                                                                    Boolean {
+                                                                        boolval: false,
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    return_type: Some(
+                        TypeName {
+                            names: [
+                                Node {
+                                    node: Some(
+                                        String(
+                                            String {
+                                                sval: "text",
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ],
+                            type_oid: 0,
+                            setof: false,
+                            pct_type: false,
+                            typmods: [],
+                            typemod: -1,
+                            array_bounds: [],
+                            location: 95,
+                        },
+                    ),
+                    options: [
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "as",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    List(
+                                                        List {
+                                                            items: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "\n SELECT CASE\n        WHEN $3 THEN UPPER($1 || ' ' || $2)\n        ELSE LOWER($1 || ' ' || $2)\n        END;\n",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 100,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "language",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "sql",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 215,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "volatility",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "immutable",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 228,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "strict",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    Boolean(
+                                                        Boolean {
+                                                            boolval: true,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 238,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    sql_body: None,
+                },
+            ),
+            range: 0..244,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0021@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0021@1.snap
@@ -1,0 +1,209 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "SELECT concat_lower_or_upper(a => 'Hello', b => 'World', uppercase => true);"
+---
+Parse {
+    cst: SourceFile@0..76
+      SelectStmt@0..76
+        Select@0..6 "SELECT"
+        Whitespace@6..7 " "
+        ResTarget@7..74
+          FuncCall@7..74
+            Ident@7..28 "concat_lower_or_upper"
+            Ascii40@28..29 "("
+            NamedArgExpr@29..41
+              Ident@29..30 "a"
+              Whitespace@30..31 " "
+              EqualsGreater@31..33 "=>"
+              Whitespace@33..34 " "
+              AConst@34..41
+                Sconst@34..41 "'Hello'"
+            Ascii44@41..42 ","
+            Whitespace@42..43 " "
+            NamedArgExpr@43..55
+              Ident@43..44 "b"
+              Whitespace@44..45 " "
+              EqualsGreater@45..47 "=>"
+              Whitespace@47..48 " "
+              AConst@48..55
+                Sconst@48..55 "'World'"
+            Ascii44@55..56 ","
+            Whitespace@56..57 " "
+            NamedArgExpr@57..74
+              Ident@57..66 "uppercase"
+              Whitespace@66..67 " "
+              EqualsGreater@67..69 "=>"
+              Whitespace@69..70 " "
+              AConst@70..74
+                TrueP@70..74 "true"
+        Ascii41@74..75 ")"
+        Ascii59@75..76 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "concat_lower_or_upper",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        NamedArgExpr(
+                                                                            NamedArgExpr {
+                                                                                xpr: None,
+                                                                                arg: Some(
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            AConst(
+                                                                                                AConst {
+                                                                                                    isnull: false,
+                                                                                                    location: 34,
+                                                                                                    val: Some(
+                                                                                                        Sval(
+                                                                                                            String {
+                                                                                                                sval: "Hello",
+                                                                                                            },
+                                                                                                        ),
+                                                                                                    ),
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                name: "a",
+                                                                                argnumber: -1,
+                                                                                location: 29,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        NamedArgExpr(
+                                                                            NamedArgExpr {
+                                                                                xpr: None,
+                                                                                arg: Some(
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            AConst(
+                                                                                                AConst {
+                                                                                                    isnull: false,
+                                                                                                    location: 48,
+                                                                                                    val: Some(
+                                                                                                        Sval(
+                                                                                                            String {
+                                                                                                                sval: "World",
+                                                                                                            },
+                                                                                                        ),
+                                                                                                    ),
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                name: "b",
+                                                                                argnumber: -1,
+                                                                                location: 43,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        NamedArgExpr(
+                                                                            NamedArgExpr {
+                                                                                xpr: None,
+                                                                                arg: Some(
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            AConst(
+                                                                                                AConst {
+                                                                                                    isnull: false,
+                                                                                                    location: 70,
+                                                                                                    val: Some(
+                                                                                                        Boolval(
+                                                                                                            Boolean {
+                                                                                                                boolval: true,
+                                                                                                            },
+                                                                                                        ),
+                                                                                                    ),
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                name: "uppercase",
+                                                                                argnumber: -1,
+                                                                                location: 57,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 7,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [],
+                    where_clause: None,
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..75,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0022@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0022@1.snap
@@ -1,0 +1,298 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "CREATE TABLE products (\n    product_no integer,\n    name text,\n    price numeric DEFAULT 9.99\n);"
+---
+Parse {
+    cst: SourceFile@0..96
+      CreateStmt@0..96
+        Create@0..6 "CREATE"
+        Whitespace@6..7 " "
+        Table@7..12 "TABLE"
+        Whitespace@12..13 " "
+        RangeVar@13..21
+          Ident@13..21 "products"
+        Whitespace@21..22 " "
+        Ascii40@22..23 "("
+        Newline@23..24 "\n"
+        Whitespace@24..28 "    "
+        ColumnDef@28..46
+          Ident@28..38 "product_no"
+          Whitespace@38..39 " "
+          TypeName@39..46
+            Integer@39..46 "integer"
+        Ascii44@46..47 ","
+        Newline@47..48 "\n"
+        Whitespace@48..52 "    "
+        ColumnDef@52..61
+          NameP@52..56 "name"
+          Whitespace@56..57 " "
+          TypeName@57..61
+            TextP@57..61 "text"
+        Ascii44@61..62 ","
+        Newline@62..63 "\n"
+        Whitespace@63..67 "    "
+        ColumnDef@67..93
+          Ident@67..72 "price"
+          Whitespace@72..73 " "
+          TypeName@73..80
+            Numeric@73..80 "numeric"
+          Whitespace@80..81 " "
+          Constraint@81..93
+            Default@81..88 "DEFAULT"
+            Whitespace@88..89 " "
+            AConst@89..93
+              Fconst@89..93 "9.99"
+        Newline@93..94 "\n"
+        Ascii41@94..95 ")"
+        Ascii59@95..96 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateStmt(
+                CreateStmt {
+                    relation: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "products",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 13,
+                        },
+                    ),
+                    table_elts: [
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "product_no",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "int4",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 39,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [],
+                                        fdwoptions: [],
+                                        location: 28,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "name",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "text",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 57,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [],
+                                        fdwoptions: [],
+                                        location: 52,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "price",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "numeric",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 73,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [
+                                            Node {
+                                                node: Some(
+                                                    Constraint(
+                                                        Constraint {
+                                                            contype: ConstrDefault,
+                                                            conname: "",
+                                                            deferrable: false,
+                                                            initdeferred: false,
+                                                            location: 81,
+                                                            is_no_inherit: false,
+                                                            raw_expr: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 89,
+                                                                                val: Some(
+                                                                                    Fval(
+                                                                                        Float {
+                                                                                            fval: "9.99",
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            cooked_expr: "",
+                                                            generated_when: "",
+                                                            nulls_not_distinct: false,
+                                                            keys: [],
+                                                            including: [],
+                                                            exclusions: [],
+                                                            options: [],
+                                                            indexname: "",
+                                                            indexspace: "",
+                                                            reset_default_tblspc: false,
+                                                            access_method: "",
+                                                            where_clause: None,
+                                                            pktable: None,
+                                                            fk_attrs: [],
+                                                            pk_attrs: [],
+                                                            fk_matchtype: "",
+                                                            fk_upd_action: "",
+                                                            fk_del_action: "",
+                                                            fk_del_set_cols: [],
+                                                            old_conpfeqop: [],
+                                                            old_pktable_oid: 0,
+                                                            skip_validation: false,
+                                                            initially_valid: false,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        fdwoptions: [],
+                                        location: 67,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    inh_relations: [],
+                    partbound: None,
+                    partspec: None,
+                    of_typename: None,
+                    constraints: [],
+                    options: [],
+                    oncommit: OncommitNoop,
+                    tablespacename: "",
+                    access_method: "",
+                    if_not_exists: false,
+                },
+            ),
+            range: 0..95,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0023@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0023@1.snap
@@ -1,0 +1,651 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "CREATE TABLE products (\n    product_no integer,\n    name text,\n    price numeric CHECK (price > 0),\n    discounted_price numeric CHECK (discounted_price > 0),\n    CHECK (price > discounted_price)\n);"
+---
+Parse {
+    cst: SourceFile@0..198
+      CreateStmt@0..198
+        Create@0..6 "CREATE"
+        Whitespace@6..7 " "
+        Table@7..12 "TABLE"
+        Whitespace@12..13 " "
+        RangeVar@13..21
+          Ident@13..21 "products"
+        Whitespace@21..22 " "
+        Ascii40@22..23 "("
+        Newline@23..24 "\n"
+        Whitespace@24..28 "    "
+        ColumnDef@28..46
+          Ident@28..38 "product_no"
+          Whitespace@38..39 " "
+          TypeName@39..46
+            Integer@39..46 "integer"
+        Ascii44@46..47 ","
+        Newline@47..48 "\n"
+        Whitespace@48..52 "    "
+        ColumnDef@52..61
+          NameP@52..56 "name"
+          Whitespace@56..57 " "
+          TypeName@57..61
+            TextP@57..61 "text"
+        Ascii44@61..62 ","
+        Newline@62..63 "\n"
+        Whitespace@63..67 "    "
+        ColumnDef@67..97
+          Ident@67..72 "price"
+          Whitespace@72..73 " "
+          TypeName@73..80
+            Numeric@73..80 "numeric"
+          Whitespace@80..81 " "
+          Constraint@81..97
+            Check@81..86 "CHECK"
+            Whitespace@86..87 " "
+            Ascii40@87..88 "("
+            AExpr@88..97
+              ColumnRef@88..93
+                Ident@88..93 "price"
+              Whitespace@93..94 " "
+              Ascii62@94..95 ">"
+              Whitespace@95..96 " "
+              AConst@96..97
+                Iconst@96..97 "0"
+        Ascii41@97..98 ")"
+        Ascii44@98..99 ","
+        Newline@99..100 "\n"
+        Whitespace@100..104 "    "
+        ColumnDef@104..156
+          Ident@104..120 "discounted_price"
+          Whitespace@120..121 " "
+          TypeName@121..128
+            Numeric@121..128 "numeric"
+          Whitespace@128..129 " "
+          Constraint@129..156
+            Check@129..134 "CHECK"
+            Whitespace@134..135 " "
+            Ascii40@135..136 "("
+            AExpr@136..156
+              ColumnRef@136..152
+                Ident@136..152 "discounted_price"
+              Whitespace@152..153 " "
+              Ascii62@153..154 ">"
+              Whitespace@154..155 " "
+              AConst@155..156
+                Iconst@155..156 "0"
+        Ascii41@156..157 ")"
+        Ascii44@157..158 ","
+        Newline@158..159 "\n"
+        Whitespace@159..163 "    "
+        Constraint@163..194
+          Check@163..168 "CHECK"
+          Whitespace@168..169 " "
+          Ascii40@169..170 "("
+          AExpr@170..194
+            ColumnRef@170..175
+              Ident@170..175 "price"
+            Whitespace@175..176 " "
+            Ascii62@176..177 ">"
+            Whitespace@177..178 " "
+            ColumnRef@178..194
+              Ident@178..194 "discounted_price"
+        Ascii41@194..195 ")"
+        Newline@195..196 "\n"
+        Ascii41@196..197 ")"
+        Ascii59@197..198 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateStmt(
+                CreateStmt {
+                    relation: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "products",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 13,
+                        },
+                    ),
+                    table_elts: [
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "product_no",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "int4",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 39,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [],
+                                        fdwoptions: [],
+                                        location: 28,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "name",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "text",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 57,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [],
+                                        fdwoptions: [],
+                                        location: 52,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "price",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "numeric",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 73,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [
+                                            Node {
+                                                node: Some(
+                                                    Constraint(
+                                                        Constraint {
+                                                            contype: ConstrCheck,
+                                                            conname: "",
+                                                            deferrable: false,
+                                                            initdeferred: false,
+                                                            location: 81,
+                                                            is_no_inherit: false,
+                                                            raw_expr: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        AExpr(
+                                                                            AExpr {
+                                                                                kind: AexprOp,
+                                                                                name: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: ">",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                lexpr: Some(
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            ColumnRef(
+                                                                                                ColumnRef {
+                                                                                                    fields: [
+                                                                                                        Node {
+                                                                                                            node: Some(
+                                                                                                                String(
+                                                                                                                    String {
+                                                                                                                        sval: "price",
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ],
+                                                                                                    location: 88,
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                rexpr: Some(
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            AConst(
+                                                                                                AConst {
+                                                                                                    isnull: false,
+                                                                                                    location: 96,
+                                                                                                    val: Some(
+                                                                                                        Ival(
+                                                                                                            Integer {
+                                                                                                                ival: 0,
+                                                                                                            },
+                                                                                                        ),
+                                                                                                    ),
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                location: 94,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            cooked_expr: "",
+                                                            generated_when: "",
+                                                            nulls_not_distinct: false,
+                                                            keys: [],
+                                                            including: [],
+                                                            exclusions: [],
+                                                            options: [],
+                                                            indexname: "",
+                                                            indexspace: "",
+                                                            reset_default_tblspc: false,
+                                                            access_method: "",
+                                                            where_clause: None,
+                                                            pktable: None,
+                                                            fk_attrs: [],
+                                                            pk_attrs: [],
+                                                            fk_matchtype: "",
+                                                            fk_upd_action: "",
+                                                            fk_del_action: "",
+                                                            fk_del_set_cols: [],
+                                                            old_conpfeqop: [],
+                                                            old_pktable_oid: 0,
+                                                            skip_validation: false,
+                                                            initially_valid: true,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        fdwoptions: [],
+                                        location: 67,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "discounted_price",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "numeric",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 121,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [
+                                            Node {
+                                                node: Some(
+                                                    Constraint(
+                                                        Constraint {
+                                                            contype: ConstrCheck,
+                                                            conname: "",
+                                                            deferrable: false,
+                                                            initdeferred: false,
+                                                            location: 129,
+                                                            is_no_inherit: false,
+                                                            raw_expr: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        AExpr(
+                                                                            AExpr {
+                                                                                kind: AexprOp,
+                                                                                name: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: ">",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                lexpr: Some(
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            ColumnRef(
+                                                                                                ColumnRef {
+                                                                                                    fields: [
+                                                                                                        Node {
+                                                                                                            node: Some(
+                                                                                                                String(
+                                                                                                                    String {
+                                                                                                                        sval: "discounted_price",
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ],
+                                                                                                    location: 136,
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                rexpr: Some(
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            AConst(
+                                                                                                AConst {
+                                                                                                    isnull: false,
+                                                                                                    location: 155,
+                                                                                                    val: Some(
+                                                                                                        Ival(
+                                                                                                            Integer {
+                                                                                                                ival: 0,
+                                                                                                            },
+                                                                                                        ),
+                                                                                                    ),
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                location: 153,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            cooked_expr: "",
+                                                            generated_when: "",
+                                                            nulls_not_distinct: false,
+                                                            keys: [],
+                                                            including: [],
+                                                            exclusions: [],
+                                                            options: [],
+                                                            indexname: "",
+                                                            indexspace: "",
+                                                            reset_default_tblspc: false,
+                                                            access_method: "",
+                                                            where_clause: None,
+                                                            pktable: None,
+                                                            fk_attrs: [],
+                                                            pk_attrs: [],
+                                                            fk_matchtype: "",
+                                                            fk_upd_action: "",
+                                                            fk_del_action: "",
+                                                            fk_del_set_cols: [],
+                                                            old_conpfeqop: [],
+                                                            old_pktable_oid: 0,
+                                                            skip_validation: false,
+                                                            initially_valid: true,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        fdwoptions: [],
+                                        location: 104,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                Constraint(
+                                    Constraint {
+                                        contype: ConstrCheck,
+                                        conname: "",
+                                        deferrable: false,
+                                        initdeferred: false,
+                                        location: 163,
+                                        is_no_inherit: false,
+                                        raw_expr: Some(
+                                            Node {
+                                                node: Some(
+                                                    AExpr(
+                                                        AExpr {
+                                                            kind: AexprOp,
+                                                            name: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: ">",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            lexpr: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        ColumnRef(
+                                                                            ColumnRef {
+                                                                                fields: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: "price",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                location: 170,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            rexpr: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        ColumnRef(
+                                                                            ColumnRef {
+                                                                                fields: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: "discounted_price",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                location: 178,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            location: 176,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        cooked_expr: "",
+                                        generated_when: "",
+                                        nulls_not_distinct: false,
+                                        keys: [],
+                                        including: [],
+                                        exclusions: [],
+                                        options: [],
+                                        indexname: "",
+                                        indexspace: "",
+                                        reset_default_tblspc: false,
+                                        access_method: "",
+                                        where_clause: None,
+                                        pktable: None,
+                                        fk_attrs: [],
+                                        pk_attrs: [],
+                                        fk_matchtype: "",
+                                        fk_upd_action: "",
+                                        fk_del_action: "",
+                                        fk_del_set_cols: [],
+                                        old_conpfeqop: [],
+                                        old_pktable_oid: 0,
+                                        skip_validation: false,
+                                        initially_valid: true,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    inh_relations: [],
+                    partbound: None,
+                    partspec: None,
+                    of_typename: None,
+                    constraints: [],
+                    options: [],
+                    oncommit: OncommitNoop,
+                    tablespacename: "",
+                    access_method: "",
+                    if_not_exists: false,
+                },
+            ),
+            range: 0..197,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0024@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0024@1.snap
@@ -1,0 +1,425 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "CREATE TABLE order_items (\n    product_no integer REFERENCES products,\n    order_id integer REFERENCES orders,\n    quantity integer,\n    PRIMARY KEY (product_no, order_id)\n);"
+---
+Parse {
+    cst: SourceFile@0..174
+      CreateStmt@0..174
+        Create@0..6 "CREATE"
+        Whitespace@6..7 " "
+        Table@7..12 "TABLE"
+        Whitespace@12..13 " "
+        RangeVar@13..24
+          Ident@13..24 "order_items"
+        Whitespace@24..25 " "
+        Ascii40@25..26 "("
+        Newline@26..27 "\n"
+        Whitespace@27..31 "    "
+        ColumnDef@31..69
+          Ident@31..41 "product_no"
+          Whitespace@41..42 " "
+          TypeName@42..49
+            Integer@42..49 "integer"
+          Whitespace@49..50 " "
+          Constraint@50..69
+            References@50..60 "REFERENCES"
+            Whitespace@60..61 " "
+            RangeVar@61..69
+              Ident@61..69 "products"
+        Ascii44@69..70 ","
+        Newline@70..71 "\n"
+        Whitespace@71..75 "    "
+        ColumnDef@75..109
+          Ident@75..83 "order_id"
+          Whitespace@83..84 " "
+          TypeName@84..91
+            Integer@84..91 "integer"
+          Whitespace@91..92 " "
+          Constraint@92..109
+            References@92..102 "REFERENCES"
+            Whitespace@102..103 " "
+            RangeVar@103..109
+              Ident@103..109 "orders"
+        Ascii44@109..110 ","
+        Newline@110..111 "\n"
+        Whitespace@111..115 "    "
+        ColumnDef@115..131
+          Ident@115..123 "quantity"
+          Whitespace@123..124 " "
+          TypeName@124..131
+            Integer@124..131 "integer"
+        Ascii44@131..132 ","
+        Newline@132..133 "\n"
+        Whitespace@133..137 "    "
+        Constraint@137..170
+          Primary@137..144 "PRIMARY"
+          Whitespace@144..145 " "
+          Key@145..148 "KEY"
+          Whitespace@148..149 " "
+          Ascii40@149..150 "("
+          Ident@150..160 "product_no"
+          Ascii44@160..161 ","
+          Whitespace@161..162 " "
+          Ident@162..170 "order_id"
+        Ascii41@170..171 ")"
+        Newline@171..172 "\n"
+        Ascii41@172..173 ")"
+        Ascii59@173..174 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateStmt(
+                CreateStmt {
+                    relation: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "order_items",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 13,
+                        },
+                    ),
+                    table_elts: [
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "product_no",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "int4",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 42,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [
+                                            Node {
+                                                node: Some(
+                                                    Constraint(
+                                                        Constraint {
+                                                            contype: ConstrForeign,
+                                                            conname: "",
+                                                            deferrable: false,
+                                                            initdeferred: false,
+                                                            location: 50,
+                                                            is_no_inherit: false,
+                                                            raw_expr: None,
+                                                            cooked_expr: "",
+                                                            generated_when: "",
+                                                            nulls_not_distinct: false,
+                                                            keys: [],
+                                                            including: [],
+                                                            exclusions: [],
+                                                            options: [],
+                                                            indexname: "",
+                                                            indexspace: "",
+                                                            reset_default_tblspc: false,
+                                                            access_method: "",
+                                                            where_clause: None,
+                                                            pktable: Some(
+                                                                RangeVar {
+                                                                    catalogname: "",
+                                                                    schemaname: "",
+                                                                    relname: "products",
+                                                                    inh: true,
+                                                                    relpersistence: "p",
+                                                                    alias: None,
+                                                                    location: 61,
+                                                                },
+                                                            ),
+                                                            fk_attrs: [],
+                                                            pk_attrs: [],
+                                                            fk_matchtype: "s",
+                                                            fk_upd_action: "a",
+                                                            fk_del_action: "a",
+                                                            fk_del_set_cols: [],
+                                                            old_conpfeqop: [],
+                                                            old_pktable_oid: 0,
+                                                            skip_validation: false,
+                                                            initially_valid: true,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        fdwoptions: [],
+                                        location: 31,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "order_id",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "int4",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 84,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [
+                                            Node {
+                                                node: Some(
+                                                    Constraint(
+                                                        Constraint {
+                                                            contype: ConstrForeign,
+                                                            conname: "",
+                                                            deferrable: false,
+                                                            initdeferred: false,
+                                                            location: 92,
+                                                            is_no_inherit: false,
+                                                            raw_expr: None,
+                                                            cooked_expr: "",
+                                                            generated_when: "",
+                                                            nulls_not_distinct: false,
+                                                            keys: [],
+                                                            including: [],
+                                                            exclusions: [],
+                                                            options: [],
+                                                            indexname: "",
+                                                            indexspace: "",
+                                                            reset_default_tblspc: false,
+                                                            access_method: "",
+                                                            where_clause: None,
+                                                            pktable: Some(
+                                                                RangeVar {
+                                                                    catalogname: "",
+                                                                    schemaname: "",
+                                                                    relname: "orders",
+                                                                    inh: true,
+                                                                    relpersistence: "p",
+                                                                    alias: None,
+                                                                    location: 103,
+                                                                },
+                                                            ),
+                                                            fk_attrs: [],
+                                                            pk_attrs: [],
+                                                            fk_matchtype: "s",
+                                                            fk_upd_action: "a",
+                                                            fk_del_action: "a",
+                                                            fk_del_set_cols: [],
+                                                            old_conpfeqop: [],
+                                                            old_pktable_oid: 0,
+                                                            skip_validation: false,
+                                                            initially_valid: true,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        fdwoptions: [],
+                                        location: 75,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "quantity",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "int4",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 124,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [],
+                                        fdwoptions: [],
+                                        location: 115,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                Constraint(
+                                    Constraint {
+                                        contype: ConstrPrimary,
+                                        conname: "",
+                                        deferrable: false,
+                                        initdeferred: false,
+                                        location: 137,
+                                        is_no_inherit: false,
+                                        raw_expr: None,
+                                        cooked_expr: "",
+                                        generated_when: "",
+                                        nulls_not_distinct: false,
+                                        keys: [
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "product_no",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "order_id",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        including: [],
+                                        exclusions: [],
+                                        options: [],
+                                        indexname: "",
+                                        indexspace: "",
+                                        reset_default_tblspc: false,
+                                        access_method: "",
+                                        where_clause: None,
+                                        pktable: None,
+                                        fk_attrs: [],
+                                        pk_attrs: [],
+                                        fk_matchtype: "",
+                                        fk_upd_action: "",
+                                        fk_del_action: "",
+                                        fk_del_set_cols: [],
+                                        old_conpfeqop: [],
+                                        old_pktable_oid: 0,
+                                        skip_validation: false,
+                                        initially_valid: false,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    inh_relations: [],
+                    partbound: None,
+                    partspec: None,
+                    of_typename: None,
+                    constraints: [],
+                    options: [],
+                    oncommit: OncommitNoop,
+                    tablespacename: "",
+                    access_method: "",
+                    if_not_exists: false,
+                },
+            ),
+            range: 0..173,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0025@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0025@1.snap
@@ -1,0 +1,176 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "ALTER TABLE products ADD CHECK (name <> '');"
+---
+Parse {
+    cst: SourceFile@0..44
+      AlterTableStmt@0..44
+        Alter@0..5 "ALTER"
+        Whitespace@5..6 " "
+        Table@6..11 "TABLE"
+        Whitespace@11..12 " "
+        RangeVar@12..20
+          Ident@12..20 "products"
+        Whitespace@20..21 " "
+        AlterTableCmd@21..42
+          AddP@21..24 "ADD"
+          Whitespace@24..25 " "
+          Constraint@25..42
+            Check@25..30 "CHECK"
+            Whitespace@30..31 " "
+            Ascii40@31..32 "("
+            AExpr@32..42
+              ColumnRef@32..36
+                NameP@32..36 "name"
+              Whitespace@36..37 " "
+              NotEquals@37..39 "<>"
+              Whitespace@39..40 " "
+              AConst@40..42
+                Sconst@40..42 "''"
+        Ascii41@42..43 ")"
+        Ascii59@43..44 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: AlterTableStmt(
+                AlterTableStmt {
+                    relation: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "products",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 12,
+                        },
+                    ),
+                    cmds: [
+                        Node {
+                            node: Some(
+                                AlterTableCmd(
+                                    AlterTableCmd {
+                                        subtype: AtAddConstraint,
+                                        name: "",
+                                        num: 0,
+                                        newowner: None,
+                                        def: Some(
+                                            Node {
+                                                node: Some(
+                                                    Constraint(
+                                                        Constraint {
+                                                            contype: ConstrCheck,
+                                                            conname: "",
+                                                            deferrable: false,
+                                                            initdeferred: false,
+                                                            location: 25,
+                                                            is_no_inherit: false,
+                                                            raw_expr: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        AExpr(
+                                                                            AExpr {
+                                                                                kind: AexprOp,
+                                                                                name: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: "<>",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                lexpr: Some(
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            ColumnRef(
+                                                                                                ColumnRef {
+                                                                                                    fields: [
+                                                                                                        Node {
+                                                                                                            node: Some(
+                                                                                                                String(
+                                                                                                                    String {
+                                                                                                                        sval: "name",
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ],
+                                                                                                    location: 32,
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                rexpr: Some(
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            AConst(
+                                                                                                AConst {
+                                                                                                    isnull: false,
+                                                                                                    location: 40,
+                                                                                                    val: Some(
+                                                                                                        Sval(
+                                                                                                            String {
+                                                                                                                sval: "",
+                                                                                                            },
+                                                                                                        ),
+                                                                                                    ),
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                location: 37,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            cooked_expr: "",
+                                                            generated_when: "",
+                                                            nulls_not_distinct: false,
+                                                            keys: [],
+                                                            including: [],
+                                                            exclusions: [],
+                                                            options: [],
+                                                            indexname: "",
+                                                            indexspace: "",
+                                                            reset_default_tblspc: false,
+                                                            access_method: "",
+                                                            where_clause: None,
+                                                            pktable: None,
+                                                            fk_attrs: [],
+                                                            pk_attrs: [],
+                                                            fk_matchtype: "",
+                                                            fk_upd_action: "",
+                                                            fk_del_action: "",
+                                                            fk_del_set_cols: [],
+                                                            old_conpfeqop: [],
+                                                            old_pktable_oid: 0,
+                                                            skip_validation: false,
+                                                            initially_valid: true,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        behavior: DropRestrict,
+                                        missing_ok: false,
+                                        recurse: false,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    objtype: ObjectTable,
+                    missing_ok: false,
+                },
+            ),
+            range: 0..43,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0026@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0026@1.snap
@@ -1,0 +1,169 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "ALTER TABLE products ALTER COLUMN price TYPE numeric(10,2);"
+---
+Parse {
+    cst: SourceFile@0..59
+      AlterTableStmt@0..59
+        Alter@0..5 "ALTER"
+        Whitespace@5..6 " "
+        Table@6..11 "TABLE"
+        Whitespace@11..12 " "
+        RangeVar@12..20
+          Ident@12..20 "products"
+        Whitespace@20..21 " "
+        AlterTableCmd@21..57
+          Alter@21..26 "ALTER"
+          Whitespace@26..27 " "
+          Column@27..33 "COLUMN"
+          Whitespace@33..34 " "
+          Ident@34..39 "price"
+          Whitespace@39..40 " "
+          TypeP@40..44 "TYPE"
+          Whitespace@44..45 " "
+          ColumnDef@45..57
+            TypeName@45..57
+              Numeric@45..52 "numeric"
+              Ascii40@52..53 "("
+              AConst@53..55
+                Iconst@53..55 "10"
+              Ascii44@55..56 ","
+              AConst@56..57
+                Iconst@56..57 "2"
+        Ascii41@57..58 ")"
+        Ascii59@58..59 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: AlterTableStmt(
+                AlterTableStmt {
+                    relation: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "products",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 12,
+                        },
+                    ),
+                    cmds: [
+                        Node {
+                            node: Some(
+                                AlterTableCmd(
+                                    AlterTableCmd {
+                                        subtype: AtAlterColumnType,
+                                        name: "price",
+                                        num: 0,
+                                        newowner: None,
+                                        def: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnDef(
+                                                        ColumnDef {
+                                                            colname: "",
+                                                            type_name: Some(
+                                                                TypeName {
+                                                                    names: [
+                                                                        Node {
+                                                                            node: Some(
+                                                                                String(
+                                                                                    String {
+                                                                                        sval: "pg_catalog",
+                                                                                    },
+                                                                                ),
+                                                                            ),
+                                                                        },
+                                                                        Node {
+                                                                            node: Some(
+                                                                                String(
+                                                                                    String {
+                                                                                        sval: "numeric",
+                                                                                    },
+                                                                                ),
+                                                                            ),
+                                                                        },
+                                                                    ],
+                                                                    type_oid: 0,
+                                                                    setof: false,
+                                                                    pct_type: false,
+                                                                    typmods: [
+                                                                        Node {
+                                                                            node: Some(
+                                                                                AConst(
+                                                                                    AConst {
+                                                                                        isnull: false,
+                                                                                        location: 53,
+                                                                                        val: Some(
+                                                                                            Ival(
+                                                                                                Integer {
+                                                                                                    ival: 10,
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                            ),
+                                                                        },
+                                                                        Node {
+                                                                            node: Some(
+                                                                                AConst(
+                                                                                    AConst {
+                                                                                        isnull: false,
+                                                                                        location: 56,
+                                                                                        val: Some(
+                                                                                            Ival(
+                                                                                                Integer {
+                                                                                                    ival: 2,
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                            ),
+                                                                        },
+                                                                    ],
+                                                                    typemod: -1,
+                                                                    array_bounds: [],
+                                                                    location: 45,
+                                                                },
+                                                            ),
+                                                            compression: "",
+                                                            inhcount: 0,
+                                                            is_local: false,
+                                                            is_not_null: false,
+                                                            is_from_type: false,
+                                                            storage: "",
+                                                            raw_default: None,
+                                                            cooked_default: None,
+                                                            identity: "",
+                                                            identity_sequence: None,
+                                                            generated: "",
+                                                            coll_clause: None,
+                                                            coll_oid: 0,
+                                                            constraints: [],
+                                                            fdwoptions: [],
+                                                            location: 34,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        behavior: DropRestrict,
+                                        missing_ok: false,
+                                        recurse: false,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    objtype: ObjectTable,
+                    missing_ok: false,
+                },
+            ),
+            range: 0..58,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0027@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0027@1.snap
@@ -1,0 +1,26 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: GRANT UPDATE ON accounts TO joe;
+---
+Parse {
+    cst: SourceFile@0..31
+      Grant@0..5 "GRANT"
+      Update@5..11 "UPDATE"
+      Whitespace@11..12 " "
+      On@12..14 "ON"
+      Whitespace@14..15 " "
+      Ident@15..23 "accounts"
+      Whitespace@23..24 " "
+      To@24..26 "TO"
+      Whitespace@26..27 " "
+      Ident@27..30 "joe"
+      Ascii59@30..31 ";"
+    ,
+    errors: [
+        SyntaxError(
+            "Invalid statement: syntax error at or near \"ON\"",
+            2..12,
+        ),
+    ],
+    stmts: [],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0028@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0028@1.snap
@@ -1,0 +1,22 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: REVOKE ALL ON accounts FROM PUBLIC;
+---
+Parse {
+    cst: SourceFile@0..35
+      Revoke@0..6 "REVOKE"
+      Whitespace@6..7 " "
+      All@7..10 "ALL"
+      Whitespace@10..11 " "
+      On@11..13 "ON"
+      Whitespace@13..14 " "
+      Ident@14..22 "accounts"
+      Whitespace@22..23 " "
+      From@23..27 "FROM"
+      Whitespace@27..28 " "
+      Ident@28..34 "PUBLIC"
+      Ascii59@34..35 ";"
+    ,
+    errors: [],
+    stmts: [],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0029@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0029@1.snap
@@ -1,0 +1,44 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "GRANT SELECT (col1), UPDATE (col1) ON mytable TO miriam_rw;"
+---
+Parse {
+    cst: SourceFile@0..57
+      Grant@0..5 "GRANT"
+      Select@5..11 "SELECT"
+      Whitespace@11..12 " "
+      Ascii40@12..13 "("
+      Ident@13..17 "col1"
+      Ascii41@17..18 ")"
+      Ascii44@18..19 ","
+      Update@19..25 "UPDATE"
+      Whitespace@25..26 " "
+      Ascii40@26..27 "("
+      Ident@27..31 "col1"
+      Ascii41@31..32 ")"
+      Whitespace@32..33 " "
+      On@33..35 "ON"
+      Whitespace@35..36 " "
+      Ident@36..43 "mytable"
+      Whitespace@43..44 " "
+      To@44..46 "TO"
+      Whitespace@46..47 " "
+      Ident@47..56 "miriam_rw"
+      Ascii59@56..57 ";"
+    ,
+    errors: [
+        SyntaxError(
+            "Expected Ascii59, found Whitespace",
+            20..20,
+        ),
+        SyntaxError(
+            "Invalid statement: syntax error at end of input",
+            2..8,
+        ),
+        SyntaxError(
+            "Invalid statement: syntax error at or near \"(\"",
+            9..23,
+        ),
+    ],
+    stmts: [],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0030@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0030@1.snap
@@ -1,0 +1,137 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "CREATE POLICY account_managers ON accounts TO managers\n    USING (manager = current_user);"
+---
+Parse {
+    cst: SourceFile@0..90
+      CreatePolicyStmt@0..90
+        Create@0..6 "CREATE"
+        Whitespace@6..7 " "
+        Policy@7..13 "POLICY"
+        Whitespace@13..14 " "
+        Ident@14..30 "account_managers"
+        Whitespace@30..31 " "
+        On@31..33 "ON"
+        Whitespace@33..34 " "
+        RangeVar@34..42
+          Ident@34..42 "accounts"
+        Whitespace@42..43 " "
+        To@43..45 "TO"
+        Whitespace@45..46 " "
+        RoleSpec@46..54
+          Ident@46..54 "managers"
+        Newline@54..55 "\n"
+        Whitespace@55..59 "    "
+        Using@59..64 "USING"
+        Whitespace@64..65 " "
+        Ascii40@65..66 "("
+        AExpr@66..88
+          ColumnRef@66..73
+            Ident@66..73 "manager"
+          Whitespace@73..74 " "
+          Ascii61@74..75 "="
+          Whitespace@75..76 " "
+          SqlvalueFunction@76..88
+            CurrentUser@76..88 "current_user"
+        Ascii41@88..89 ")"
+        Ascii59@89..90 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreatePolicyStmt(
+                CreatePolicyStmt {
+                    policy_name: "account_managers",
+                    table: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "accounts",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 34,
+                        },
+                    ),
+                    cmd_name: "all",
+                    permissive: true,
+                    roles: [
+                        Node {
+                            node: Some(
+                                RoleSpec(
+                                    RoleSpec {
+                                        roletype: RolespecCstring,
+                                        rolename: "managers",
+                                        location: 46,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    qual: Some(
+                        Node {
+                            node: Some(
+                                AExpr(
+                                    AExpr {
+                                        kind: AexprOp,
+                                        name: [
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "=",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        lexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "manager",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 66,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        rexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    SqlvalueFunction(
+                                                        SqlValueFunction {
+                                                            xpr: None,
+                                                            op: SvfopCurrentUser,
+                                                            r#type: 0,
+                                                            typmod: -1,
+                                                            location: 76,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 74,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    with_check: None,
+                },
+            ),
+            range: 0..89,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0031@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0031@1.snap
@@ -1,0 +1,83 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "CREATE POLICY user_mod ON passwd FOR UPDATE\n  USING (current_user = user_name)\n  WITH CHECK (\n    current_user = user_name AND\n    shell IN ('/bin/bash','/bin/sh','/bin/dash','/bin/zsh','/bin/tcsh')\n  );"
+---
+Parse {
+    cst: SourceFile@0..202
+      Create@0..6 "CREATE"
+      Whitespace@6..7 " "
+      Policy@7..13 "POLICY"
+      Whitespace@13..14 " "
+      Ident@14..22 "user_mod"
+      Whitespace@22..23 " "
+      On@23..25 "ON"
+      Whitespace@25..26 " "
+      Ident@26..32 "passwd"
+      Whitespace@32..33 " "
+      For@33..36 "FOR"
+      Update@36..42 "UPDATE"
+      Newline@42..43 "\n"
+      Whitespace@43..45 "  "
+      Using@45..50 "USING"
+      Whitespace@50..51 " "
+      Ascii40@51..52 "("
+      CurrentUser@52..64 "current_user"
+      Whitespace@64..65 " "
+      Ascii61@65..66 "="
+      Whitespace@66..67 " "
+      Ident@67..76 "user_name"
+      Ascii41@76..77 ")"
+      Newline@77..78 "\n"
+      Whitespace@78..80 "  "
+      With@80..84 "WITH"
+      Whitespace@84..85 " "
+      Check@85..90 "CHECK"
+      Whitespace@90..91 " "
+      Ascii40@91..92 "("
+      Newline@92..93 "\n"
+      Whitespace@93..97 "    "
+      CurrentUser@97..109 "current_user"
+      Whitespace@109..110 " "
+      Ascii61@110..111 "="
+      Whitespace@111..112 " "
+      Ident@112..121 "user_name"
+      Whitespace@121..122 " "
+      And@122..125 "AND"
+      Newline@125..126 "\n"
+      Whitespace@126..130 "    "
+      Ident@130..135 "shell"
+      Whitespace@135..136 " "
+      InP@136..138 "IN"
+      Whitespace@138..139 " "
+      Ascii40@139..140 "("
+      Sconst@140..151 "'/bin/bash'"
+      Ascii44@151..152 ","
+      Sconst@152..161 "'/bin/sh'"
+      Ascii44@161..162 ","
+      Sconst@162..173 "'/bin/dash'"
+      Ascii44@173..174 ","
+      Sconst@174..184 "'/bin/zsh'"
+      Ascii44@184..185 ","
+      Sconst@185..196 "'/bin/tcsh'"
+      Ascii41@196..197 ")"
+      Newline@197..198 "\n"
+      Whitespace@198..200 "  "
+      Ascii41@200..201 ")"
+      Ascii59@201..202 ";"
+    ,
+    errors: [
+        SyntaxError(
+            "Expected Ascii59, found Whitespace",
+            36..36,
+        ),
+        SyntaxError(
+            "Invalid statement: syntax error at end of input",
+            0..11,
+        ),
+        SyntaxError(
+            "Invalid statement: syntax error at or near \"USING\"",
+            12..61,
+        ),
+    ],
+    stmts: [],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0032@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0032@1.snap
@@ -1,0 +1,70 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "SET search_path TO myschema,public;"
+---
+Parse {
+    cst: SourceFile@0..35
+      VariableSetStmt@0..35
+        Set@0..3 "SET"
+        Whitespace@3..4 " "
+        Ident@4..15 "search_path"
+        Whitespace@15..16 " "
+        To@16..18 "TO"
+        Whitespace@18..19 " "
+        AConst@19..27
+          Ident@19..27 "myschema"
+        Ascii44@27..28 ","
+        AConst@28..34
+          Ident@28..34 "public"
+        Ascii59@34..35 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: VariableSetStmt(
+                VariableSetStmt {
+                    kind: VarSetValue,
+                    name: "search_path",
+                    args: [
+                        Node {
+                            node: Some(
+                                AConst(
+                                    AConst {
+                                        isnull: false,
+                                        location: 19,
+                                        val: Some(
+                                            Sval(
+                                                String {
+                                                    sval: "myschema",
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                AConst(
+                                    AConst {
+                                        isnull: false,
+                                        location: 28,
+                                        val: Some(
+                                            Sval(
+                                                String {
+                                                    sval: "public",
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    is_local: false,
+                },
+            ),
+            range: 0..34,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0033@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0033@1.snap
@@ -1,0 +1,419 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "CREATE TABLE measurement (\n    city_id         int not null,\n    logdate         date not null,\n    peaktemp        int,\n    unitsales       int\n) PARTITION BY RANGE (logdate);"
+---
+Parse {
+    cst: SourceFile@0..176
+      CreateStmt@0..176
+        Create@0..6 "CREATE"
+        Whitespace@6..7 " "
+        Table@7..12 "TABLE"
+        Whitespace@12..13 " "
+        RangeVar@13..24
+          Ident@13..24 "measurement"
+        Whitespace@24..25 " "
+        Ascii40@25..26 "("
+        Newline@26..27 "\n"
+        Whitespace@27..31 "    "
+        ColumnDef@31..59
+          Ident@31..38 "city_id"
+          Whitespace@38..47 "         "
+          TypeName@47..50
+            IntP@47..50 "int"
+          Whitespace@50..51 " "
+          Constraint@51..59
+            Not@51..54 "not"
+            Whitespace@54..55 " "
+            NullP@55..59 "null"
+        Ascii44@59..60 ","
+        Newline@60..61 "\n"
+        Whitespace@61..65 "    "
+        ColumnDef@65..94
+          Ident@65..72 "logdate"
+          Whitespace@72..81 "         "
+          TypeName@81..85
+            Ident@81..85 "date"
+          Whitespace@85..86 " "
+          Constraint@86..94
+            Not@86..89 "not"
+            Whitespace@89..90 " "
+            NullP@90..94 "null"
+        Ascii44@94..95 ","
+        Newline@95..96 "\n"
+        Whitespace@96..100 "    "
+        ColumnDef@100..119
+          Ident@100..108 "peaktemp"
+          Whitespace@108..116 "        "
+          TypeName@116..119
+            IntP@116..119 "int"
+        Ascii44@119..120 ","
+        Newline@120..121 "\n"
+        Whitespace@121..125 "    "
+        ColumnDef@125..144
+          Ident@125..134 "unitsales"
+          Whitespace@134..141 "       "
+          TypeName@141..144
+            IntP@141..144 "int"
+        Newline@144..145 "\n"
+        Ascii41@145..146 ")"
+        Whitespace@146..147 " "
+        PartitionSpec@147..174
+          Partition@147..156 "PARTITION"
+          Whitespace@156..157 " "
+          By@157..159 "BY"
+          Whitespace@159..160 " "
+          Range@160..165 "RANGE"
+          Whitespace@165..166 " "
+          Ascii40@166..167 "("
+          PartitionElem@167..174
+            Ident@167..174 "logdate"
+        Ascii41@174..175 ")"
+        Ascii59@175..176 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateStmt(
+                CreateStmt {
+                    relation: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "measurement",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 13,
+                        },
+                    ),
+                    table_elts: [
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "city_id",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "int4",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 47,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [
+                                            Node {
+                                                node: Some(
+                                                    Constraint(
+                                                        Constraint {
+                                                            contype: ConstrNotnull,
+                                                            conname: "",
+                                                            deferrable: false,
+                                                            initdeferred: false,
+                                                            location: 51,
+                                                            is_no_inherit: false,
+                                                            raw_expr: None,
+                                                            cooked_expr: "",
+                                                            generated_when: "",
+                                                            nulls_not_distinct: false,
+                                                            keys: [],
+                                                            including: [],
+                                                            exclusions: [],
+                                                            options: [],
+                                                            indexname: "",
+                                                            indexspace: "",
+                                                            reset_default_tblspc: false,
+                                                            access_method: "",
+                                                            where_clause: None,
+                                                            pktable: None,
+                                                            fk_attrs: [],
+                                                            pk_attrs: [],
+                                                            fk_matchtype: "",
+                                                            fk_upd_action: "",
+                                                            fk_del_action: "",
+                                                            fk_del_set_cols: [],
+                                                            old_conpfeqop: [],
+                                                            old_pktable_oid: 0,
+                                                            skip_validation: false,
+                                                            initially_valid: false,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        fdwoptions: [],
+                                        location: 31,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "logdate",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "date",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 81,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [
+                                            Node {
+                                                node: Some(
+                                                    Constraint(
+                                                        Constraint {
+                                                            contype: ConstrNotnull,
+                                                            conname: "",
+                                                            deferrable: false,
+                                                            initdeferred: false,
+                                                            location: 86,
+                                                            is_no_inherit: false,
+                                                            raw_expr: None,
+                                                            cooked_expr: "",
+                                                            generated_when: "",
+                                                            nulls_not_distinct: false,
+                                                            keys: [],
+                                                            including: [],
+                                                            exclusions: [],
+                                                            options: [],
+                                                            indexname: "",
+                                                            indexspace: "",
+                                                            reset_default_tblspc: false,
+                                                            access_method: "",
+                                                            where_clause: None,
+                                                            pktable: None,
+                                                            fk_attrs: [],
+                                                            pk_attrs: [],
+                                                            fk_matchtype: "",
+                                                            fk_upd_action: "",
+                                                            fk_del_action: "",
+                                                            fk_del_set_cols: [],
+                                                            old_conpfeqop: [],
+                                                            old_pktable_oid: 0,
+                                                            skip_validation: false,
+                                                            initially_valid: false,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        fdwoptions: [],
+                                        location: 65,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "peaktemp",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "int4",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 116,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [],
+                                        fdwoptions: [],
+                                        location: 100,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "unitsales",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "int4",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 141,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [],
+                                        fdwoptions: [],
+                                        location: 125,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    inh_relations: [],
+                    partbound: None,
+                    partspec: Some(
+                        PartitionSpec {
+                            strategy: "range",
+                            part_params: [
+                                Node {
+                                    node: Some(
+                                        PartitionElem(
+                                            PartitionElem {
+                                                name: "logdate",
+                                                expr: None,
+                                                collation: [],
+                                                opclass: [],
+                                                location: 167,
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ],
+                            location: 147,
+                        },
+                    ),
+                    of_typename: None,
+                    constraints: [],
+                    options: [],
+                    oncommit: OncommitNoop,
+                    tablespacename: "",
+                    access_method: "",
+                    if_not_exists: false,
+                },
+            ),
+            range: 0..175,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0034@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0034@1.snap
@@ -1,0 +1,210 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "select *,some_col from contact where id = '123 4 5';"
+---
+Parse {
+    cst: SourceFile@0..52
+      SelectStmt@0..52
+        Select@0..6 "select"
+        Whitespace@6..7 " "
+        ResTarget@7..8
+          ColumnRef@7..8
+            AStar@7..8
+              Ascii42@7..8 "*"
+        Ascii44@8..9 ","
+        ResTarget@9..17
+          ColumnRef@9..17
+            Ident@9..17 "some_col"
+        Whitespace@17..18 " "
+        From@18..22 "from"
+        Whitespace@22..23 " "
+        RangeVar@23..30
+          Ident@23..30 "contact"
+        Whitespace@30..31 " "
+        Where@31..36 "where"
+        Whitespace@36..37 " "
+        AExpr@37..51
+          ColumnRef@37..39
+            Ident@37..39 "id"
+          Whitespace@39..40 " "
+          Ascii61@40..41 "="
+          Whitespace@41..42 " "
+          AConst@42..51
+            Sconst@42..51 "'123 4 5'"
+        Ascii59@51..52 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AStar(
+                                                                            AStar,
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 7,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "some_col",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 9,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 9,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [
+                        Node {
+                            node: Some(
+                                RangeVar(
+                                    RangeVar {
+                                        catalogname: "",
+                                        schemaname: "",
+                                        relname: "contact",
+                                        inh: true,
+                                        relpersistence: "p",
+                                        alias: None,
+                                        location: 23,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    where_clause: Some(
+                        Node {
+                            node: Some(
+                                AExpr(
+                                    AExpr {
+                                        kind: AexprOp,
+                                        name: [
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "=",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        lexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "id",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 37,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        rexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    AConst(
+                                                        AConst {
+                                                            isnull: false,
+                                                            location: 42,
+                                                            val: Some(
+                                                                Sval(
+                                                                    String {
+                                                                        sval: "123 4 5",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 40,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..51,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0035@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0035@1.snap
@@ -1,0 +1,210 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "select *,some_col from contact where id = '123 4 5';"
+---
+Parse {
+    cst: SourceFile@0..52
+      SelectStmt@0..52
+        Select@0..6 "select"
+        Whitespace@6..7 " "
+        ResTarget@7..8
+          ColumnRef@7..8
+            AStar@7..8
+              Ascii42@7..8 "*"
+        Ascii44@8..9 ","
+        ResTarget@9..17
+          ColumnRef@9..17
+            Ident@9..17 "some_col"
+        Whitespace@17..18 " "
+        From@18..22 "from"
+        Whitespace@22..23 " "
+        RangeVar@23..30
+          Ident@23..30 "contact"
+        Whitespace@30..31 " "
+        Where@31..36 "where"
+        Whitespace@36..37 " "
+        AExpr@37..51
+          ColumnRef@37..39
+            Ident@37..39 "id"
+          Whitespace@39..40 " "
+          Ascii61@40..41 "="
+          Whitespace@41..42 " "
+          AConst@42..51
+            Sconst@42..51 "'123 4 5'"
+        Ascii59@51..52 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AStar(
+                                                                            AStar,
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 7,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "some_col",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 9,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 9,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [
+                        Node {
+                            node: Some(
+                                RangeVar(
+                                    RangeVar {
+                                        catalogname: "",
+                                        schemaname: "",
+                                        relname: "contact",
+                                        inh: true,
+                                        relpersistence: "p",
+                                        alias: None,
+                                        location: 23,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    where_clause: Some(
+                        Node {
+                            node: Some(
+                                AExpr(
+                                    AExpr {
+                                        kind: AexprOp,
+                                        name: [
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "=",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        lexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "id",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 37,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        rexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    AConst(
+                                                        AConst {
+                                                            isnull: false,
+                                                            location: 42,
+                                                            val: Some(
+                                                                Sval(
+                                                                    String {
+                                                                        sval: "123 4 5",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 40,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..51,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0036@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0036@1.snap
@@ -1,0 +1,255 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "CREATE FUNCTION dup(in int, out f1 int, out f2 text)\n    AS $$ SELECT $1, CAST($1 AS text) || ' is text' $$\n    LANGUAGE SQL;"
+---
+Parse {
+    cst: SourceFile@0..125
+      CreateFunctionStmt@0..125
+        Create@0..6 "CREATE"
+        Whitespace@6..7 " "
+        Function@7..15 "FUNCTION"
+        Whitespace@15..16 " "
+        Ident@16..19 "dup"
+        Ascii40@19..20 "("
+        FunctionParameter@20..26
+          InP@20..22 "in"
+          Whitespace@22..23 " "
+          TypeName@23..26
+            IntP@23..26 "int"
+        Ascii44@26..27 ","
+        Whitespace@27..28 " "
+        FunctionParameter@28..38
+          OutP@28..31 "out"
+          Whitespace@31..32 " "
+          Ident@32..34 "f1"
+          Whitespace@34..35 " "
+          TypeName@35..38
+            IntP@35..38 "int"
+        Ascii44@38..39 ","
+        Whitespace@39..40 " "
+        FunctionParameter@40..51
+          OutP@40..43 "out"
+          Whitespace@43..44 " "
+          Ident@44..46 "f2"
+          Whitespace@46..47 " "
+          TypeName@47..51
+            TextP@47..51 "text"
+        Ascii41@51..52 ")"
+        Newline@52..53 "\n"
+        Whitespace@53..57 "    "
+        DefElem@57..107
+          As@57..59 "AS"
+          Whitespace@59..60 " "
+          List@60..107
+            Sconst@60..107 "$$ SELECT $1, CAST($1 ..."
+        Newline@107..108 "\n"
+        Whitespace@108..112 "    "
+        DefElem@112..124
+          Language@112..120 "LANGUAGE"
+          Whitespace@120..121 " "
+          SqlP@121..124 "SQL"
+        Ascii59@124..125 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateFunctionStmt(
+                CreateFunctionStmt {
+                    is_procedure: false,
+                    replace: false,
+                    funcname: [
+                        Node {
+                            node: Some(
+                                String(
+                                    String {
+                                        sval: "dup",
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    parameters: [
+                        Node {
+                            node: Some(
+                                FunctionParameter(
+                                    FunctionParameter {
+                                        name: "",
+                                        arg_type: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "int4",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 23,
+                                            },
+                                        ),
+                                        mode: FuncParamIn,
+                                        defexpr: None,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                FunctionParameter(
+                                    FunctionParameter {
+                                        name: "f1",
+                                        arg_type: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "int4",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 35,
+                                            },
+                                        ),
+                                        mode: FuncParamOut,
+                                        defexpr: None,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                FunctionParameter(
+                                    FunctionParameter {
+                                        name: "f2",
+                                        arg_type: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "text",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 47,
+                                            },
+                                        ),
+                                        mode: FuncParamOut,
+                                        defexpr: None,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    return_type: None,
+                    options: [
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "as",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    List(
+                                                        List {
+                                                            items: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: " SELECT $1, CAST($1 AS text) || ' is text' ",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 57,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "language",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "sql",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 112,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    sql_body: None,
+                },
+            ),
+            range: 0..124,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0037@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0037@1.snap
@@ -1,0 +1,79 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "CREATE TYPE bug_status AS ENUM ('new', 'open', 'closed');"
+---
+Parse {
+    cst: SourceFile@0..57
+      CreateEnumStmt@0..57
+        Create@0..6 "CREATE"
+        Whitespace@6..7 " "
+        TypeP@7..11 "TYPE"
+        Whitespace@11..12 " "
+        Ident@12..22 "bug_status"
+        Whitespace@22..23 " "
+        As@23..25 "AS"
+        Whitespace@25..26 " "
+        EnumP@26..30 "ENUM"
+        Whitespace@30..31 " "
+        Ascii40@31..32 "("
+        Sconst@32..37 "'new'"
+        Ascii44@37..38 ","
+        Whitespace@38..39 " "
+        Sconst@39..45 "'open'"
+        Ascii44@45..46 ","
+        Whitespace@46..47 " "
+        Sconst@47..55 "'closed'"
+        Ascii41@55..56 ")"
+        Ascii59@56..57 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateEnumStmt(
+                CreateEnumStmt {
+                    type_name: [
+                        Node {
+                            node: Some(
+                                String(
+                                    String {
+                                        sval: "bug_status",
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    vals: [
+                        Node {
+                            node: Some(
+                                String(
+                                    String {
+                                        sval: "new",
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                String(
+                                    String {
+                                        sval: "open",
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                String(
+                                    String {
+                                        sval: "closed",
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                },
+            ),
+            range: 0..56,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0038@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0038@1.snap
@@ -1,0 +1,200 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: CREATE CAST (bigint AS int4) WITH FUNCTION int4(bigint) AS ASSIGNMENT;
+---
+Parse {
+    cst: SourceFile@0..70
+      CreateCastStmt@0..70
+        Create@0..6 "CREATE"
+        Whitespace@6..7 " "
+        Cast@7..11 "CAST"
+        Whitespace@11..12 " "
+        Ascii40@12..13 "("
+        TypeName@13..19
+          Bigint@13..19 "bigint"
+        Whitespace@19..20 " "
+        As@20..22 "AS"
+        Whitespace@22..23 " "
+        TypeName@23..27
+          Ident@23..27 "int4"
+        Ascii41@27..28 ")"
+        Whitespace@28..29 " "
+        With@29..33 "WITH"
+        Whitespace@33..34 " "
+        Function@34..42 "FUNCTION"
+        Whitespace@42..43 " "
+        ObjectWithArgs@43..55
+          Ident@43..47 "int4"
+          Ascii40@47..48 "("
+          TypeName@48..54
+            Bigint@48..54 "bigint"
+          Ascii41@54..55 ")"
+        Whitespace@55..56 " "
+        As@56..58 "AS"
+        Whitespace@58..59 " "
+        Assignment@59..69 "ASSIGNMENT"
+        Ascii59@69..70 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateCastStmt(
+                CreateCastStmt {
+                    sourcetype: Some(
+                        TypeName {
+                            names: [
+                                Node {
+                                    node: Some(
+                                        String(
+                                            String {
+                                                sval: "pg_catalog",
+                                            },
+                                        ),
+                                    ),
+                                },
+                                Node {
+                                    node: Some(
+                                        String(
+                                            String {
+                                                sval: "int8",
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ],
+                            type_oid: 0,
+                            setof: false,
+                            pct_type: false,
+                            typmods: [],
+                            typemod: -1,
+                            array_bounds: [],
+                            location: 13,
+                        },
+                    ),
+                    targettype: Some(
+                        TypeName {
+                            names: [
+                                Node {
+                                    node: Some(
+                                        String(
+                                            String {
+                                                sval: "int4",
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ],
+                            type_oid: 0,
+                            setof: false,
+                            pct_type: false,
+                            typmods: [],
+                            typemod: -1,
+                            array_bounds: [],
+                            location: 23,
+                        },
+                    ),
+                    func: Some(
+                        ObjectWithArgs {
+                            objname: [
+                                Node {
+                                    node: Some(
+                                        String(
+                                            String {
+                                                sval: "int4",
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ],
+                            objargs: [
+                                Node {
+                                    node: Some(
+                                        TypeName(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "int8",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 48,
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ],
+                            objfuncargs: [
+                                Node {
+                                    node: Some(
+                                        FunctionParameter(
+                                            FunctionParameter {
+                                                name: "",
+                                                arg_type: Some(
+                                                    TypeName {
+                                                        names: [
+                                                            Node {
+                                                                node: Some(
+                                                                    String(
+                                                                        String {
+                                                                            sval: "pg_catalog",
+                                                                        },
+                                                                    ),
+                                                                ),
+                                                            },
+                                                            Node {
+                                                                node: Some(
+                                                                    String(
+                                                                        String {
+                                                                            sval: "int8",
+                                                                        },
+                                                                    ),
+                                                                ),
+                                                            },
+                                                        ],
+                                                        type_oid: 0,
+                                                        setof: false,
+                                                        pct_type: false,
+                                                        typmods: [],
+                                                        typemod: -1,
+                                                        array_bounds: [],
+                                                        location: 48,
+                                                    },
+                                                ),
+                                                mode: FuncParamDefault,
+                                                defexpr: None,
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ],
+                            args_unspecified: false,
+                        },
+                    ),
+                    context: CoercionAssignment,
+                    inout: false,
+                },
+            ),
+            range: 0..69,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0038@2.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0038@2.snap
@@ -1,0 +1,98 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE CAST (bigint AS int4) WITHOUT FUNCTION AS IMPLICIT;"
+---
+Parse {
+    cst: SourceFile@0..59
+      Newline@0..1 "\n"
+      CreateCastStmt@1..59
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        Cast@8..12 "CAST"
+        Whitespace@12..13 " "
+        Ascii40@13..14 "("
+        TypeName@14..20
+          Bigint@14..20 "bigint"
+        Whitespace@20..21 " "
+        As@21..23 "AS"
+        Whitespace@23..24 " "
+        TypeName@24..28
+          Ident@24..28 "int4"
+        Ascii41@28..29 ")"
+        Whitespace@29..30 " "
+        Without@30..37 "WITHOUT"
+        Whitespace@37..38 " "
+        Function@38..46 "FUNCTION"
+        Whitespace@46..47 " "
+        As@47..49 "AS"
+        Whitespace@49..50 " "
+        ImplicitP@50..58 "IMPLICIT"
+        Ascii59@58..59 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateCastStmt(
+                CreateCastStmt {
+                    sourcetype: Some(
+                        TypeName {
+                            names: [
+                                Node {
+                                    node: Some(
+                                        String(
+                                            String {
+                                                sval: "pg_catalog",
+                                            },
+                                        ),
+                                    ),
+                                },
+                                Node {
+                                    node: Some(
+                                        String(
+                                            String {
+                                                sval: "int8",
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ],
+                            type_oid: 0,
+                            setof: false,
+                            pct_type: false,
+                            typmods: [],
+                            typemod: -1,
+                            array_bounds: [],
+                            location: 13,
+                        },
+                    ),
+                    targettype: Some(
+                        TypeName {
+                            names: [
+                                Node {
+                                    node: Some(
+                                        String(
+                                            String {
+                                                sval: "int4",
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ],
+                            type_oid: 0,
+                            setof: false,
+                            pct_type: false,
+                            typmods: [],
+                            typemod: -1,
+                            array_bounds: [],
+                            location: 23,
+                        },
+                    ),
+                    func: None,
+                    context: CoercionImplicit,
+                    inout: false,
+                },
+            ),
+            range: 0..58,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0038@3.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0038@3.snap
@@ -1,0 +1,98 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE CAST (bigint AS int4) WITH INOUT AS ASSIGNMENT;"
+---
+Parse {
+    cst: SourceFile@0..55
+      Newline@0..1 "\n"
+      CreateCastStmt@1..55
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        Cast@8..12 "CAST"
+        Whitespace@12..13 " "
+        Ascii40@13..14 "("
+        TypeName@14..20
+          Bigint@14..20 "bigint"
+        Whitespace@20..21 " "
+        As@21..23 "AS"
+        Whitespace@23..24 " "
+        TypeName@24..28
+          Ident@24..28 "int4"
+        Ascii41@28..29 ")"
+        Whitespace@29..30 " "
+        With@30..34 "WITH"
+        Whitespace@34..35 " "
+        Inout@35..40 "INOUT"
+        Whitespace@40..41 " "
+        As@41..43 "AS"
+        Whitespace@43..44 " "
+        Assignment@44..54 "ASSIGNMENT"
+        Ascii59@54..55 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateCastStmt(
+                CreateCastStmt {
+                    sourcetype: Some(
+                        TypeName {
+                            names: [
+                                Node {
+                                    node: Some(
+                                        String(
+                                            String {
+                                                sval: "pg_catalog",
+                                            },
+                                        ),
+                                    ),
+                                },
+                                Node {
+                                    node: Some(
+                                        String(
+                                            String {
+                                                sval: "int8",
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ],
+                            type_oid: 0,
+                            setof: false,
+                            pct_type: false,
+                            typmods: [],
+                            typemod: -1,
+                            array_bounds: [],
+                            location: 13,
+                        },
+                    ),
+                    targettype: Some(
+                        TypeName {
+                            names: [
+                                Node {
+                                    node: Some(
+                                        String(
+                                            String {
+                                                sval: "int4",
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ],
+                            type_oid: 0,
+                            setof: false,
+                            pct_type: false,
+                            typmods: [],
+                            typemod: -1,
+                            array_bounds: [],
+                            location: 23,
+                        },
+                    ),
+                    func: None,
+                    context: CoercionAssignment,
+                    inout: true,
+                },
+            ),
+            range: 0..54,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0039@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0039@1.snap
@@ -1,0 +1,202 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "CREATE AGGREGATE aggregate1 (int4) (sfunc = sfunc1, stype = stype1);"
+---
+Parse {
+    cst: SourceFile@0..68
+      DefineStmt@0..68
+        Create@0..6 "CREATE"
+        Whitespace@6..7 " "
+        Aggregate@7..16 "AGGREGATE"
+        Whitespace@16..17 " "
+        Ident@17..27 "aggregate1"
+        Whitespace@27..28 " "
+        Ascii40@28..29 "("
+        List@29..33
+          FunctionParameter@29..33
+            TypeName@29..33
+              Ident@29..33 "int4"
+        Ascii41@33..34 ")"
+        Whitespace@34..35 " "
+        Ascii40@35..36 "("
+        DefElem@36..50
+          Ident@36..41 "sfunc"
+          Whitespace@41..42 " "
+          Ascii61@42..43 "="
+          Whitespace@43..44 " "
+          TypeName@44..50
+            Ident@44..50 "sfunc1"
+        Ascii44@50..51 ","
+        Whitespace@51..52 " "
+        DefElem@52..66
+          Ident@52..57 "stype"
+          Whitespace@57..58 " "
+          Ascii61@58..59 "="
+          Whitespace@59..60 " "
+          TypeName@60..66
+            Ident@60..66 "stype1"
+        Ascii41@66..67 ")"
+        Ascii59@67..68 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: DefineStmt(
+                DefineStmt {
+                    kind: ObjectAggregate,
+                    oldstyle: false,
+                    defnames: [
+                        Node {
+                            node: Some(
+                                String(
+                                    String {
+                                        sval: "aggregate1",
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    args: [
+                        Node {
+                            node: Some(
+                                List(
+                                    List {
+                                        items: [
+                                            Node {
+                                                node: Some(
+                                                    FunctionParameter(
+                                                        FunctionParameter {
+                                                            name: "",
+                                                            arg_type: Some(
+                                                                TypeName {
+                                                                    names: [
+                                                                        Node {
+                                                                            node: Some(
+                                                                                String(
+                                                                                    String {
+                                                                                        sval: "int4",
+                                                                                    },
+                                                                                ),
+                                                                            ),
+                                                                        },
+                                                                    ],
+                                                                    type_oid: 0,
+                                                                    setof: false,
+                                                                    pct_type: false,
+                                                                    typmods: [],
+                                                                    typemod: -1,
+                                                                    array_bounds: [],
+                                                                    location: 29,
+                                                                },
+                                                            ),
+                                                            mode: FuncParamDefault,
+                                                            defexpr: None,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                Integer(
+                                    Integer {
+                                        ival: -1,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    definition: [
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "sfunc",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    TypeName(
+                                                        TypeName {
+                                                            names: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "sfunc1",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            type_oid: 0,
+                                                            setof: false,
+                                                            pct_type: false,
+                                                            typmods: [],
+                                                            typemod: -1,
+                                                            array_bounds: [],
+                                                            location: 44,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 36,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "stype",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    TypeName(
+                                                        TypeName {
+                                                            names: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "stype1",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            type_oid: 0,
+                                                            setof: false,
+                                                            pct_type: false,
+                                                            typmods: [],
+                                                            typemod: -1,
+                                                            array_bounds: [],
+                                                            location: 60,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 52,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    if_not_exists: false,
+                    replace: false,
+                },
+            ),
+            range: 0..67,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0039@2.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0039@2.snap
@@ -1,0 +1,241 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE AGGREGATE aggregate1 (int4, bool) (sfunc = sfunc1, stype = stype1);"
+---
+Parse {
+    cst: SourceFile@0..75
+      Newline@0..1 "\n"
+      DefineStmt@1..75
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        Aggregate@8..17 "AGGREGATE"
+        Whitespace@17..18 " "
+        Ident@18..28 "aggregate1"
+        Whitespace@28..29 " "
+        Ascii40@29..30 "("
+        List@30..40
+          FunctionParameter@30..34
+            TypeName@30..34
+              Ident@30..34 "int4"
+          Ascii44@34..35 ","
+          Whitespace@35..36 " "
+          FunctionParameter@36..40
+            TypeName@36..40
+              Ident@36..40 "bool"
+        Ascii41@40..41 ")"
+        Whitespace@41..42 " "
+        Ascii40@42..43 "("
+        DefElem@43..57
+          Ident@43..48 "sfunc"
+          Whitespace@48..49 " "
+          Ascii61@49..50 "="
+          Whitespace@50..51 " "
+          TypeName@51..57
+            Ident@51..57 "sfunc1"
+        Ascii44@57..58 ","
+        Whitespace@58..59 " "
+        DefElem@59..73
+          Ident@59..64 "stype"
+          Whitespace@64..65 " "
+          Ascii61@65..66 "="
+          Whitespace@66..67 " "
+          TypeName@67..73
+            Ident@67..73 "stype1"
+        Ascii41@73..74 ")"
+        Ascii59@74..75 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: DefineStmt(
+                DefineStmt {
+                    kind: ObjectAggregate,
+                    oldstyle: false,
+                    defnames: [
+                        Node {
+                            node: Some(
+                                String(
+                                    String {
+                                        sval: "aggregate1",
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    args: [
+                        Node {
+                            node: Some(
+                                List(
+                                    List {
+                                        items: [
+                                            Node {
+                                                node: Some(
+                                                    FunctionParameter(
+                                                        FunctionParameter {
+                                                            name: "",
+                                                            arg_type: Some(
+                                                                TypeName {
+                                                                    names: [
+                                                                        Node {
+                                                                            node: Some(
+                                                                                String(
+                                                                                    String {
+                                                                                        sval: "int4",
+                                                                                    },
+                                                                                ),
+                                                                            ),
+                                                                        },
+                                                                    ],
+                                                                    type_oid: 0,
+                                                                    setof: false,
+                                                                    pct_type: false,
+                                                                    typmods: [],
+                                                                    typemod: -1,
+                                                                    array_bounds: [],
+                                                                    location: 29,
+                                                                },
+                                                            ),
+                                                            mode: FuncParamDefault,
+                                                            defexpr: None,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                            Node {
+                                                node: Some(
+                                                    FunctionParameter(
+                                                        FunctionParameter {
+                                                            name: "",
+                                                            arg_type: Some(
+                                                                TypeName {
+                                                                    names: [
+                                                                        Node {
+                                                                            node: Some(
+                                                                                String(
+                                                                                    String {
+                                                                                        sval: "bool",
+                                                                                    },
+                                                                                ),
+                                                                            ),
+                                                                        },
+                                                                    ],
+                                                                    type_oid: 0,
+                                                                    setof: false,
+                                                                    pct_type: false,
+                                                                    typmods: [],
+                                                                    typemod: -1,
+                                                                    array_bounds: [],
+                                                                    location: 35,
+                                                                },
+                                                            ),
+                                                            mode: FuncParamDefault,
+                                                            defexpr: None,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                Integer(
+                                    Integer {
+                                        ival: -1,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    definition: [
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "sfunc",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    TypeName(
+                                                        TypeName {
+                                                            names: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "sfunc1",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            type_oid: 0,
+                                                            setof: false,
+                                                            pct_type: false,
+                                                            typmods: [],
+                                                            typemod: -1,
+                                                            array_bounds: [],
+                                                            location: 50,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 42,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "stype",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    TypeName(
+                                                        TypeName {
+                                                            names: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "stype1",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            type_oid: 0,
+                                                            setof: false,
+                                                            pct_type: false,
+                                                            typmods: [],
+                                                            typemod: -1,
+                                                            array_bounds: [],
+                                                            location: 66,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 58,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    if_not_exists: false,
+                    replace: false,
+                },
+            ),
+            range: 0..74,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0039@3.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0039@3.snap
@@ -1,0 +1,160 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE AGGREGATE aggregate1 (*) (sfunc = sfunc1, stype = stype1);"
+---
+Parse {
+    cst: SourceFile@0..66
+      Newline@0..1 "\n"
+      DefineStmt@1..66
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        Aggregate@8..17 "AGGREGATE"
+        Whitespace@17..18 " "
+        Ident@18..28 "aggregate1"
+        Whitespace@28..29 " "
+        Ascii40@29..30 "("
+        Ascii42@30..31 "*"
+        Ascii41@31..32 ")"
+        Whitespace@32..33 " "
+        Ascii40@33..34 "("
+        DefElem@34..48
+          Ident@34..39 "sfunc"
+          Whitespace@39..40 " "
+          Ascii61@40..41 "="
+          Whitespace@41..42 " "
+          TypeName@42..48
+            Ident@42..48 "sfunc1"
+        Ascii44@48..49 ","
+        Whitespace@49..50 " "
+        DefElem@50..64
+          Ident@50..55 "stype"
+          Whitespace@55..56 " "
+          Ascii61@56..57 "="
+          Whitespace@57..58 " "
+          TypeName@58..64
+            Ident@58..64 "stype1"
+        Ascii41@64..65 ")"
+        Ascii59@65..66 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: DefineStmt(
+                DefineStmt {
+                    kind: ObjectAggregate,
+                    oldstyle: false,
+                    defnames: [
+                        Node {
+                            node: Some(
+                                String(
+                                    String {
+                                        sval: "aggregate1",
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    args: [
+                        Node {
+                            node: None,
+                        },
+                        Node {
+                            node: Some(
+                                Integer(
+                                    Integer {
+                                        ival: -1,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    definition: [
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "sfunc",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    TypeName(
+                                                        TypeName {
+                                                            names: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "sfunc1",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            type_oid: 0,
+                                                            setof: false,
+                                                            pct_type: false,
+                                                            typmods: [],
+                                                            typemod: -1,
+                                                            array_bounds: [],
+                                                            location: 41,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 33,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "stype",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    TypeName(
+                                                        TypeName {
+                                                            names: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "stype1",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            type_oid: 0,
+                                                            setof: false,
+                                                            pct_type: false,
+                                                            typmods: [],
+                                                            typemod: -1,
+                                                            array_bounds: [],
+                                                            location: 57,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 49,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    if_not_exists: false,
+                    replace: false,
+                },
+            ),
+            range: 0..65,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0039@4.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0039@4.snap
@@ -1,0 +1,237 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE AGGREGATE aggregate1 (int4) (sfunc = sfunc1, stype = stype1, finalfunc_extra, mfinalfuncextra);"
+---
+Parse {
+    cst: SourceFile@0..103
+      Newline@0..1 "\n"
+      DefineStmt@1..103
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        Aggregate@8..17 "AGGREGATE"
+        Whitespace@17..18 " "
+        Ident@18..28 "aggregate1"
+        Whitespace@28..29 " "
+        Ascii40@29..30 "("
+        List@30..34
+          FunctionParameter@30..34
+            TypeName@30..34
+              Ident@30..34 "int4"
+        Ascii41@34..35 ")"
+        Whitespace@35..36 " "
+        Ascii40@36..37 "("
+        DefElem@37..51
+          Ident@37..42 "sfunc"
+          Whitespace@42..43 " "
+          Ascii61@43..44 "="
+          Whitespace@44..45 " "
+          TypeName@45..51
+            Ident@45..51 "sfunc1"
+        Ascii44@51..52 ","
+        Whitespace@52..53 " "
+        DefElem@53..67
+          Ident@53..58 "stype"
+          Whitespace@58..59 " "
+          Ascii61@59..60 "="
+          Whitespace@60..61 " "
+          TypeName@61..67
+            Ident@61..67 "stype1"
+        Ascii44@67..68 ","
+        Whitespace@68..69 " "
+        DefElem@69..84
+          Ident@69..84 "finalfunc_extra"
+        Ascii44@84..85 ","
+        Whitespace@85..86 " "
+        DefElem@86..101
+          Ident@86..101 "mfinalfuncextra"
+        Ascii41@101..102 ")"
+        Ascii59@102..103 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: DefineStmt(
+                DefineStmt {
+                    kind: ObjectAggregate,
+                    oldstyle: false,
+                    defnames: [
+                        Node {
+                            node: Some(
+                                String(
+                                    String {
+                                        sval: "aggregate1",
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    args: [
+                        Node {
+                            node: Some(
+                                List(
+                                    List {
+                                        items: [
+                                            Node {
+                                                node: Some(
+                                                    FunctionParameter(
+                                                        FunctionParameter {
+                                                            name: "",
+                                                            arg_type: Some(
+                                                                TypeName {
+                                                                    names: [
+                                                                        Node {
+                                                                            node: Some(
+                                                                                String(
+                                                                                    String {
+                                                                                        sval: "int4",
+                                                                                    },
+                                                                                ),
+                                                                            ),
+                                                                        },
+                                                                    ],
+                                                                    type_oid: 0,
+                                                                    setof: false,
+                                                                    pct_type: false,
+                                                                    typmods: [],
+                                                                    typemod: -1,
+                                                                    array_bounds: [],
+                                                                    location: 29,
+                                                                },
+                                                            ),
+                                                            mode: FuncParamDefault,
+                                                            defexpr: None,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                Integer(
+                                    Integer {
+                                        ival: -1,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    definition: [
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "sfunc",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    TypeName(
+                                                        TypeName {
+                                                            names: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "sfunc1",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            type_oid: 0,
+                                                            setof: false,
+                                                            pct_type: false,
+                                                            typmods: [],
+                                                            typemod: -1,
+                                                            array_bounds: [],
+                                                            location: 44,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 36,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "stype",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    TypeName(
+                                                        TypeName {
+                                                            names: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "stype1",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            type_oid: 0,
+                                                            setof: false,
+                                                            pct_type: false,
+                                                            typmods: [],
+                                                            typemod: -1,
+                                                            array_bounds: [],
+                                                            location: 60,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 52,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "finalfunc_extra",
+                                        arg: None,
+                                        defaction: DefelemUnspec,
+                                        location: 68,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "mfinalfuncextra",
+                                        arg: None,
+                                        defaction: DefelemUnspec,
+                                        location: 85,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    if_not_exists: false,
+                    replace: false,
+                },
+            ),
+            range: 0..102,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0039@5.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0039@5.snap
@@ -1,0 +1,301 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE AGGREGATE aggregate1 (int4) (sfunc = sfunc1, stype = stype1, finalfunc_modify = read_only, parallel = restricted);"
+---
+Parse {
+    cst: SourceFile@0..122
+      Newline@0..1 "\n"
+      DefineStmt@1..122
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        Aggregate@8..17 "AGGREGATE"
+        Whitespace@17..18 " "
+        Ident@18..28 "aggregate1"
+        Whitespace@28..29 " "
+        Ascii40@29..30 "("
+        List@30..34
+          FunctionParameter@30..34
+            TypeName@30..34
+              Ident@30..34 "int4"
+        Ascii41@34..35 ")"
+        Whitespace@35..36 " "
+        Ascii40@36..37 "("
+        DefElem@37..51
+          Ident@37..42 "sfunc"
+          Whitespace@42..43 " "
+          Ascii61@43..44 "="
+          Whitespace@44..45 " "
+          TypeName@45..51
+            Ident@45..51 "sfunc1"
+        Ascii44@51..52 ","
+        Whitespace@52..53 " "
+        DefElem@53..67
+          Ident@53..58 "stype"
+          Whitespace@58..59 " "
+          Ascii61@59..60 "="
+          Whitespace@60..61 " "
+          TypeName@61..67
+            Ident@61..67 "stype1"
+        Ascii44@67..68 ","
+        Whitespace@68..69 " "
+        DefElem@69..97
+          Ident@69..85 "finalfunc_modify"
+          Whitespace@85..86 " "
+          Ascii61@86..87 "="
+          Whitespace@87..88 " "
+          TypeName@88..97
+            Ident@88..97 "read_only"
+        Ascii44@97..98 ","
+        Whitespace@98..99 " "
+        DefElem@99..120
+          Parallel@99..107 "parallel"
+          Whitespace@107..108 " "
+          Ascii61@108..109 "="
+          Whitespace@109..110 " "
+          TypeName@110..120
+            Ident@110..120 "restricted"
+        Ascii41@120..121 ")"
+        Ascii59@121..122 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: DefineStmt(
+                DefineStmt {
+                    kind: ObjectAggregate,
+                    oldstyle: false,
+                    defnames: [
+                        Node {
+                            node: Some(
+                                String(
+                                    String {
+                                        sval: "aggregate1",
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    args: [
+                        Node {
+                            node: Some(
+                                List(
+                                    List {
+                                        items: [
+                                            Node {
+                                                node: Some(
+                                                    FunctionParameter(
+                                                        FunctionParameter {
+                                                            name: "",
+                                                            arg_type: Some(
+                                                                TypeName {
+                                                                    names: [
+                                                                        Node {
+                                                                            node: Some(
+                                                                                String(
+                                                                                    String {
+                                                                                        sval: "int4",
+                                                                                    },
+                                                                                ),
+                                                                            ),
+                                                                        },
+                                                                    ],
+                                                                    type_oid: 0,
+                                                                    setof: false,
+                                                                    pct_type: false,
+                                                                    typmods: [],
+                                                                    typemod: -1,
+                                                                    array_bounds: [],
+                                                                    location: 29,
+                                                                },
+                                                            ),
+                                                            mode: FuncParamDefault,
+                                                            defexpr: None,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                Integer(
+                                    Integer {
+                                        ival: -1,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    definition: [
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "sfunc",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    TypeName(
+                                                        TypeName {
+                                                            names: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "sfunc1",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            type_oid: 0,
+                                                            setof: false,
+                                                            pct_type: false,
+                                                            typmods: [],
+                                                            typemod: -1,
+                                                            array_bounds: [],
+                                                            location: 44,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 36,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "stype",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    TypeName(
+                                                        TypeName {
+                                                            names: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "stype1",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            type_oid: 0,
+                                                            setof: false,
+                                                            pct_type: false,
+                                                            typmods: [],
+                                                            typemod: -1,
+                                                            array_bounds: [],
+                                                            location: 60,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 52,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "finalfunc_modify",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    TypeName(
+                                                        TypeName {
+                                                            names: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "read_only",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            type_oid: 0,
+                                                            setof: false,
+                                                            pct_type: false,
+                                                            typmods: [],
+                                                            typemod: -1,
+                                                            array_bounds: [],
+                                                            location: 87,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 68,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "parallel",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    TypeName(
+                                                        TypeName {
+                                                            names: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "restricted",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            type_oid: 0,
+                                                            setof: false,
+                                                            pct_type: false,
+                                                            typmods: [],
+                                                            typemod: -1,
+                                                            array_bounds: [],
+                                                            location: 109,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 98,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    if_not_exists: false,
+                    replace: false,
+                },
+            ),
+            range: 0..121,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0039@6.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0039@6.snap
@@ -1,0 +1,310 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE AGGREGATE percentile_disc (float8 ORDER BY anyelement) (sfunc = ordered_set_transition, stype = internal, finalfunc = percentile_disc_final, finalfunc_extra);"
+---
+Parse {
+    cst: SourceFile@0..166
+      Newline@0..1 "\n"
+      DefineStmt@1..166
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        Aggregate@8..17 "AGGREGATE"
+        Whitespace@17..18 " "
+        Ident@18..33 "percentile_disc"
+        Whitespace@33..34 " "
+        Ascii40@34..35 "("
+        List@35..61
+          FunctionParameter@35..41
+            TypeName@35..41
+              Ident@35..41 "float8"
+          Whitespace@41..42 " "
+          Order@42..47 "ORDER"
+          Whitespace@47..48 " "
+          By@48..50 "BY"
+          Whitespace@50..51 " "
+          FunctionParameter@51..61
+            TypeName@51..61
+              Ident@51..61 "anyelement"
+        Ascii41@61..62 ")"
+        Whitespace@62..63 " "
+        Ascii40@63..64 "("
+        DefElem@64..94
+          Ident@64..69 "sfunc"
+          Whitespace@69..70 " "
+          Ascii61@70..71 "="
+          Whitespace@71..72 " "
+          TypeName@72..94
+            Ident@72..94 "ordered_set_transition"
+        Ascii44@94..95 ","
+        Whitespace@95..96 " "
+        DefElem@96..112
+          Ident@96..101 "stype"
+          Whitespace@101..102 " "
+          Ascii61@102..103 "="
+          Whitespace@103..104 " "
+          TypeName@104..112
+            Ident@104..112 "internal"
+        Ascii44@112..113 ","
+        Whitespace@113..114 " "
+        DefElem@114..147
+          Ident@114..123 "finalfunc"
+          Whitespace@123..124 " "
+          Ascii61@124..125 "="
+          Whitespace@125..126 " "
+          TypeName@126..147
+            Ident@126..147 "percentile_disc_final"
+        Ascii44@147..148 ","
+        Whitespace@148..149 " "
+        DefElem@149..164
+          Ident@149..164 "finalfunc_extra"
+        Ascii41@164..165 ")"
+        Ascii59@165..166 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: DefineStmt(
+                DefineStmt {
+                    kind: ObjectAggregate,
+                    oldstyle: false,
+                    defnames: [
+                        Node {
+                            node: Some(
+                                String(
+                                    String {
+                                        sval: "percentile_disc",
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    args: [
+                        Node {
+                            node: Some(
+                                List(
+                                    List {
+                                        items: [
+                                            Node {
+                                                node: Some(
+                                                    FunctionParameter(
+                                                        FunctionParameter {
+                                                            name: "",
+                                                            arg_type: Some(
+                                                                TypeName {
+                                                                    names: [
+                                                                        Node {
+                                                                            node: Some(
+                                                                                String(
+                                                                                    String {
+                                                                                        sval: "float8",
+                                                                                    },
+                                                                                ),
+                                                                            ),
+                                                                        },
+                                                                    ],
+                                                                    type_oid: 0,
+                                                                    setof: false,
+                                                                    pct_type: false,
+                                                                    typmods: [],
+                                                                    typemod: -1,
+                                                                    array_bounds: [],
+                                                                    location: 34,
+                                                                },
+                                                            ),
+                                                            mode: FuncParamDefault,
+                                                            defexpr: None,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                            Node {
+                                                node: Some(
+                                                    FunctionParameter(
+                                                        FunctionParameter {
+                                                            name: "",
+                                                            arg_type: Some(
+                                                                TypeName {
+                                                                    names: [
+                                                                        Node {
+                                                                            node: Some(
+                                                                                String(
+                                                                                    String {
+                                                                                        sval: "anyelement",
+                                                                                    },
+                                                                                ),
+                                                                            ),
+                                                                        },
+                                                                    ],
+                                                                    type_oid: 0,
+                                                                    setof: false,
+                                                                    pct_type: false,
+                                                                    typmods: [],
+                                                                    typemod: -1,
+                                                                    array_bounds: [],
+                                                                    location: 50,
+                                                                },
+                                                            ),
+                                                            mode: FuncParamDefault,
+                                                            defexpr: None,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                Integer(
+                                    Integer {
+                                        ival: 1,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    definition: [
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "sfunc",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    TypeName(
+                                                        TypeName {
+                                                            names: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "ordered_set_transition",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            type_oid: 0,
+                                                            setof: false,
+                                                            pct_type: false,
+                                                            typmods: [],
+                                                            typemod: -1,
+                                                            array_bounds: [],
+                                                            location: 71,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 63,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "stype",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    TypeName(
+                                                        TypeName {
+                                                            names: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "internal",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            type_oid: 0,
+                                                            setof: false,
+                                                            pct_type: false,
+                                                            typmods: [],
+                                                            typemod: -1,
+                                                            array_bounds: [],
+                                                            location: 103,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 95,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "finalfunc",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    TypeName(
+                                                        TypeName {
+                                                            names: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "percentile_disc_final",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            type_oid: 0,
+                                                            setof: false,
+                                                            pct_type: false,
+                                                            typmods: [],
+                                                            typemod: -1,
+                                                            array_bounds: [],
+                                                            location: 125,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 113,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "finalfunc_extra",
+                                        arg: None,
+                                        defaction: DefelemUnspec,
+                                        location: 148,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    if_not_exists: false,
+                    replace: false,
+                },
+            ),
+            range: 0..165,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0039@7.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0039@7.snap
@@ -1,0 +1,282 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE AGGREGATE custom_aggregate (float8 ORDER BY column1, column2) (sfunc = sfunc1, stype = stype1);"
+---
+Parse {
+    cst: SourceFile@0..103
+      Newline@0..1 "\n"
+      DefineStmt@1..103
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        Aggregate@8..17 "AGGREGATE"
+        Whitespace@17..18 " "
+        Ident@18..34 "custom_aggregate"
+        Whitespace@34..35 " "
+        Ascii40@35..36 "("
+        List@36..68
+          FunctionParameter@36..42
+            TypeName@36..42
+              Ident@36..42 "float8"
+          Whitespace@42..43 " "
+          Order@43..48 "ORDER"
+          Whitespace@48..49 " "
+          By@49..51 "BY"
+          Whitespace@51..52 " "
+          FunctionParameter@52..59
+            TypeName@52..59
+              Ident@52..59 "column1"
+          Ascii44@59..60 ","
+          Whitespace@60..61 " "
+          FunctionParameter@61..68
+            TypeName@61..68
+              Ident@61..68 "column2"
+        Ascii41@68..69 ")"
+        Whitespace@69..70 " "
+        Ascii40@70..71 "("
+        DefElem@71..85
+          Ident@71..76 "sfunc"
+          Whitespace@76..77 " "
+          Ascii61@77..78 "="
+          Whitespace@78..79 " "
+          TypeName@79..85
+            Ident@79..85 "sfunc1"
+        Ascii44@85..86 ","
+        Whitespace@86..87 " "
+        DefElem@87..101
+          Ident@87..92 "stype"
+          Whitespace@92..93 " "
+          Ascii61@93..94 "="
+          Whitespace@94..95 " "
+          TypeName@95..101
+            Ident@95..101 "stype1"
+        Ascii41@101..102 ")"
+        Ascii59@102..103 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: DefineStmt(
+                DefineStmt {
+                    kind: ObjectAggregate,
+                    oldstyle: false,
+                    defnames: [
+                        Node {
+                            node: Some(
+                                String(
+                                    String {
+                                        sval: "custom_aggregate",
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    args: [
+                        Node {
+                            node: Some(
+                                List(
+                                    List {
+                                        items: [
+                                            Node {
+                                                node: Some(
+                                                    FunctionParameter(
+                                                        FunctionParameter {
+                                                            name: "",
+                                                            arg_type: Some(
+                                                                TypeName {
+                                                                    names: [
+                                                                        Node {
+                                                                            node: Some(
+                                                                                String(
+                                                                                    String {
+                                                                                        sval: "float8",
+                                                                                    },
+                                                                                ),
+                                                                            ),
+                                                                        },
+                                                                    ],
+                                                                    type_oid: 0,
+                                                                    setof: false,
+                                                                    pct_type: false,
+                                                                    typmods: [],
+                                                                    typemod: -1,
+                                                                    array_bounds: [],
+                                                                    location: 35,
+                                                                },
+                                                            ),
+                                                            mode: FuncParamDefault,
+                                                            defexpr: None,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                            Node {
+                                                node: Some(
+                                                    FunctionParameter(
+                                                        FunctionParameter {
+                                                            name: "",
+                                                            arg_type: Some(
+                                                                TypeName {
+                                                                    names: [
+                                                                        Node {
+                                                                            node: Some(
+                                                                                String(
+                                                                                    String {
+                                                                                        sval: "column1",
+                                                                                    },
+                                                                                ),
+                                                                            ),
+                                                                        },
+                                                                    ],
+                                                                    type_oid: 0,
+                                                                    setof: false,
+                                                                    pct_type: false,
+                                                                    typmods: [],
+                                                                    typemod: -1,
+                                                                    array_bounds: [],
+                                                                    location: 51,
+                                                                },
+                                                            ),
+                                                            mode: FuncParamDefault,
+                                                            defexpr: None,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                            Node {
+                                                node: Some(
+                                                    FunctionParameter(
+                                                        FunctionParameter {
+                                                            name: "",
+                                                            arg_type: Some(
+                                                                TypeName {
+                                                                    names: [
+                                                                        Node {
+                                                                            node: Some(
+                                                                                String(
+                                                                                    String {
+                                                                                        sval: "column2",
+                                                                                    },
+                                                                                ),
+                                                                            ),
+                                                                        },
+                                                                    ],
+                                                                    type_oid: 0,
+                                                                    setof: false,
+                                                                    pct_type: false,
+                                                                    typmods: [],
+                                                                    typemod: -1,
+                                                                    array_bounds: [],
+                                                                    location: 60,
+                                                                },
+                                                            ),
+                                                            mode: FuncParamDefault,
+                                                            defexpr: None,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                Integer(
+                                    Integer {
+                                        ival: 1,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    definition: [
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "sfunc",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    TypeName(
+                                                        TypeName {
+                                                            names: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "sfunc1",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            type_oid: 0,
+                                                            setof: false,
+                                                            pct_type: false,
+                                                            typmods: [],
+                                                            typemod: -1,
+                                                            array_bounds: [],
+                                                            location: 78,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 70,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "stype",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    TypeName(
+                                                        TypeName {
+                                                            names: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "stype1",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            type_oid: 0,
+                                                            setof: false,
+                                                            pct_type: false,
+                                                            typmods: [],
+                                                            typemod: -1,
+                                                            array_bounds: [],
+                                                            location: 94,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 86,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    if_not_exists: false,
+                    replace: false,
+                },
+            ),
+            range: 0..102,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0040@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0040@1.snap
@@ -1,0 +1,186 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "CREATE FUNCTION getfoo(int) RETURNS SETOF users AS $$SELECT * FROM \\\"users\\\" WHERE users.id = $1;$$ LANGUAGE sql;"
+---
+Parse {
+    cst: SourceFile@0..113
+      CreateFunctionStmt@0..113
+        Create@0..6 "CREATE"
+        Whitespace@6..7 " "
+        Function@7..15 "FUNCTION"
+        Whitespace@15..16 " "
+        Ident@16..22 "getfoo"
+        Ascii40@22..23 "("
+        FunctionParameter@23..26
+          TypeName@23..26
+            IntP@23..26 "int"
+        Ascii41@26..27 ")"
+        Whitespace@27..28 " "
+        Returns@28..35 "RETURNS"
+        Whitespace@35..36 " "
+        Setof@36..41 "SETOF"
+        Whitespace@41..42 " "
+        TypeName@42..47
+          Ident@42..47 "users"
+        Whitespace@47..48 " "
+        DefElem@48..99
+          As@48..50 "AS"
+          Whitespace@50..51 " "
+          List@51..99
+            Sconst@51..99 "$$SELECT * FROM \\\"use ..."
+        Whitespace@99..100 " "
+        DefElem@100..112
+          Language@100..108 "LANGUAGE"
+          Whitespace@108..109 " "
+          SqlP@109..112 "sql"
+        Ascii59@112..113 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateFunctionStmt(
+                CreateFunctionStmt {
+                    is_procedure: false,
+                    replace: false,
+                    funcname: [
+                        Node {
+                            node: Some(
+                                String(
+                                    String {
+                                        sval: "getfoo",
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    parameters: [
+                        Node {
+                            node: Some(
+                                FunctionParameter(
+                                    FunctionParameter {
+                                        name: "",
+                                        arg_type: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "int4",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 23,
+                                            },
+                                        ),
+                                        mode: FuncParamDefault,
+                                        defexpr: None,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    return_type: Some(
+                        TypeName {
+                            names: [
+                                Node {
+                                    node: Some(
+                                        String(
+                                            String {
+                                                sval: "users",
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ],
+                            type_oid: 0,
+                            setof: true,
+                            pct_type: false,
+                            typmods: [],
+                            typemod: -1,
+                            array_bounds: [],
+                            location: 42,
+                        },
+                    ),
+                    options: [
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "as",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    List(
+                                                        List {
+                                                            items: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "SELECT * FROM \\\"users\\\" WHERE users.id = $1;",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 48,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "language",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "sql",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 100,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    sql_body: None,
+                },
+            ),
+            range: 0..112,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0040@2.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0040@2.snap
@@ -1,0 +1,191 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE OR REPLACE FUNCTION getfoo(int) RETURNS SETOF users AS $$SELECT * FROM \\\"users\\\" WHERE users.id = $1;$$ LANGUAGE sql;"
+---
+Parse {
+    cst: SourceFile@0..125
+      Newline@0..1 "\n"
+      CreateFunctionStmt@1..125
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        Or@8..10 "OR"
+        Whitespace@10..11 " "
+        Replace@11..18 "REPLACE"
+        Whitespace@18..19 " "
+        Function@19..27 "FUNCTION"
+        Whitespace@27..28 " "
+        Ident@28..34 "getfoo"
+        Ascii40@34..35 "("
+        FunctionParameter@35..38
+          TypeName@35..38
+            IntP@35..38 "int"
+        Ascii41@38..39 ")"
+        Whitespace@39..40 " "
+        Returns@40..47 "RETURNS"
+        Whitespace@47..48 " "
+        Setof@48..53 "SETOF"
+        Whitespace@53..54 " "
+        TypeName@54..59
+          Ident@54..59 "users"
+        Whitespace@59..60 " "
+        DefElem@60..111
+          As@60..62 "AS"
+          Whitespace@62..63 " "
+          List@63..111
+            Sconst@63..111 "$$SELECT * FROM \\\"use ..."
+        Whitespace@111..112 " "
+        DefElem@112..124
+          Language@112..120 "LANGUAGE"
+          Whitespace@120..121 " "
+          SqlP@121..124 "sql"
+        Ascii59@124..125 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateFunctionStmt(
+                CreateFunctionStmt {
+                    is_procedure: false,
+                    replace: true,
+                    funcname: [
+                        Node {
+                            node: Some(
+                                String(
+                                    String {
+                                        sval: "getfoo",
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    parameters: [
+                        Node {
+                            node: Some(
+                                FunctionParameter(
+                                    FunctionParameter {
+                                        name: "",
+                                        arg_type: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "int4",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 34,
+                                            },
+                                        ),
+                                        mode: FuncParamDefault,
+                                        defexpr: None,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    return_type: Some(
+                        TypeName {
+                            names: [
+                                Node {
+                                    node: Some(
+                                        String(
+                                            String {
+                                                sval: "users",
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ],
+                            type_oid: 0,
+                            setof: true,
+                            pct_type: false,
+                            typmods: [],
+                            typemod: -1,
+                            array_bounds: [],
+                            location: 53,
+                        },
+                    ),
+                    options: [
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "as",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    List(
+                                                        List {
+                                                            items: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "SELECT * FROM \\\"users\\\" WHERE users.id = $1;",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 59,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "language",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "sql",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 111,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    sql_body: None,
+                },
+            ),
+            range: 0..124,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0040@3.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0040@3.snap
@@ -1,0 +1,217 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE OR REPLACE FUNCTION getfoo(int) RETURNS SETOF users AS $$SELECT * FROM \\\"users\\\" WHERE users.id = $1;$$ LANGUAGE sql IMMUTABLE;"
+---
+Parse {
+    cst: SourceFile@0..135
+      Newline@0..1 "\n"
+      CreateFunctionStmt@1..135
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        Or@8..10 "OR"
+        Whitespace@10..11 " "
+        Replace@11..18 "REPLACE"
+        Whitespace@18..19 " "
+        Function@19..27 "FUNCTION"
+        Whitespace@27..28 " "
+        Ident@28..34 "getfoo"
+        Ascii40@34..35 "("
+        FunctionParameter@35..38
+          TypeName@35..38
+            IntP@35..38 "int"
+        Ascii41@38..39 ")"
+        Whitespace@39..40 " "
+        Returns@40..47 "RETURNS"
+        Whitespace@47..48 " "
+        Setof@48..53 "SETOF"
+        Whitespace@53..54 " "
+        TypeName@54..59
+          Ident@54..59 "users"
+        Whitespace@59..60 " "
+        DefElem@60..111
+          As@60..62 "AS"
+          Whitespace@62..63 " "
+          List@63..111
+            Sconst@63..111 "$$SELECT * FROM \\\"use ..."
+        Whitespace@111..112 " "
+        DefElem@112..124
+          Language@112..120 "LANGUAGE"
+          Whitespace@120..121 " "
+          SqlP@121..124 "sql"
+        Whitespace@124..125 " "
+        DefElem@125..134
+          Immutable@125..134 "IMMUTABLE"
+        Ascii59@134..135 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateFunctionStmt(
+                CreateFunctionStmt {
+                    is_procedure: false,
+                    replace: true,
+                    funcname: [
+                        Node {
+                            node: Some(
+                                String(
+                                    String {
+                                        sval: "getfoo",
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    parameters: [
+                        Node {
+                            node: Some(
+                                FunctionParameter(
+                                    FunctionParameter {
+                                        name: "",
+                                        arg_type: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "int4",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 34,
+                                            },
+                                        ),
+                                        mode: FuncParamDefault,
+                                        defexpr: None,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    return_type: Some(
+                        TypeName {
+                            names: [
+                                Node {
+                                    node: Some(
+                                        String(
+                                            String {
+                                                sval: "users",
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ],
+                            type_oid: 0,
+                            setof: true,
+                            pct_type: false,
+                            typmods: [],
+                            typemod: -1,
+                            array_bounds: [],
+                            location: 53,
+                        },
+                    ),
+                    options: [
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "as",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    List(
+                                                        List {
+                                                            items: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "SELECT * FROM \\\"users\\\" WHERE users.id = $1;",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 59,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "language",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "sql",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 111,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "volatility",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "immutable",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 124,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    sql_body: None,
+                },
+            ),
+            range: 0..134,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0040@4.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0040@4.snap
@@ -1,0 +1,243 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE OR REPLACE FUNCTION getfoo(int) RETURNS SETOF users AS $$SELECT * FROM \\\"users\\\" WHERE users.id = $1;$$ LANGUAGE sql IMMUTABLE STRICT;"
+---
+Parse {
+    cst: SourceFile@0..142
+      Newline@0..1 "\n"
+      CreateFunctionStmt@1..142
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        Or@8..10 "OR"
+        Whitespace@10..11 " "
+        Replace@11..18 "REPLACE"
+        Whitespace@18..19 " "
+        Function@19..27 "FUNCTION"
+        Whitespace@27..28 " "
+        Ident@28..34 "getfoo"
+        Ascii40@34..35 "("
+        FunctionParameter@35..38
+          TypeName@35..38
+            IntP@35..38 "int"
+        Ascii41@38..39 ")"
+        Whitespace@39..40 " "
+        Returns@40..47 "RETURNS"
+        Whitespace@47..48 " "
+        Setof@48..53 "SETOF"
+        Whitespace@53..54 " "
+        TypeName@54..59
+          Ident@54..59 "users"
+        Whitespace@59..60 " "
+        DefElem@60..111
+          As@60..62 "AS"
+          Whitespace@62..63 " "
+          List@63..111
+            Sconst@63..111 "$$SELECT * FROM \\\"use ..."
+        Whitespace@111..112 " "
+        DefElem@112..124
+          Language@112..120 "LANGUAGE"
+          Whitespace@120..121 " "
+          SqlP@121..124 "sql"
+        Whitespace@124..125 " "
+        DefElem@125..134
+          Immutable@125..134 "IMMUTABLE"
+        Whitespace@134..135 " "
+        DefElem@135..141
+          StrictP@135..141 "STRICT"
+        Ascii59@141..142 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateFunctionStmt(
+                CreateFunctionStmt {
+                    is_procedure: false,
+                    replace: true,
+                    funcname: [
+                        Node {
+                            node: Some(
+                                String(
+                                    String {
+                                        sval: "getfoo",
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    parameters: [
+                        Node {
+                            node: Some(
+                                FunctionParameter(
+                                    FunctionParameter {
+                                        name: "",
+                                        arg_type: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "int4",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 34,
+                                            },
+                                        ),
+                                        mode: FuncParamDefault,
+                                        defexpr: None,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    return_type: Some(
+                        TypeName {
+                            names: [
+                                Node {
+                                    node: Some(
+                                        String(
+                                            String {
+                                                sval: "users",
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ],
+                            type_oid: 0,
+                            setof: true,
+                            pct_type: false,
+                            typmods: [],
+                            typemod: -1,
+                            array_bounds: [],
+                            location: 53,
+                        },
+                    ),
+                    options: [
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "as",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    List(
+                                                        List {
+                                                            items: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "SELECT * FROM \\\"users\\\" WHERE users.id = $1;",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 59,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "language",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "sql",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 111,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "volatility",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "immutable",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 124,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "strict",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    Boolean(
+                                                        Boolean {
+                                                            boolval: true,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 134,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    sql_body: None,
+                },
+            ),
+            range: 0..141,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0040@5.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0040@5.snap
@@ -1,0 +1,251 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE OR REPLACE FUNCTION getfoo(int) RETURNS SETOF users AS $$SELECT * FROM \\\"users\\\" WHERE users.id = $1;$$ LANGUAGE sql IMMUTABLE RETURNS NULL ON NULL INPUT;"
+---
+Parse {
+    cst: SourceFile@0..162
+      Newline@0..1 "\n"
+      CreateFunctionStmt@1..162
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        Or@8..10 "OR"
+        Whitespace@10..11 " "
+        Replace@11..18 "REPLACE"
+        Whitespace@18..19 " "
+        Function@19..27 "FUNCTION"
+        Whitespace@27..28 " "
+        Ident@28..34 "getfoo"
+        Ascii40@34..35 "("
+        FunctionParameter@35..38
+          TypeName@35..38
+            IntP@35..38 "int"
+        Ascii41@38..39 ")"
+        Whitespace@39..40 " "
+        Returns@40..47 "RETURNS"
+        Whitespace@47..48 " "
+        Setof@48..53 "SETOF"
+        Whitespace@53..54 " "
+        TypeName@54..59
+          Ident@54..59 "users"
+        Whitespace@59..60 " "
+        DefElem@60..111
+          As@60..62 "AS"
+          Whitespace@62..63 " "
+          List@63..111
+            Sconst@63..111 "$$SELECT * FROM \\\"use ..."
+        Whitespace@111..112 " "
+        DefElem@112..124
+          Language@112..120 "LANGUAGE"
+          Whitespace@120..121 " "
+          SqlP@121..124 "sql"
+        Whitespace@124..125 " "
+        DefElem@125..134
+          Immutable@125..134 "IMMUTABLE"
+        Whitespace@134..135 " "
+        DefElem@135..142
+          Returns@135..142 "RETURNS"
+        Whitespace@142..143 " "
+        NullP@143..147 "NULL"
+        Whitespace@147..148 " "
+        On@148..150 "ON"
+        Whitespace@150..151 " "
+        NullP@151..155 "NULL"
+        Whitespace@155..156 " "
+        InputP@156..161 "INPUT"
+        Ascii59@161..162 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateFunctionStmt(
+                CreateFunctionStmt {
+                    is_procedure: false,
+                    replace: true,
+                    funcname: [
+                        Node {
+                            node: Some(
+                                String(
+                                    String {
+                                        sval: "getfoo",
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    parameters: [
+                        Node {
+                            node: Some(
+                                FunctionParameter(
+                                    FunctionParameter {
+                                        name: "",
+                                        arg_type: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "int4",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 34,
+                                            },
+                                        ),
+                                        mode: FuncParamDefault,
+                                        defexpr: None,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    return_type: Some(
+                        TypeName {
+                            names: [
+                                Node {
+                                    node: Some(
+                                        String(
+                                            String {
+                                                sval: "users",
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ],
+                            type_oid: 0,
+                            setof: true,
+                            pct_type: false,
+                            typmods: [],
+                            typemod: -1,
+                            array_bounds: [],
+                            location: 53,
+                        },
+                    ),
+                    options: [
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "as",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    List(
+                                                        List {
+                                                            items: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "SELECT * FROM \\\"users\\\" WHERE users.id = $1;",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 59,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "language",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "sql",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 111,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "volatility",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "immutable",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 124,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "strict",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    Boolean(
+                                                        Boolean {
+                                                            boolval: true,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 134,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    sql_body: None,
+                },
+            ),
+            range: 0..161,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0040@6.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0040@6.snap
@@ -1,0 +1,249 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE OR REPLACE FUNCTION getfoo(int) RETURNS SETOF users AS $$SELECT * FROM \\\"users\\\" WHERE users.id = $1;$$ LANGUAGE sql IMMUTABLE CALLED ON NULL INPUT;"
+---
+Parse {
+    cst: SourceFile@0..156
+      Newline@0..1 "\n"
+      CreateFunctionStmt@1..156
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        Or@8..10 "OR"
+        Whitespace@10..11 " "
+        Replace@11..18 "REPLACE"
+        Whitespace@18..19 " "
+        Function@19..27 "FUNCTION"
+        Whitespace@27..28 " "
+        Ident@28..34 "getfoo"
+        Ascii40@34..35 "("
+        FunctionParameter@35..38
+          TypeName@35..38
+            IntP@35..38 "int"
+        Ascii41@38..39 ")"
+        Whitespace@39..40 " "
+        Returns@40..47 "RETURNS"
+        Whitespace@47..48 " "
+        Setof@48..53 "SETOF"
+        Whitespace@53..54 " "
+        TypeName@54..59
+          Ident@54..59 "users"
+        Whitespace@59..60 " "
+        DefElem@60..111
+          As@60..62 "AS"
+          Whitespace@62..63 " "
+          List@63..111
+            Sconst@63..111 "$$SELECT * FROM \\\"use ..."
+        Whitespace@111..112 " "
+        DefElem@112..124
+          Language@112..120 "LANGUAGE"
+          Whitespace@120..121 " "
+          SqlP@121..124 "sql"
+        Whitespace@124..125 " "
+        DefElem@125..134
+          Immutable@125..134 "IMMUTABLE"
+        Whitespace@134..135 " "
+        DefElem@135..141
+          Called@135..141 "CALLED"
+        Whitespace@141..142 " "
+        On@142..144 "ON"
+        Whitespace@144..145 " "
+        NullP@145..149 "NULL"
+        Whitespace@149..150 " "
+        InputP@150..155 "INPUT"
+        Ascii59@155..156 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateFunctionStmt(
+                CreateFunctionStmt {
+                    is_procedure: false,
+                    replace: true,
+                    funcname: [
+                        Node {
+                            node: Some(
+                                String(
+                                    String {
+                                        sval: "getfoo",
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    parameters: [
+                        Node {
+                            node: Some(
+                                FunctionParameter(
+                                    FunctionParameter {
+                                        name: "",
+                                        arg_type: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "int4",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 34,
+                                            },
+                                        ),
+                                        mode: FuncParamDefault,
+                                        defexpr: None,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    return_type: Some(
+                        TypeName {
+                            names: [
+                                Node {
+                                    node: Some(
+                                        String(
+                                            String {
+                                                sval: "users",
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ],
+                            type_oid: 0,
+                            setof: true,
+                            pct_type: false,
+                            typmods: [],
+                            typemod: -1,
+                            array_bounds: [],
+                            location: 53,
+                        },
+                    ),
+                    options: [
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "as",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    List(
+                                                        List {
+                                                            items: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "SELECT * FROM \\\"users\\\" WHERE users.id = $1;",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 59,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "language",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "sql",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 111,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "volatility",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "immutable",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 124,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "strict",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    Boolean(
+                                                        Boolean {
+                                                            boolval: false,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 134,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    sql_body: None,
+                },
+            ),
+            range: 0..155,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0040@7.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0040@7.snap
@@ -1,0 +1,201 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE OR REPLACE FUNCTION getfoo() RETURNS text AS $$SELECT name FROM \\\"users\\\" LIMIT 1$$ LANGUAGE sql IMMUTABLE CALLED ON NULL INPUT;"
+---
+Parse {
+    cst: SourceFile@0..136
+      Newline@0..1 "\n"
+      CreateFunctionStmt@1..136
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        Or@8..10 "OR"
+        Whitespace@10..11 " "
+        Replace@11..18 "REPLACE"
+        Whitespace@18..19 " "
+        Function@19..27 "FUNCTION"
+        Whitespace@27..28 " "
+        Ident@28..34 "getfoo"
+        Ascii40@34..35 "("
+        Ascii41@35..36 ")"
+        Whitespace@36..37 " "
+        Returns@37..44 "RETURNS"
+        Whitespace@44..45 " "
+        TypeName@45..49
+          TextP@45..49 "text"
+        Whitespace@49..50 " "
+        DefElem@50..91
+          As@50..52 "AS"
+          Whitespace@52..53 " "
+          List@53..91
+            Sconst@53..91 "$$SELECT name FROM \\\" ..."
+        Whitespace@91..92 " "
+        DefElem@92..104
+          Language@92..100 "LANGUAGE"
+          Whitespace@100..101 " "
+          SqlP@101..104 "sql"
+        Whitespace@104..105 " "
+        DefElem@105..114
+          Immutable@105..114 "IMMUTABLE"
+        Whitespace@114..115 " "
+        DefElem@115..121
+          Called@115..121 "CALLED"
+        Whitespace@121..122 " "
+        On@122..124 "ON"
+        Whitespace@124..125 " "
+        NullP@125..129 "NULL"
+        Whitespace@129..130 " "
+        InputP@130..135 "INPUT"
+        Ascii59@135..136 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateFunctionStmt(
+                CreateFunctionStmt {
+                    is_procedure: false,
+                    replace: true,
+                    funcname: [
+                        Node {
+                            node: Some(
+                                String(
+                                    String {
+                                        sval: "getfoo",
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    parameters: [],
+                    return_type: Some(
+                        TypeName {
+                            names: [
+                                Node {
+                                    node: Some(
+                                        String(
+                                            String {
+                                                sval: "text",
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ],
+                            type_oid: 0,
+                            setof: false,
+                            pct_type: false,
+                            typmods: [],
+                            typemod: -1,
+                            array_bounds: [],
+                            location: 44,
+                        },
+                    ),
+                    options: [
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "as",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    List(
+                                                        List {
+                                                            items: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "SELECT name FROM \\\"users\\\" LIMIT 1",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 49,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "language",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "sql",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 91,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "volatility",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "immutable",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 104,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "strict",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    Boolean(
+                                                        Boolean {
+                                                            boolval: false,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 114,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    sql_body: None,
+                },
+            ),
+            range: 0..135,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0041@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0041@1.snap
@@ -1,0 +1,29 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: CREATE SCHEMA myschema;
+---
+Parse {
+    cst: SourceFile@0..23
+      CreateSchemaStmt@0..23
+        Create@0..6 "CREATE"
+        Whitespace@6..7 " "
+        Schema@7..13 "SCHEMA"
+        Whitespace@13..14 " "
+        Ident@14..22 "myschema"
+        Ascii59@22..23 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateSchemaStmt(
+                CreateSchemaStmt {
+                    schemaname: "myschema",
+                    authrole: None,
+                    schema_elts: [],
+                    if_not_exists: false,
+                },
+            ),
+            range: 0..22,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0041@2.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0041@2.snap
@@ -1,0 +1,39 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE SCHEMA AUTHORIZATION joe;"
+---
+Parse {
+    cst: SourceFile@0..33
+      Newline@0..1 "\n"
+      CreateSchemaStmt@1..33
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        Schema@8..14 "SCHEMA"
+        Whitespace@14..15 " "
+        Authorization@15..28 "AUTHORIZATION"
+        Whitespace@28..29 " "
+        RoleSpec@29..32
+          Ident@29..32 "joe"
+        Ascii59@32..33 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateSchemaStmt(
+                CreateSchemaStmt {
+                    schemaname: "",
+                    authrole: Some(
+                        RoleSpec {
+                            roletype: RolespecCstring,
+                            rolename: "joe",
+                            location: 28,
+                        },
+                    ),
+                    schema_elts: [],
+                    if_not_exists: false,
+                },
+            ),
+            range: 0..32,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0041@3.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0041@3.snap
@@ -1,0 +1,47 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE SCHEMA IF NOT EXISTS test AUTHORIZATION joe;"
+---
+Parse {
+    cst: SourceFile@0..52
+      Newline@0..1 "\n"
+      CreateSchemaStmt@1..52
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        Schema@8..14 "SCHEMA"
+        Whitespace@14..15 " "
+        IfP@15..17 "IF"
+        Whitespace@17..18 " "
+        Not@18..21 "NOT"
+        Whitespace@21..22 " "
+        Exists@22..28 "EXISTS"
+        Whitespace@28..29 " "
+        Ident@29..33 "test"
+        Whitespace@33..34 " "
+        Authorization@34..47 "AUTHORIZATION"
+        Whitespace@47..48 " "
+        RoleSpec@48..51
+          Ident@48..51 "joe"
+        Ascii59@51..52 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateSchemaStmt(
+                CreateSchemaStmt {
+                    schemaname: "test",
+                    authrole: Some(
+                        RoleSpec {
+                            roletype: RolespecCstring,
+                            rolename: "joe",
+                            location: 47,
+                        },
+                    ),
+                    schema_elts: [],
+                    if_not_exists: true,
+                },
+            ),
+            range: 0..51,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0041@4.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0041@4.snap
@@ -1,0 +1,459 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE SCHEMA hollywood CREATE TABLE films (title text, release date, awards text[]) CREATE VIEW winners AS SELECT title, release FROM films WHERE awards IS NOT NULL;"
+---
+Parse {
+    cst: SourceFile@0..165
+      Newline@0..1 "\n"
+      CreateSchemaStmt@1..24
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        Schema@8..14 "SCHEMA"
+        Whitespace@14..15 " "
+        Ident@15..24 "hollywood"
+      CreateStmt@24..84
+        Create@24..30 "CREATE"
+        Whitespace@30..31 " "
+        Table@31..36 "TABLE"
+        Whitespace@36..37 " "
+        RangeVar@37..42
+          Ident@37..42 "films"
+        Whitespace@42..43 " "
+        Ascii40@43..44 "("
+        ColumnDef@44..54
+          Ident@44..49 "title"
+          Whitespace@49..50 " "
+          TypeName@50..54
+            TextP@50..54 "text"
+        Ascii44@54..55 ","
+        Whitespace@55..56 " "
+        ColumnDef@56..68
+          Release@56..63 "release"
+          Whitespace@63..64 " "
+          TypeName@64..68
+            Ident@64..68 "date"
+        Ascii44@68..69 ","
+        Whitespace@69..70 " "
+        ColumnDef@70..81
+          Ident@70..76 "awards"
+          Whitespace@76..77 " "
+          TypeName@77..81
+            TextP@77..81 "text"
+        Ascii91@81..82 "["
+        Ascii93@82..83 "]"
+        Ascii41@83..84 ")"
+      ViewStmt@84..165
+        Create@84..90 "CREATE"
+        Whitespace@90..91 " "
+        View@91..95 "VIEW"
+        Whitespace@95..96 " "
+        RangeVar@96..103
+          Ident@96..103 "winners"
+        Whitespace@103..104 " "
+        As@104..106 "AS"
+        Whitespace@106..107 " "
+        SelectStmt@107..164
+          Select@107..113 "SELECT"
+          Whitespace@113..114 " "
+          ResTarget@114..119
+            ColumnRef@114..119
+              Ident@114..119 "title"
+          Ascii44@119..120 ","
+          Whitespace@120..121 " "
+          ResTarget@121..128
+            ColumnRef@121..128
+              Release@121..128 "release"
+          Whitespace@128..129 " "
+          From@129..133 "FROM"
+          Whitespace@133..134 " "
+          RangeVar@134..139
+            Ident@134..139 "films"
+          Whitespace@139..140 " "
+          Where@140..145 "WHERE"
+          Whitespace@145..146 " "
+          NullTest@146..164
+            ColumnRef@146..152
+              Ident@146..152 "awards"
+            Whitespace@152..153 " "
+            Is@153..155 "IS"
+            Whitespace@155..156 " "
+            Not@156..159 "NOT"
+            Whitespace@159..160 " "
+            NullP@160..164 "NULL"
+        Ascii59@164..165 ";"
+    ,
+    errors: [
+        SyntaxError(
+            "Expected Ascii59, found Whitespace",
+            24..24,
+        ),
+        SyntaxError(
+            "Expected Ascii59, found Whitespace",
+            85..85,
+        ),
+    ],
+    stmts: [
+        RawStmt {
+            stmt: CreateSchemaStmt(
+                CreateSchemaStmt {
+                    schemaname: "hollywood",
+                    authrole: None,
+                    schema_elts: [],
+                    if_not_exists: false,
+                },
+            ),
+            range: 0..24,
+        },
+        RawStmt {
+            stmt: CreateStmt(
+                CreateStmt {
+                    relation: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "films",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 13,
+                        },
+                    ),
+                    table_elts: [
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "title",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "text",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 26,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [],
+                                        fdwoptions: [],
+                                        location: 20,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "release",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "date",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 40,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [],
+                                        fdwoptions: [],
+                                        location: 32,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "awards",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "text",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [
+                                                    Node {
+                                                        node: Some(
+                                                            Integer(
+                                                                Integer {
+                                                                    ival: -1,
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                location: 53,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [],
+                                        fdwoptions: [],
+                                        location: 46,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    inh_relations: [],
+                    partbound: None,
+                    partspec: None,
+                    of_typename: None,
+                    constraints: [],
+                    options: [],
+                    oncommit: OncommitNoop,
+                    tablespacename: "",
+                    access_method: "",
+                    if_not_exists: false,
+                },
+            ),
+            range: 24..85,
+        },
+        RawStmt {
+            stmt: ViewStmt(
+                ViewStmt {
+                    view: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "winners",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 12,
+                        },
+                    ),
+                    aliases: [],
+                    query: Some(
+                        Node {
+                            node: Some(
+                                SelectStmt(
+                                    SelectStmt {
+                                        distinct_clause: [],
+                                        into_clause: None,
+                                        target_list: [
+                                            Node {
+                                                node: Some(
+                                                    ResTarget(
+                                                        ResTarget {
+                                                            name: "",
+                                                            indirection: [],
+                                                            val: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        ColumnRef(
+                                                                            ColumnRef {
+                                                                                fields: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: "title",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                location: 30,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            location: 30,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                            Node {
+                                                node: Some(
+                                                    ResTarget(
+                                                        ResTarget {
+                                                            name: "",
+                                                            indirection: [],
+                                                            val: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        ColumnRef(
+                                                                            ColumnRef {
+                                                                                fields: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: "release",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                location: 37,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            location: 37,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        from_clause: [
+                                            Node {
+                                                node: Some(
+                                                    RangeVar(
+                                                        RangeVar {
+                                                            catalogname: "",
+                                                            schemaname: "",
+                                                            relname: "films",
+                                                            inh: true,
+                                                            relpersistence: "p",
+                                                            alias: None,
+                                                            location: 50,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        where_clause: Some(
+                                            Node {
+                                                node: Some(
+                                                    NullTest(
+                                                        NullTest {
+                                                            xpr: None,
+                                                            arg: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        ColumnRef(
+                                                                            ColumnRef {
+                                                                                fields: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: "awards",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                location: 62,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            nulltesttype: IsNotNull,
+                                                            argisrow: false,
+                                                            location: 69,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        group_clause: [],
+                                        group_distinct: false,
+                                        having_clause: None,
+                                        window_clause: [],
+                                        values_lists: [],
+                                        sort_clause: [],
+                                        limit_offset: None,
+                                        limit_count: None,
+                                        limit_option: Default,
+                                        locking_clause: [],
+                                        with_clause: None,
+                                        op: SetopNone,
+                                        all: false,
+                                        larg: None,
+                                        rarg: None,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    replace: false,
+                    options: [],
+                    with_check_option: NoCheckOption,
+                },
+            ),
+            range: 85..166,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0042@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0042@1.snap
@@ -1,0 +1,267 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "CREATE DOMAIN us_postal_code AS TEXT CHECK(VALUE ~ '^\\d{5}$' OR VALUE ~ '^\\d{5}-\\d{4}$');"
+---
+Parse {
+    cst: SourceFile@0..89
+      CreateDomainStmt@0..89
+        Create@0..6 "CREATE"
+        Whitespace@6..7 " "
+        DomainP@7..13 "DOMAIN"
+        Whitespace@13..14 " "
+        Ident@14..28 "us_postal_code"
+        Whitespace@28..29 " "
+        As@29..31 "AS"
+        Whitespace@31..32 " "
+        TypeName@32..36
+          TextP@32..36 "TEXT"
+        Whitespace@36..37 " "
+        Constraint@37..87
+          Check@37..42 "CHECK"
+          Ascii40@42..43 "("
+          BoolExpr@43..87
+            AExpr@43..60
+              ColumnRef@43..48
+                ValueP@43..48 "VALUE"
+              Whitespace@48..49 " "
+              Op@49..50 "~"
+              Whitespace@50..51 " "
+              AConst@51..60
+                Sconst@51..60 "'^\\d{5}$'"
+            Whitespace@60..61 " "
+            Or@61..63 "OR"
+            Whitespace@63..64 " "
+            AExpr@64..87
+              ColumnRef@64..69
+                ValueP@64..69 "VALUE"
+              Whitespace@69..70 " "
+              Op@70..71 "~"
+              Whitespace@71..72 " "
+              AConst@72..87
+                Sconst@72..87 "'^\\d{5}-\\d{4}$'"
+        Ascii41@87..88 ")"
+        Ascii59@88..89 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateDomainStmt(
+                CreateDomainStmt {
+                    domainname: [
+                        Node {
+                            node: Some(
+                                String(
+                                    String {
+                                        sval: "us_postal_code",
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    type_name: Some(
+                        TypeName {
+                            names: [
+                                Node {
+                                    node: Some(
+                                        String(
+                                            String {
+                                                sval: "text",
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ],
+                            type_oid: 0,
+                            setof: false,
+                            pct_type: false,
+                            typmods: [],
+                            typemod: -1,
+                            array_bounds: [],
+                            location: 32,
+                        },
+                    ),
+                    coll_clause: None,
+                    constraints: [
+                        Node {
+                            node: Some(
+                                Constraint(
+                                    Constraint {
+                                        contype: ConstrCheck,
+                                        conname: "",
+                                        deferrable: false,
+                                        initdeferred: false,
+                                        location: 37,
+                                        is_no_inherit: false,
+                                        raw_expr: Some(
+                                            Node {
+                                                node: Some(
+                                                    BoolExpr(
+                                                        BoolExpr {
+                                                            xpr: None,
+                                                            boolop: OrExpr,
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AExpr(
+                                                                            AExpr {
+                                                                                kind: AexprOp,
+                                                                                name: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: "~",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                lexpr: Some(
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            ColumnRef(
+                                                                                                ColumnRef {
+                                                                                                    fields: [
+                                                                                                        Node {
+                                                                                                            node: Some(
+                                                                                                                String(
+                                                                                                                    String {
+                                                                                                                        sval: "value",
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ],
+                                                                                                    location: 43,
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                rexpr: Some(
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            AConst(
+                                                                                                AConst {
+                                                                                                    isnull: false,
+                                                                                                    location: 51,
+                                                                                                    val: Some(
+                                                                                                        Sval(
+                                                                                                            String {
+                                                                                                                sval: "^\\d{5}$",
+                                                                                                            },
+                                                                                                        ),
+                                                                                                    ),
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                location: 49,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AExpr(
+                                                                            AExpr {
+                                                                                kind: AexprOp,
+                                                                                name: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: "~",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                lexpr: Some(
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            ColumnRef(
+                                                                                                ColumnRef {
+                                                                                                    fields: [
+                                                                                                        Node {
+                                                                                                            node: Some(
+                                                                                                                String(
+                                                                                                                    String {
+                                                                                                                        sval: "value",
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ],
+                                                                                                    location: 64,
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                rexpr: Some(
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            AConst(
+                                                                                                AConst {
+                                                                                                    isnull: false,
+                                                                                                    location: 72,
+                                                                                                    val: Some(
+                                                                                                        Sval(
+                                                                                                            String {
+                                                                                                                sval: "^\\d{5}-\\d{4}$",
+                                                                                                            },
+                                                                                                        ),
+                                                                                                    ),
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                location: 70,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 61,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        cooked_expr: "",
+                                        generated_when: "",
+                                        nulls_not_distinct: false,
+                                        keys: [],
+                                        including: [],
+                                        exclusions: [],
+                                        options: [],
+                                        indexname: "",
+                                        indexspace: "",
+                                        reset_default_tblspc: false,
+                                        access_method: "",
+                                        where_clause: None,
+                                        pktable: None,
+                                        fk_attrs: [],
+                                        pk_attrs: [],
+                                        fk_matchtype: "",
+                                        fk_upd_action: "",
+                                        fk_del_action: "",
+                                        fk_del_set_cols: [],
+                                        old_conpfeqop: [],
+                                        old_pktable_oid: 0,
+                                        skip_validation: false,
+                                        initially_valid: true,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                },
+            ),
+            range: 0..88,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0044@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0044@1.snap
@@ -1,0 +1,208 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "CREATE VIEW comedies AS SELECT * FROM films WHERE kind = 'Comedy';"
+---
+Parse {
+    cst: SourceFile@0..66
+      ViewStmt@0..66
+        Create@0..6 "CREATE"
+        Whitespace@6..7 " "
+        View@7..11 "VIEW"
+        Whitespace@11..12 " "
+        RangeVar@12..20
+          Ident@12..20 "comedies"
+        Whitespace@20..21 " "
+        As@21..23 "AS"
+        Whitespace@23..24 " "
+        SelectStmt@24..65
+          Select@24..30 "SELECT"
+          Whitespace@30..31 " "
+          ResTarget@31..32
+            ColumnRef@31..32
+              AStar@31..32
+                Ascii42@31..32 "*"
+          Whitespace@32..33 " "
+          From@33..37 "FROM"
+          Whitespace@37..38 " "
+          RangeVar@38..43
+            Ident@38..43 "films"
+          Whitespace@43..44 " "
+          Where@44..49 "WHERE"
+          Whitespace@49..50 " "
+          AExpr@50..65
+            ColumnRef@50..54
+              Ident@50..54 "kind"
+            Whitespace@54..55 " "
+            Ascii61@55..56 "="
+            Whitespace@56..57 " "
+            AConst@57..65
+              Sconst@57..65 "'Comedy'"
+        Ascii59@65..66 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: ViewStmt(
+                ViewStmt {
+                    view: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "comedies",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 12,
+                        },
+                    ),
+                    aliases: [],
+                    query: Some(
+                        Node {
+                            node: Some(
+                                SelectStmt(
+                                    SelectStmt {
+                                        distinct_clause: [],
+                                        into_clause: None,
+                                        target_list: [
+                                            Node {
+                                                node: Some(
+                                                    ResTarget(
+                                                        ResTarget {
+                                                            name: "",
+                                                            indirection: [],
+                                                            val: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        ColumnRef(
+                                                                            ColumnRef {
+                                                                                fields: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            AStar(
+                                                                                                AStar,
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                location: 31,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            location: 31,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        from_clause: [
+                                            Node {
+                                                node: Some(
+                                                    RangeVar(
+                                                        RangeVar {
+                                                            catalogname: "",
+                                                            schemaname: "",
+                                                            relname: "films",
+                                                            inh: true,
+                                                            relpersistence: "p",
+                                                            alias: None,
+                                                            location: 38,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        where_clause: Some(
+                                            Node {
+                                                node: Some(
+                                                    AExpr(
+                                                        AExpr {
+                                                            kind: AexprOp,
+                                                            name: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "=",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            lexpr: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        ColumnRef(
+                                                                            ColumnRef {
+                                                                                fields: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: "kind",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                location: 50,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            rexpr: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 57,
+                                                                                val: Some(
+                                                                                    Sval(
+                                                                                        String {
+                                                                                            sval: "Comedy",
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            location: 55,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        group_clause: [],
+                                        group_distinct: false,
+                                        having_clause: None,
+                                        window_clause: [],
+                                        values_lists: [],
+                                        sort_clause: [],
+                                        limit_offset: None,
+                                        limit_count: None,
+                                        limit_option: Default,
+                                        locking_clause: [],
+                                        with_clause: None,
+                                        op: SetopNone,
+                                        all: false,
+                                        larg: None,
+                                        rarg: None,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    replace: false,
+                    options: [],
+                    with_check_option: NoCheckOption,
+                },
+            ),
+            range: 0..65,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0044@2.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0044@2.snap
@@ -1,0 +1,217 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE VIEW universal_comedies AS SELECT * FROM comedies WHERE classification = 'U' WITH LOCAL CHECK OPTION;"
+---
+Parse {
+    cst: SourceFile@0..109
+      Newline@0..1 "\n"
+      ViewStmt@1..109
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        View@8..12 "VIEW"
+        Whitespace@12..13 " "
+        RangeVar@13..31
+          Ident@13..31 "universal_comedies"
+        Whitespace@31..32 " "
+        As@32..34 "AS"
+        Whitespace@34..35 " "
+        SelectStmt@35..84
+          Select@35..41 "SELECT"
+          Whitespace@41..42 " "
+          ResTarget@42..43
+            ColumnRef@42..43
+              AStar@42..43
+                Ascii42@42..43 "*"
+          Whitespace@43..44 " "
+          From@44..48 "FROM"
+          Whitespace@48..49 " "
+          RangeVar@49..57
+            Ident@49..57 "comedies"
+          Whitespace@57..58 " "
+          Where@58..63 "WHERE"
+          Whitespace@63..64 " "
+          AExpr@64..84
+            ColumnRef@64..78
+              Ident@64..78 "classification"
+            Whitespace@78..79 " "
+            Ascii61@79..80 "="
+            Whitespace@80..81 " "
+            AConst@81..84
+              Sconst@81..84 "'U'"
+        Whitespace@84..85 " "
+        With@85..89 "WITH"
+        Whitespace@89..90 " "
+        Local@90..95 "LOCAL"
+        Whitespace@95..96 " "
+        Check@96..101 "CHECK"
+        Whitespace@101..102 " "
+        Option@102..108 "OPTION"
+        Ascii59@108..109 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: ViewStmt(
+                ViewStmt {
+                    view: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "universal_comedies",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 12,
+                        },
+                    ),
+                    aliases: [],
+                    query: Some(
+                        Node {
+                            node: Some(
+                                SelectStmt(
+                                    SelectStmt {
+                                        distinct_clause: [],
+                                        into_clause: None,
+                                        target_list: [
+                                            Node {
+                                                node: Some(
+                                                    ResTarget(
+                                                        ResTarget {
+                                                            name: "",
+                                                            indirection: [],
+                                                            val: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        ColumnRef(
+                                                                            ColumnRef {
+                                                                                fields: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            AStar(
+                                                                                                AStar,
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                location: 41,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            location: 41,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        from_clause: [
+                                            Node {
+                                                node: Some(
+                                                    RangeVar(
+                                                        RangeVar {
+                                                            catalogname: "",
+                                                            schemaname: "",
+                                                            relname: "comedies",
+                                                            inh: true,
+                                                            relpersistence: "p",
+                                                            alias: None,
+                                                            location: 48,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        where_clause: Some(
+                                            Node {
+                                                node: Some(
+                                                    AExpr(
+                                                        AExpr {
+                                                            kind: AexprOp,
+                                                            name: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "=",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            lexpr: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        ColumnRef(
+                                                                            ColumnRef {
+                                                                                fields: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: "classification",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                location: 63,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            rexpr: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 80,
+                                                                                val: Some(
+                                                                                    Sval(
+                                                                                        String {
+                                                                                            sval: "U",
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            location: 78,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        group_clause: [],
+                                        group_distinct: false,
+                                        having_clause: None,
+                                        window_clause: [],
+                                        values_lists: [],
+                                        sort_clause: [],
+                                        limit_offset: None,
+                                        limit_count: None,
+                                        limit_option: Default,
+                                        locking_clause: [],
+                                        with_clause: None,
+                                        op: SetopNone,
+                                        all: false,
+                                        larg: None,
+                                        rarg: None,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    replace: false,
+                    options: [],
+                    with_check_option: LocalCheckOption,
+                },
+            ),
+            range: 0..108,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0044@3.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0044@3.snap
@@ -1,0 +1,217 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE VIEW pg_comedies AS SELECT * FROM comedies WHERE classification = 'PG' WITH CASCADED CHECK OPTION;"
+---
+Parse {
+    cst: SourceFile@0..106
+      Newline@0..1 "\n"
+      ViewStmt@1..106
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        View@8..12 "VIEW"
+        Whitespace@12..13 " "
+        RangeVar@13..24
+          Ident@13..24 "pg_comedies"
+        Whitespace@24..25 " "
+        As@25..27 "AS"
+        Whitespace@27..28 " "
+        SelectStmt@28..78
+          Select@28..34 "SELECT"
+          Whitespace@34..35 " "
+          ResTarget@35..36
+            ColumnRef@35..36
+              AStar@35..36
+                Ascii42@35..36 "*"
+          Whitespace@36..37 " "
+          From@37..41 "FROM"
+          Whitespace@41..42 " "
+          RangeVar@42..50
+            Ident@42..50 "comedies"
+          Whitespace@50..51 " "
+          Where@51..56 "WHERE"
+          Whitespace@56..57 " "
+          AExpr@57..78
+            ColumnRef@57..71
+              Ident@57..71 "classification"
+            Whitespace@71..72 " "
+            Ascii61@72..73 "="
+            Whitespace@73..74 " "
+            AConst@74..78
+              Sconst@74..78 "'PG'"
+        Whitespace@78..79 " "
+        With@79..83 "WITH"
+        Whitespace@83..84 " "
+        Cascaded@84..92 "CASCADED"
+        Whitespace@92..93 " "
+        Check@93..98 "CHECK"
+        Whitespace@98..99 " "
+        Option@99..105 "OPTION"
+        Ascii59@105..106 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: ViewStmt(
+                ViewStmt {
+                    view: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "pg_comedies",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 12,
+                        },
+                    ),
+                    aliases: [],
+                    query: Some(
+                        Node {
+                            node: Some(
+                                SelectStmt(
+                                    SelectStmt {
+                                        distinct_clause: [],
+                                        into_clause: None,
+                                        target_list: [
+                                            Node {
+                                                node: Some(
+                                                    ResTarget(
+                                                        ResTarget {
+                                                            name: "",
+                                                            indirection: [],
+                                                            val: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        ColumnRef(
+                                                                            ColumnRef {
+                                                                                fields: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            AStar(
+                                                                                                AStar,
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                location: 34,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            location: 34,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        from_clause: [
+                                            Node {
+                                                node: Some(
+                                                    RangeVar(
+                                                        RangeVar {
+                                                            catalogname: "",
+                                                            schemaname: "",
+                                                            relname: "comedies",
+                                                            inh: true,
+                                                            relpersistence: "p",
+                                                            alias: None,
+                                                            location: 41,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        where_clause: Some(
+                                            Node {
+                                                node: Some(
+                                                    AExpr(
+                                                        AExpr {
+                                                            kind: AexprOp,
+                                                            name: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "=",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            lexpr: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        ColumnRef(
+                                                                            ColumnRef {
+                                                                                fields: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: "classification",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                location: 56,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            rexpr: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 73,
+                                                                                val: Some(
+                                                                                    Sval(
+                                                                                        String {
+                                                                                            sval: "PG",
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            location: 71,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        group_clause: [],
+                                        group_distinct: false,
+                                        having_clause: None,
+                                        window_clause: [],
+                                        values_lists: [],
+                                        sort_clause: [],
+                                        limit_offset: None,
+                                        limit_count: None,
+                                        limit_option: Default,
+                                        locking_clause: [],
+                                        with_clause: None,
+                                        op: SetopNone,
+                                        all: false,
+                                        larg: None,
+                                        rarg: None,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    replace: false,
+                    options: [],
+                    with_check_option: CascadedCheckOption,
+                },
+            ),
+            range: 0..105,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0044@4.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0044@4.snap
@@ -1,0 +1,606 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE VIEW comedies AS SELECT f.*, country_code_to_name(f.country_code) AS country, (SELECT avg(r.rating) FROM user_ratings r WHERE r.film_id = f.id) AS avg_rating FROM films f WHERE f.kind = 'Comedy';"
+---
+Parse {
+    cst: SourceFile@0..203
+      Newline@0..1 "\n"
+      ViewStmt@1..203
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        View@8..12 "VIEW"
+        Whitespace@12..13 " "
+        RangeVar@13..21
+          Ident@13..21 "comedies"
+        Whitespace@21..22 " "
+        As@22..24 "AS"
+        Whitespace@24..25 " "
+        SelectStmt@25..202
+          Select@25..31 "SELECT"
+          Whitespace@31..32 " "
+          ResTarget@32..35
+            ColumnRef@32..35
+              Ident@32..33 "f"
+              Ascii46@33..34 "."
+              AStar@34..35
+                Ascii42@34..35 "*"
+          Ascii44@35..36 ","
+          Whitespace@36..37 " "
+          ResTarget@37..84
+            FuncCall@37..72
+              Ident@37..57 "country_code_to_name"
+              Ascii40@57..58 "("
+              ColumnRef@58..72
+                Ident@58..59 "f"
+                Ascii46@59..60 "."
+                Ident@60..72 "country_code"
+            Ascii41@72..73 ")"
+            Whitespace@73..74 " "
+            As@74..76 "AS"
+            Whitespace@76..77 " "
+            Ident@77..84 "country"
+          Ascii44@84..85 ","
+          Whitespace@85..86 " "
+          ResTarget@86..165
+            SubLink@86..150
+              SelectStmt@86..150
+                Ascii40@86..87 "("
+                Select@87..93 "SELECT"
+                Whitespace@93..94 " "
+                ResTarget@94..106
+                  FuncCall@94..106
+                    Ident@94..97 "avg"
+                    Ascii40@97..98 "("
+                    ColumnRef@98..106
+                      Ident@98..99 "r"
+                      Ascii46@99..100 "."
+                      Ident@100..106 "rating"
+                Ascii41@106..107 ")"
+                Whitespace@107..108 " "
+                From@108..112 "FROM"
+                Whitespace@112..113 " "
+                RangeVar@113..127
+                  Ident@113..125 "user_ratings"
+                  Whitespace@125..126 " "
+                  Alias@126..127
+                    Ident@126..127 "r"
+                Whitespace@127..128 " "
+                Where@128..133 "WHERE"
+                Whitespace@133..134 " "
+                AExpr@134..150
+                  ColumnRef@134..143
+                    Ident@134..135 "r"
+                    Ascii46@135..136 "."
+                    Ident@136..143 "film_id"
+                  Whitespace@143..144 " "
+                  Ascii61@144..145 "="
+                  Whitespace@145..146 " "
+                  ColumnRef@146..150
+                    Ident@146..147 "f"
+                    Ascii46@147..148 "."
+                    Ident@148..150 "id"
+            Ascii41@150..151 ")"
+            Whitespace@151..152 " "
+            As@152..154 "AS"
+            Whitespace@154..155 " "
+            Ident@155..165 "avg_rating"
+          Whitespace@165..166 " "
+          From@166..170 "FROM"
+          Whitespace@170..171 " "
+          RangeVar@171..178
+            Ident@171..176 "films"
+            Whitespace@176..177 " "
+            Alias@177..178
+              Ident@177..178 "f"
+          Whitespace@178..179 " "
+          Where@179..184 "WHERE"
+          Whitespace@184..185 " "
+          AExpr@185..202
+            ColumnRef@185..191
+              Ident@185..186 "f"
+              Ascii46@186..187 "."
+              Ident@187..191 "kind"
+            Whitespace@191..192 " "
+            Ascii61@192..193 "="
+            Whitespace@193..194 " "
+            AConst@194..202
+              Sconst@194..202 "'Comedy'"
+        Ascii59@202..203 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: ViewStmt(
+                ViewStmt {
+                    view: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "comedies",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 12,
+                        },
+                    ),
+                    aliases: [],
+                    query: Some(
+                        Node {
+                            node: Some(
+                                SelectStmt(
+                                    SelectStmt {
+                                        distinct_clause: [],
+                                        into_clause: None,
+                                        target_list: [
+                                            Node {
+                                                node: Some(
+                                                    ResTarget(
+                                                        ResTarget {
+                                                            name: "",
+                                                            indirection: [],
+                                                            val: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        ColumnRef(
+                                                                            ColumnRef {
+                                                                                fields: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: "f",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            AStar(
+                                                                                                AStar,
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                location: 31,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            location: 31,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                            Node {
+                                                node: Some(
+                                                    ResTarget(
+                                                        ResTarget {
+                                                            name: "country",
+                                                            indirection: [],
+                                                            val: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        FuncCall(
+                                                                            FuncCall {
+                                                                                funcname: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: "country_code_to_name",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                args: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            ColumnRef(
+                                                                                                ColumnRef {
+                                                                                                    fields: [
+                                                                                                        Node {
+                                                                                                            node: Some(
+                                                                                                                String(
+                                                                                                                    String {
+                                                                                                                        sval: "f",
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                        Node {
+                                                                                                            node: Some(
+                                                                                                                String(
+                                                                                                                    String {
+                                                                                                                        sval: "country_code",
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ],
+                                                                                                    location: 57,
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                agg_order: [],
+                                                                                agg_filter: None,
+                                                                                over: None,
+                                                                                agg_within_group: false,
+                                                                                agg_star: false,
+                                                                                agg_distinct: false,
+                                                                                func_variadic: false,
+                                                                                funcformat: CoerceExplicitCall,
+                                                                                location: 36,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            location: 36,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                            Node {
+                                                node: Some(
+                                                    ResTarget(
+                                                        ResTarget {
+                                                            name: "avg_rating",
+                                                            indirection: [],
+                                                            val: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        SubLink(
+                                                                            SubLink {
+                                                                                xpr: None,
+                                                                                sub_link_type: ExprSublink,
+                                                                                sub_link_id: 0,
+                                                                                testexpr: None,
+                                                                                oper_name: [],
+                                                                                subselect: Some(
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            SelectStmt(
+                                                                                                SelectStmt {
+                                                                                                    distinct_clause: [],
+                                                                                                    into_clause: None,
+                                                                                                    target_list: [
+                                                                                                        Node {
+                                                                                                            node: Some(
+                                                                                                                ResTarget(
+                                                                                                                    ResTarget {
+                                                                                                                        name: "",
+                                                                                                                        indirection: [],
+                                                                                                                        val: Some(
+                                                                                                                            Node {
+                                                                                                                                node: Some(
+                                                                                                                                    FuncCall(
+                                                                                                                                        FuncCall {
+                                                                                                                                            funcname: [
+                                                                                                                                                Node {
+                                                                                                                                                    node: Some(
+                                                                                                                                                        String(
+                                                                                                                                                            String {
+                                                                                                                                                                sval: "avg",
+                                                                                                                                                            },
+                                                                                                                                                        ),
+                                                                                                                                                    ),
+                                                                                                                                                },
+                                                                                                                                            ],
+                                                                                                                                            args: [
+                                                                                                                                                Node {
+                                                                                                                                                    node: Some(
+                                                                                                                                                        ColumnRef(
+                                                                                                                                                            ColumnRef {
+                                                                                                                                                                fields: [
+                                                                                                                                                                    Node {
+                                                                                                                                                                        node: Some(
+                                                                                                                                                                            String(
+                                                                                                                                                                                String {
+                                                                                                                                                                                    sval: "r",
+                                                                                                                                                                                },
+                                                                                                                                                                            ),
+                                                                                                                                                                        ),
+                                                                                                                                                                    },
+                                                                                                                                                                    Node {
+                                                                                                                                                                        node: Some(
+                                                                                                                                                                            String(
+                                                                                                                                                                                String {
+                                                                                                                                                                                    sval: "rating",
+                                                                                                                                                                                },
+                                                                                                                                                                            ),
+                                                                                                                                                                        ),
+                                                                                                                                                                    },
+                                                                                                                                                                ],
+                                                                                                                                                                location: 97,
+                                                                                                                                                            },
+                                                                                                                                                        ),
+                                                                                                                                                    ),
+                                                                                                                                                },
+                                                                                                                                            ],
+                                                                                                                                            agg_order: [],
+                                                                                                                                            agg_filter: None,
+                                                                                                                                            over: None,
+                                                                                                                                            agg_within_group: false,
+                                                                                                                                            agg_star: false,
+                                                                                                                                            agg_distinct: false,
+                                                                                                                                            func_variadic: false,
+                                                                                                                                            funcformat: CoerceExplicitCall,
+                                                                                                                                            location: 93,
+                                                                                                                                        },
+                                                                                                                                    ),
+                                                                                                                                ),
+                                                                                                                            },
+                                                                                                                        ),
+                                                                                                                        location: 93,
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ],
+                                                                                                    from_clause: [
+                                                                                                        Node {
+                                                                                                            node: Some(
+                                                                                                                RangeVar(
+                                                                                                                    RangeVar {
+                                                                                                                        catalogname: "",
+                                                                                                                        schemaname: "",
+                                                                                                                        relname: "user_ratings",
+                                                                                                                        inh: true,
+                                                                                                                        relpersistence: "p",
+                                                                                                                        alias: Some(
+                                                                                                                            Alias {
+                                                                                                                                aliasname: "r",
+                                                                                                                                colnames: [],
+                                                                                                                            },
+                                                                                                                        ),
+                                                                                                                        location: 112,
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ],
+                                                                                                    where_clause: Some(
+                                                                                                        Node {
+                                                                                                            node: Some(
+                                                                                                                AExpr(
+                                                                                                                    AExpr {
+                                                                                                                        kind: AexprOp,
+                                                                                                                        name: [
+                                                                                                                            Node {
+                                                                                                                                node: Some(
+                                                                                                                                    String(
+                                                                                                                                        String {
+                                                                                                                                            sval: "=",
+                                                                                                                                        },
+                                                                                                                                    ),
+                                                                                                                                ),
+                                                                                                                            },
+                                                                                                                        ],
+                                                                                                                        lexpr: Some(
+                                                                                                                            Node {
+                                                                                                                                node: Some(
+                                                                                                                                    ColumnRef(
+                                                                                                                                        ColumnRef {
+                                                                                                                                            fields: [
+                                                                                                                                                Node {
+                                                                                                                                                    node: Some(
+                                                                                                                                                        String(
+                                                                                                                                                            String {
+                                                                                                                                                                sval: "r",
+                                                                                                                                                            },
+                                                                                                                                                        ),
+                                                                                                                                                    ),
+                                                                                                                                                },
+                                                                                                                                                Node {
+                                                                                                                                                    node: Some(
+                                                                                                                                                        String(
+                                                                                                                                                            String {
+                                                                                                                                                                sval: "film_id",
+                                                                                                                                                            },
+                                                                                                                                                        ),
+                                                                                                                                                    ),
+                                                                                                                                                },
+                                                                                                                                            ],
+                                                                                                                                            location: 133,
+                                                                                                                                        },
+                                                                                                                                    ),
+                                                                                                                                ),
+                                                                                                                            },
+                                                                                                                        ),
+                                                                                                                        rexpr: Some(
+                                                                                                                            Node {
+                                                                                                                                node: Some(
+                                                                                                                                    ColumnRef(
+                                                                                                                                        ColumnRef {
+                                                                                                                                            fields: [
+                                                                                                                                                Node {
+                                                                                                                                                    node: Some(
+                                                                                                                                                        String(
+                                                                                                                                                            String {
+                                                                                                                                                                sval: "f",
+                                                                                                                                                            },
+                                                                                                                                                        ),
+                                                                                                                                                    ),
+                                                                                                                                                },
+                                                                                                                                                Node {
+                                                                                                                                                    node: Some(
+                                                                                                                                                        String(
+                                                                                                                                                            String {
+                                                                                                                                                                sval: "id",
+                                                                                                                                                            },
+                                                                                                                                                        ),
+                                                                                                                                                    ),
+                                                                                                                                                },
+                                                                                                                                            ],
+                                                                                                                                            location: 145,
+                                                                                                                                        },
+                                                                                                                                    ),
+                                                                                                                                ),
+                                                                                                                            },
+                                                                                                                        ),
+                                                                                                                        location: 143,
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    group_clause: [],
+                                                                                                    group_distinct: false,
+                                                                                                    having_clause: None,
+                                                                                                    window_clause: [],
+                                                                                                    values_lists: [],
+                                                                                                    sort_clause: [],
+                                                                                                    limit_offset: None,
+                                                                                                    limit_count: None,
+                                                                                                    limit_option: Default,
+                                                                                                    locking_clause: [],
+                                                                                                    with_clause: None,
+                                                                                                    op: SetopNone,
+                                                                                                    all: false,
+                                                                                                    larg: None,
+                                                                                                    rarg: None,
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                location: 85,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            location: 85,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        from_clause: [
+                                            Node {
+                                                node: Some(
+                                                    RangeVar(
+                                                        RangeVar {
+                                                            catalogname: "",
+                                                            schemaname: "",
+                                                            relname: "films",
+                                                            inh: true,
+                                                            relpersistence: "p",
+                                                            alias: Some(
+                                                                Alias {
+                                                                    aliasname: "f",
+                                                                    colnames: [],
+                                                                },
+                                                            ),
+                                                            location: 170,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        where_clause: Some(
+                                            Node {
+                                                node: Some(
+                                                    AExpr(
+                                                        AExpr {
+                                                            kind: AexprOp,
+                                                            name: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "=",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            lexpr: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        ColumnRef(
+                                                                            ColumnRef {
+                                                                                fields: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: "f",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: "kind",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                location: 184,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            rexpr: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 193,
+                                                                                val: Some(
+                                                                                    Sval(
+                                                                                        String {
+                                                                                            sval: "Comedy",
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            location: 191,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        group_clause: [],
+                                        group_distinct: false,
+                                        having_clause: None,
+                                        window_clause: [],
+                                        values_lists: [],
+                                        sort_clause: [],
+                                        limit_offset: None,
+                                        limit_count: None,
+                                        limit_option: Default,
+                                        locking_clause: [],
+                                        with_clause: None,
+                                        op: SetopNone,
+                                        all: false,
+                                        larg: None,
+                                        rarg: None,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    replace: false,
+                    options: [],
+                    with_check_option: NoCheckOption,
+                },
+            ),
+            range: 0..202,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0044@5.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0044@5.snap
@@ -1,0 +1,255 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE RECURSIVE VIEW public.nums_1_100 (n) AS VALUES (1) UNION ALL SELECT n+1 FROM nums_1_100 WHERE n < 100;"
+---
+Parse {
+    cst: SourceFile@0..109
+      Newline@0..1 "\n"
+      Create@1..7 "CREATE"
+      Whitespace@7..8 " "
+      Recursive@8..17 "RECURSIVE"
+      Whitespace@17..18 " "
+      View@18..22 "VIEW"
+      Whitespace@22..23 " "
+      Ident@23..29 "public"
+      Ascii46@29..30 "."
+      Ident@30..40 "nums_1_100"
+      Whitespace@40..41 " "
+      Ascii40@41..42 "("
+      Ident@42..43 "n"
+      Ascii41@43..44 ")"
+      Whitespace@44..45 " "
+      As@45..47 "AS"
+      Whitespace@47..48 " "
+      Values@48..54 "VALUES"
+      Whitespace@54..55 " "
+      Ascii40@55..56 "("
+      Iconst@56..57 "1"
+      Ascii41@57..58 ")"
+      Whitespace@58..59 " "
+      Union@59..64 "UNION"
+      Whitespace@64..65 " "
+      All@65..68 "ALL"
+      SelectStmt@68..109
+        Select@68..74 "SELECT"
+        Whitespace@74..75 " "
+        ResTarget@75..78
+          AExpr@75..78
+            ColumnRef@75..76
+              Ident@75..76 "n"
+            Ascii43@76..77 "+"
+            AConst@77..78
+              Iconst@77..78 "1"
+        Whitespace@78..79 " "
+        From@79..83 "FROM"
+        Whitespace@83..84 " "
+        RangeVar@84..94
+          Ident@84..94 "nums_1_100"
+        Whitespace@94..95 " "
+        Where@95..100 "WHERE"
+        Whitespace@100..101 " "
+        AExpr@101..108
+          ColumnRef@101..102
+            Ident@101..102 "n"
+          Whitespace@102..103 " "
+          Ascii60@103..104 "<"
+          Whitespace@104..105 " "
+          AConst@105..108
+            Iconst@105..108 "100"
+        Ascii59@108..109 ";"
+    ,
+    errors: [
+        SyntaxError(
+            "Expected Ascii59, found Whitespace",
+            68..68,
+        ),
+        SyntaxError(
+            "Invalid statement: syntax error at end of input",
+            1..26,
+        ),
+    ],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    AExpr(
+                                                        AExpr {
+                                                            kind: AexprOp,
+                                                            name: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "+",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            lexpr: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        ColumnRef(
+                                                                            ColumnRef {
+                                                                                fields: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: "n",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                location: 7,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            rexpr: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 9,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            location: 8,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [
+                        Node {
+                            node: Some(
+                                RangeVar(
+                                    RangeVar {
+                                        catalogname: "",
+                                        schemaname: "",
+                                        relname: "nums_1_100",
+                                        inh: true,
+                                        relpersistence: "p",
+                                        alias: None,
+                                        location: 16,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    where_clause: Some(
+                        Node {
+                            node: Some(
+                                AExpr(
+                                    AExpr {
+                                        kind: AexprOp,
+                                        name: [
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "<",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        lexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "n",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 33,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        rexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    AConst(
+                                                        AConst {
+                                                            isnull: false,
+                                                            location: 37,
+                                                            val: Some(
+                                                                Ival(
+                                                                    Integer {
+                                                                        ival: 100,
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 35,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 68..109,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0046@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0046@1.snap
@@ -1,0 +1,16 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: CREATE TYPE type1;
+---
+Parse {
+    cst: SourceFile@0..18
+      Create@0..6 "CREATE"
+      Whitespace@6..7 " "
+      TypeP@7..11 "TYPE"
+      Whitespace@11..12 " "
+      Ident@12..17 "type1"
+      Ascii59@17..18 ";"
+    ,
+    errors: [],
+    stmts: [],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0046@2.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0046@2.snap
@@ -1,0 +1,30 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE TYPE type1 AS (attr1 int4, attr2 bool);"
+---
+Parse {
+    cst: SourceFile@0..47
+      Newline@0..1 "\n"
+      Create@1..7 "CREATE"
+      Whitespace@7..8 " "
+      TypeP@8..12 "TYPE"
+      Whitespace@12..13 " "
+      Ident@13..18 "type1"
+      Whitespace@18..19 " "
+      As@19..21 "AS"
+      Whitespace@21..22 " "
+      Ascii40@22..23 "("
+      Ident@23..28 "attr1"
+      Whitespace@28..29 " "
+      Ident@29..33 "int4"
+      Ascii44@33..34 ","
+      Whitespace@34..35 " "
+      Ident@35..40 "attr2"
+      Whitespace@40..41 " "
+      Ident@41..45 "bool"
+      Ascii41@45..46 ")"
+      Ascii59@46..47 ";"
+    ,
+    errors: [],
+    stmts: [],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0046@3.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0046@3.snap
@@ -1,0 +1,34 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE TYPE type1 AS (attr1 int4 COLLATE collation1, attr2 bool);"
+---
+Parse {
+    cst: SourceFile@0..66
+      Newline@0..1 "\n"
+      Create@1..7 "CREATE"
+      Whitespace@7..8 " "
+      TypeP@8..12 "TYPE"
+      Whitespace@12..13 " "
+      Ident@13..18 "type1"
+      Whitespace@18..19 " "
+      As@19..21 "AS"
+      Whitespace@21..22 " "
+      Ascii40@22..23 "("
+      Ident@23..28 "attr1"
+      Whitespace@28..29 " "
+      Ident@29..33 "int4"
+      Whitespace@33..34 " "
+      Collate@34..41 "COLLATE"
+      Whitespace@41..42 " "
+      Ident@42..52 "collation1"
+      Ascii44@52..53 ","
+      Whitespace@53..54 " "
+      Ident@54..59 "attr2"
+      Whitespace@59..60 " "
+      Ident@60..64 "bool"
+      Ascii41@64..65 ")"
+      Ascii59@65..66 ";"
+    ,
+    errors: [],
+    stmts: [],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0046@4.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0046@4.snap
@@ -1,0 +1,80 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE TYPE type1 AS ENUM ('value1', 'value2', 'value3');"
+---
+Parse {
+    cst: SourceFile@0..58
+      Newline@0..1 "\n"
+      CreateEnumStmt@1..58
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        TypeP@8..12 "TYPE"
+        Whitespace@12..13 " "
+        Ident@13..18 "type1"
+        Whitespace@18..19 " "
+        As@19..21 "AS"
+        Whitespace@21..22 " "
+        EnumP@22..26 "ENUM"
+        Whitespace@26..27 " "
+        Ascii40@27..28 "("
+        Sconst@28..36 "'value1'"
+        Ascii44@36..37 ","
+        Whitespace@37..38 " "
+        Sconst@38..46 "'value2'"
+        Ascii44@46..47 ","
+        Whitespace@47..48 " "
+        Sconst@48..56 "'value3'"
+        Ascii41@56..57 ")"
+        Ascii59@57..58 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateEnumStmt(
+                CreateEnumStmt {
+                    type_name: [
+                        Node {
+                            node: Some(
+                                String(
+                                    String {
+                                        sval: "type1",
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    vals: [
+                        Node {
+                            node: Some(
+                                String(
+                                    String {
+                                        sval: "value1",
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                String(
+                                    String {
+                                        sval: "value2",
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                String(
+                                    String {
+                                        sval: "value3",
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                },
+            ),
+            range: 0..57,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0046@5.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0046@5.snap
@@ -1,0 +1,93 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE TYPE type1 AS RANGE (subtype = int4);"
+---
+Parse {
+    cst: SourceFile@0..45
+      Newline@0..1 "\n"
+      CreateRangeStmt@1..45
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        TypeP@8..12 "TYPE"
+        Whitespace@12..13 " "
+        Ident@13..18 "type1"
+        Whitespace@18..19 " "
+        As@19..21 "AS"
+        Whitespace@21..22 " "
+        Range@22..27 "RANGE"
+        Whitespace@27..28 " "
+        Ascii40@28..29 "("
+        DefElem@29..43
+          Ident@29..36 "subtype"
+          Whitespace@36..37 " "
+          Ascii61@37..38 "="
+          Whitespace@38..39 " "
+          TypeName@39..43
+            Ident@39..43 "int4"
+        Ascii41@43..44 ")"
+        Ascii59@44..45 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateRangeStmt(
+                CreateRangeStmt {
+                    type_name: [
+                        Node {
+                            node: Some(
+                                String(
+                                    String {
+                                        sval: "type1",
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    params: [
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "subtype",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    TypeName(
+                                                        TypeName {
+                                                            names: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "int4",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            type_oid: 0,
+                                                            setof: false,
+                                                            pct_type: false,
+                                                            typmods: [],
+                                                            typemod: -1,
+                                                            array_bounds: [],
+                                                            location: 38,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 28,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                },
+            ),
+            range: 0..44,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0046@6.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0046@6.snap
@@ -1,0 +1,159 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE TYPE type1 AS RANGE (subtype = int4, receive = receive_func, passedbyvalue);"
+---
+Parse {
+    cst: SourceFile@0..84
+      Newline@0..1 "\n"
+      CreateRangeStmt@1..84
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        TypeP@8..12 "TYPE"
+        Whitespace@12..13 " "
+        Ident@13..18 "type1"
+        Whitespace@18..19 " "
+        As@19..21 "AS"
+        Whitespace@21..22 " "
+        Range@22..27 "RANGE"
+        Whitespace@27..28 " "
+        Ascii40@28..29 "("
+        DefElem@29..43
+          Ident@29..36 "subtype"
+          Whitespace@36..37 " "
+          Ascii61@37..38 "="
+          Whitespace@38..39 " "
+          TypeName@39..43
+            Ident@39..43 "int4"
+        Ascii44@43..44 ","
+        Whitespace@44..45 " "
+        DefElem@45..67
+          Ident@45..52 "receive"
+          Whitespace@52..53 " "
+          Ascii61@53..54 "="
+          Whitespace@54..55 " "
+          TypeName@55..67
+            Ident@55..67 "receive_func"
+        Ascii44@67..68 ","
+        Whitespace@68..69 " "
+        DefElem@69..82
+          Ident@69..82 "passedbyvalue"
+        Ascii41@82..83 ")"
+        Ascii59@83..84 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateRangeStmt(
+                CreateRangeStmt {
+                    type_name: [
+                        Node {
+                            node: Some(
+                                String(
+                                    String {
+                                        sval: "type1",
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    params: [
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "subtype",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    TypeName(
+                                                        TypeName {
+                                                            names: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "int4",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            type_oid: 0,
+                                                            setof: false,
+                                                            pct_type: false,
+                                                            typmods: [],
+                                                            typemod: -1,
+                                                            array_bounds: [],
+                                                            location: 38,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 28,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "receive",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    TypeName(
+                                                        TypeName {
+                                                            names: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "receive_func",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            type_oid: 0,
+                                                            setof: false,
+                                                            pct_type: false,
+                                                            typmods: [],
+                                                            typemod: -1,
+                                                            array_bounds: [],
+                                                            location: 54,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 44,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "passedbyvalue",
+                                        arg: None,
+                                        defaction: DefelemUnspec,
+                                        location: 68,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                },
+            ),
+            range: 0..83,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0046@7.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0046@7.snap
@@ -1,0 +1,32 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE TYPE type1 (input = input1, output = output1);"
+---
+Parse {
+    cst: SourceFile@0..54
+      Newline@0..1 "\n"
+      Create@1..7 "CREATE"
+      Whitespace@7..8 " "
+      TypeP@8..12 "TYPE"
+      Whitespace@12..13 " "
+      Ident@13..18 "type1"
+      Whitespace@18..19 " "
+      Ascii40@19..20 "("
+      InputP@20..25 "input"
+      Whitespace@25..26 " "
+      Ascii61@26..27 "="
+      Whitespace@27..28 " "
+      Ident@28..34 "input1"
+      Ascii44@34..35 ","
+      Whitespace@35..36 " "
+      Ident@36..42 "output"
+      Whitespace@42..43 " "
+      Ascii61@43..44 "="
+      Whitespace@44..45 " "
+      Ident@45..52 "output1"
+      Ascii41@52..53 ")"
+      Ascii59@53..54 ";"
+    ,
+    errors: [],
+    stmts: [],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0046@8.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0046@8.snap
@@ -1,0 +1,35 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE TYPE type1 (input = input1, output = output1, passedbyvalue);"
+---
+Parse {
+    cst: SourceFile@0..69
+      Newline@0..1 "\n"
+      Create@1..7 "CREATE"
+      Whitespace@7..8 " "
+      TypeP@8..12 "TYPE"
+      Whitespace@12..13 " "
+      Ident@13..18 "type1"
+      Whitespace@18..19 " "
+      Ascii40@19..20 "("
+      InputP@20..25 "input"
+      Whitespace@25..26 " "
+      Ascii61@26..27 "="
+      Whitespace@27..28 " "
+      Ident@28..34 "input1"
+      Ascii44@34..35 ","
+      Whitespace@35..36 " "
+      Ident@36..42 "output"
+      Whitespace@42..43 " "
+      Ascii61@43..44 "="
+      Whitespace@44..45 " "
+      Ident@45..52 "output1"
+      Ascii44@52..53 ","
+      Whitespace@53..54 " "
+      Ident@54..67 "passedbyvalue"
+      Ascii41@67..68 ")"
+      Ascii59@68..69 ";"
+    ,
+    errors: [],
+    stmts: [],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0051@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0051@1.snap
@@ -1,0 +1,88 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: CREATE UNIQUE INDEX title_idx ON films (title);
+---
+Parse {
+    cst: SourceFile@0..47
+      IndexStmt@0..47
+        Create@0..6 "CREATE"
+        Whitespace@6..7 " "
+        Unique@7..13 "UNIQUE"
+        Whitespace@13..14 " "
+        Index@14..19 "INDEX"
+        Whitespace@19..20 " "
+        Ident@20..29 "title_idx"
+        Whitespace@29..30 " "
+        On@30..32 "ON"
+        Whitespace@32..33 " "
+        RangeVar@33..38
+          Ident@33..38 "films"
+        Whitespace@38..39 " "
+        Ascii40@39..40 "("
+        IndexElem@40..45
+          Ident@40..45 "title"
+        Ascii41@45..46 ")"
+        Ascii59@46..47 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: IndexStmt(
+                IndexStmt {
+                    idxname: "title_idx",
+                    relation: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "films",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 33,
+                        },
+                    ),
+                    access_method: "btree",
+                    table_space: "",
+                    index_params: [
+                        Node {
+                            node: Some(
+                                IndexElem(
+                                    IndexElem {
+                                        name: "title",
+                                        expr: None,
+                                        indexcolname: "",
+                                        collation: [],
+                                        opclass: [],
+                                        opclassopts: [],
+                                        ordering: SortbyDefault,
+                                        nulls_ordering: SortbyNullsDefault,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    index_including_params: [],
+                    options: [],
+                    where_clause: None,
+                    exclude_op_names: [],
+                    idxcomment: "",
+                    index_oid: 0,
+                    old_node: 0,
+                    old_create_subid: 0,
+                    old_first_relfilenode_subid: 0,
+                    unique: true,
+                    nulls_not_distinct: false,
+                    primary: false,
+                    isconstraint: false,
+                    deferrable: false,
+                    initdeferred: false,
+                    transformed: false,
+                    concurrent: false,
+                    if_not_exists: false,
+                    reset_default_tblspc: false,
+                },
+            ),
+            range: 0..46,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0051@10.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0051@10.snap
@@ -1,0 +1,170 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE INDEX pointloc ON points USING gist (box(location,location));"
+---
+Parse {
+    cst: SourceFile@0..69
+      Newline@0..1 "\n"
+      IndexStmt@1..69
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        Index@8..13 "INDEX"
+        Whitespace@13..14 " "
+        Ident@14..22 "pointloc"
+        Whitespace@22..23 " "
+        On@23..25 "ON"
+        Whitespace@25..26 " "
+        RangeVar@26..32
+          Ident@26..32 "points"
+        Whitespace@32..33 " "
+        Using@33..38 "USING"
+        Whitespace@38..39 " "
+        Ident@39..43 "gist"
+        Whitespace@43..44 " "
+        Ascii40@44..45 "("
+        IndexElem@45..66
+          FuncCall@45..66
+            Ident@45..48 "box"
+            Ascii40@48..49 "("
+            ColumnRef@49..57
+              Location@49..57 "location"
+            Ascii44@57..58 ","
+            ColumnRef@58..66
+              Location@58..66 "location"
+        Ascii41@66..67 ")"
+        Ascii41@67..68 ")"
+        Ascii59@68..69 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: IndexStmt(
+                IndexStmt {
+                    idxname: "pointloc",
+                    relation: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "points",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 25,
+                        },
+                    ),
+                    access_method: "gist",
+                    table_space: "",
+                    index_params: [
+                        Node {
+                            node: Some(
+                                IndexElem(
+                                    IndexElem {
+                                        name: "",
+                                        expr: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "box",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        ColumnRef(
+                                                                            ColumnRef {
+                                                                                fields: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: "location",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                location: 48,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        ColumnRef(
+                                                                            ColumnRef {
+                                                                                fields: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: "location",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                location: 57,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 44,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        indexcolname: "",
+                                        collation: [],
+                                        opclass: [],
+                                        opclassopts: [],
+                                        ordering: SortbyDefault,
+                                        nulls_ordering: SortbyNullsDefault,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    index_including_params: [],
+                    options: [],
+                    where_clause: None,
+                    exclude_op_names: [],
+                    idxcomment: "",
+                    index_oid: 0,
+                    old_node: 0,
+                    old_create_subid: 0,
+                    old_first_relfilenode_subid: 0,
+                    unique: false,
+                    nulls_not_distinct: false,
+                    primary: false,
+                    isconstraint: false,
+                    deferrable: false,
+                    initdeferred: false,
+                    transformed: false,
+                    concurrent: false,
+                    if_not_exists: false,
+                    reset_default_tblspc: false,
+                },
+            ),
+            range: 0..68,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0051@11.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0051@11.snap
@@ -1,0 +1,89 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE INDEX CONCURRENTLY sales_quantity_index ON sales_table (quantity);"
+---
+Parse {
+    cst: SourceFile@0..74
+      Newline@0..1 "\n"
+      IndexStmt@1..74
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        Index@8..13 "INDEX"
+        Whitespace@13..14 " "
+        Concurrently@14..26 "CONCURRENTLY"
+        Whitespace@26..27 " "
+        Ident@27..47 "sales_quantity_index"
+        Whitespace@47..48 " "
+        On@48..50 "ON"
+        Whitespace@50..51 " "
+        RangeVar@51..62
+          Ident@51..62 "sales_table"
+        Whitespace@62..63 " "
+        Ascii40@63..64 "("
+        IndexElem@64..72
+          Ident@64..72 "quantity"
+        Ascii41@72..73 ")"
+        Ascii59@73..74 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: IndexStmt(
+                IndexStmt {
+                    idxname: "sales_quantity_index",
+                    relation: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "sales_table",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 50,
+                        },
+                    ),
+                    access_method: "btree",
+                    table_space: "",
+                    index_params: [
+                        Node {
+                            node: Some(
+                                IndexElem(
+                                    IndexElem {
+                                        name: "quantity",
+                                        expr: None,
+                                        indexcolname: "",
+                                        collation: [],
+                                        opclass: [],
+                                        opclassopts: [],
+                                        ordering: SortbyDefault,
+                                        nulls_ordering: SortbyNullsDefault,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    index_including_params: [],
+                    options: [],
+                    where_clause: None,
+                    exclude_op_names: [],
+                    idxcomment: "",
+                    index_oid: 0,
+                    old_node: 0,
+                    old_create_subid: 0,
+                    old_first_relfilenode_subid: 0,
+                    unique: false,
+                    nulls_not_distinct: false,
+                    primary: false,
+                    isconstraint: false,
+                    deferrable: false,
+                    initdeferred: false,
+                    transformed: false,
+                    concurrent: true,
+                    if_not_exists: false,
+                    reset_default_tblspc: false,
+                },
+            ),
+            range: 0..73,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0051@2.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0051@2.snap
@@ -1,0 +1,133 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE UNIQUE INDEX title_idx ON films (title) INCLUDE (director, rating);"
+---
+Parse {
+    cst: SourceFile@0..75
+      Newline@0..1 "\n"
+      IndexStmt@1..75
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        Unique@8..14 "UNIQUE"
+        Whitespace@14..15 " "
+        Index@15..20 "INDEX"
+        Whitespace@20..21 " "
+        Ident@21..30 "title_idx"
+        Whitespace@30..31 " "
+        On@31..33 "ON"
+        Whitespace@33..34 " "
+        RangeVar@34..39
+          Ident@34..39 "films"
+        Whitespace@39..40 " "
+        Ascii40@40..41 "("
+        IndexElem@41..46
+          Ident@41..46 "title"
+        Ascii41@46..47 ")"
+        Whitespace@47..48 " "
+        Include@48..55 "INCLUDE"
+        Whitespace@55..56 " "
+        Ascii40@56..57 "("
+        IndexElem@57..65
+          Ident@57..65 "director"
+        Ascii44@65..66 ","
+        Whitespace@66..67 " "
+        IndexElem@67..73
+          Ident@67..73 "rating"
+        Ascii41@73..74 ")"
+        Ascii59@74..75 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: IndexStmt(
+                IndexStmt {
+                    idxname: "title_idx",
+                    relation: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "films",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 33,
+                        },
+                    ),
+                    access_method: "btree",
+                    table_space: "",
+                    index_params: [
+                        Node {
+                            node: Some(
+                                IndexElem(
+                                    IndexElem {
+                                        name: "title",
+                                        expr: None,
+                                        indexcolname: "",
+                                        collation: [],
+                                        opclass: [],
+                                        opclassopts: [],
+                                        ordering: SortbyDefault,
+                                        nulls_ordering: SortbyNullsDefault,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    index_including_params: [
+                        Node {
+                            node: Some(
+                                IndexElem(
+                                    IndexElem {
+                                        name: "director",
+                                        expr: None,
+                                        indexcolname: "",
+                                        collation: [],
+                                        opclass: [],
+                                        opclassopts: [],
+                                        ordering: SortbyDefault,
+                                        nulls_ordering: SortbyNullsDefault,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                IndexElem(
+                                    IndexElem {
+                                        name: "rating",
+                                        expr: None,
+                                        indexcolname: "",
+                                        collation: [],
+                                        opclass: [],
+                                        opclassopts: [],
+                                        ordering: SortbyDefault,
+                                        nulls_ordering: SortbyNullsDefault,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    options: [],
+                    where_clause: None,
+                    exclude_op_names: [],
+                    idxcomment: "",
+                    index_oid: 0,
+                    old_node: 0,
+                    old_create_subid: 0,
+                    old_first_relfilenode_subid: 0,
+                    unique: true,
+                    nulls_not_distinct: false,
+                    primary: false,
+                    isconstraint: false,
+                    deferrable: false,
+                    initdeferred: false,
+                    transformed: false,
+                    concurrent: false,
+                    if_not_exists: false,
+                    reset_default_tblspc: false,
+                },
+            ),
+            range: 0..74,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0051@3.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0051@3.snap
@@ -1,0 +1,140 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE INDEX title_idx ON films (title) WITH (deduplicate_items = off);"
+---
+Parse {
+    cst: SourceFile@0..72
+      Newline@0..1 "\n"
+      IndexStmt@1..72
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        Index@8..13 "INDEX"
+        Whitespace@13..14 " "
+        Ident@14..23 "title_idx"
+        Whitespace@23..24 " "
+        On@24..26 "ON"
+        Whitespace@26..27 " "
+        RangeVar@27..32
+          Ident@27..32 "films"
+        Whitespace@32..33 " "
+        Ascii40@33..34 "("
+        IndexElem@34..39
+          Ident@34..39 "title"
+        Ascii41@39..40 ")"
+        Whitespace@40..41 " "
+        With@41..45 "WITH"
+        Whitespace@45..46 " "
+        Ascii40@46..47 "("
+        DefElem@47..70
+          Ident@47..64 "deduplicate_items"
+          Whitespace@64..65 " "
+          Ascii61@65..66 "="
+          Whitespace@66..67 " "
+          TypeName@67..70
+            Off@67..70 "off"
+        Ascii41@70..71 ")"
+        Ascii59@71..72 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: IndexStmt(
+                IndexStmt {
+                    idxname: "title_idx",
+                    relation: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "films",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 26,
+                        },
+                    ),
+                    access_method: "btree",
+                    table_space: "",
+                    index_params: [
+                        Node {
+                            node: Some(
+                                IndexElem(
+                                    IndexElem {
+                                        name: "title",
+                                        expr: None,
+                                        indexcolname: "",
+                                        collation: [],
+                                        opclass: [],
+                                        opclassopts: [],
+                                        ordering: SortbyDefault,
+                                        nulls_ordering: SortbyNullsDefault,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    index_including_params: [],
+                    options: [
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "deduplicate_items",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    TypeName(
+                                                        TypeName {
+                                                            names: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "off",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            type_oid: 0,
+                                                            setof: false,
+                                                            pct_type: false,
+                                                            typmods: [],
+                                                            typemod: -1,
+                                                            array_bounds: [],
+                                                            location: 66,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 46,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    where_clause: None,
+                    exclude_op_names: [],
+                    idxcomment: "",
+                    index_oid: 0,
+                    old_node: 0,
+                    old_create_subid: 0,
+                    old_first_relfilenode_subid: 0,
+                    unique: false,
+                    nulls_not_distinct: false,
+                    primary: false,
+                    isconstraint: false,
+                    deferrable: false,
+                    initdeferred: false,
+                    transformed: false,
+                    concurrent: false,
+                    if_not_exists: false,
+                    reset_default_tblspc: false,
+                },
+            ),
+            range: 0..71,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0051@4.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0051@4.snap
@@ -1,0 +1,143 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE INDEX ON films ((lower(title)));"
+---
+Parse {
+    cst: SourceFile@0..40
+      Newline@0..1 "\n"
+      IndexStmt@1..40
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        Index@8..13 "INDEX"
+        Whitespace@13..14 " "
+        On@14..16 "ON"
+        Whitespace@16..17 " "
+        RangeVar@17..22
+          Ident@17..22 "films"
+        Whitespace@22..23 " "
+        Ascii40@23..24 "("
+        Ascii40@24..25 "("
+        IndexElem@25..36
+          FuncCall@25..36
+            Ident@25..30 "lower"
+            Ascii40@30..31 "("
+            ColumnRef@31..36
+              Ident@31..36 "title"
+        Ascii41@36..37 ")"
+        Ascii41@37..38 ")"
+        Ascii41@38..39 ")"
+        Ascii59@39..40 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: IndexStmt(
+                IndexStmt {
+                    idxname: "",
+                    relation: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "films",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 16,
+                        },
+                    ),
+                    access_method: "btree",
+                    table_space: "",
+                    index_params: [
+                        Node {
+                            node: Some(
+                                IndexElem(
+                                    IndexElem {
+                                        name: "",
+                                        expr: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "lower",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        ColumnRef(
+                                                                            ColumnRef {
+                                                                                fields: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: "title",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                location: 30,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 24,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        indexcolname: "",
+                                        collation: [],
+                                        opclass: [],
+                                        opclassopts: [],
+                                        ordering: SortbyDefault,
+                                        nulls_ordering: SortbyNullsDefault,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    index_including_params: [],
+                    options: [],
+                    where_clause: None,
+                    exclude_op_names: [],
+                    idxcomment: "",
+                    index_oid: 0,
+                    old_node: 0,
+                    old_create_subid: 0,
+                    old_first_relfilenode_subid: 0,
+                    unique: false,
+                    nulls_not_distinct: false,
+                    primary: false,
+                    isconstraint: false,
+                    deferrable: false,
+                    initdeferred: false,
+                    transformed: false,
+                    concurrent: false,
+                    if_not_exists: false,
+                    reset_default_tblspc: false,
+                },
+            ),
+            range: 0..39,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0051@5.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0051@5.snap
@@ -1,0 +1,101 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE INDEX title_idx_german ON films (title COLLATE \"de_DE\");"
+---
+Parse {
+    cst: SourceFile@0..64
+      Newline@0..1 "\n"
+      IndexStmt@1..64
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        Index@8..13 "INDEX"
+        Whitespace@13..14 " "
+        Ident@14..30 "title_idx_german"
+        Whitespace@30..31 " "
+        On@31..33 "ON"
+        Whitespace@33..34 " "
+        RangeVar@34..39
+          Ident@34..39 "films"
+        Whitespace@39..40 " "
+        Ascii40@40..41 "("
+        IndexElem@41..62
+          Ident@41..46 "title"
+          Whitespace@46..47 " "
+          Collate@47..54 "COLLATE"
+          Whitespace@54..55 " "
+          Ident@55..62 "\"de_DE\""
+        Ascii41@62..63 ")"
+        Ascii59@63..64 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: IndexStmt(
+                IndexStmt {
+                    idxname: "title_idx_german",
+                    relation: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "films",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 33,
+                        },
+                    ),
+                    access_method: "btree",
+                    table_space: "",
+                    index_params: [
+                        Node {
+                            node: Some(
+                                IndexElem(
+                                    IndexElem {
+                                        name: "title",
+                                        expr: None,
+                                        indexcolname: "",
+                                        collation: [
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "de_DE",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        opclass: [],
+                                        opclassopts: [],
+                                        ordering: SortbyDefault,
+                                        nulls_ordering: SortbyNullsDefault,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    index_including_params: [],
+                    options: [],
+                    where_clause: None,
+                    exclude_op_names: [],
+                    idxcomment: "",
+                    index_oid: 0,
+                    old_node: 0,
+                    old_create_subid: 0,
+                    old_first_relfilenode_subid: 0,
+                    unique: false,
+                    nulls_not_distinct: false,
+                    primary: false,
+                    isconstraint: false,
+                    deferrable: false,
+                    initdeferred: false,
+                    transformed: false,
+                    concurrent: false,
+                    if_not_exists: false,
+                    reset_default_tblspc: false,
+                },
+            ),
+            range: 0..63,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0051@6.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0051@6.snap
@@ -1,0 +1,91 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE INDEX title_idx_nulls_low ON films (title NULLS FIRST);"
+---
+Parse {
+    cst: SourceFile@0..63
+      Newline@0..1 "\n"
+      IndexStmt@1..63
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        Index@8..13 "INDEX"
+        Whitespace@13..14 " "
+        Ident@14..33 "title_idx_nulls_low"
+        Whitespace@33..34 " "
+        On@34..36 "ON"
+        Whitespace@36..37 " "
+        RangeVar@37..42
+          Ident@37..42 "films"
+        Whitespace@42..43 " "
+        Ascii40@43..44 "("
+        IndexElem@44..61
+          Ident@44..49 "title"
+          Whitespace@49..50 " "
+          NullsP@50..55 "NULLS"
+          Whitespace@55..56 " "
+          FirstP@56..61 "FIRST"
+        Ascii41@61..62 ")"
+        Ascii59@62..63 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: IndexStmt(
+                IndexStmt {
+                    idxname: "title_idx_nulls_low",
+                    relation: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "films",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 36,
+                        },
+                    ),
+                    access_method: "btree",
+                    table_space: "",
+                    index_params: [
+                        Node {
+                            node: Some(
+                                IndexElem(
+                                    IndexElem {
+                                        name: "title",
+                                        expr: None,
+                                        indexcolname: "",
+                                        collation: [],
+                                        opclass: [],
+                                        opclassopts: [],
+                                        ordering: SortbyDefault,
+                                        nulls_ordering: SortbyNullsFirst,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    index_including_params: [],
+                    options: [],
+                    where_clause: None,
+                    exclude_op_names: [],
+                    idxcomment: "",
+                    index_oid: 0,
+                    old_node: 0,
+                    old_create_subid: 0,
+                    old_first_relfilenode_subid: 0,
+                    unique: false,
+                    nulls_not_distinct: false,
+                    primary: false,
+                    isconstraint: false,
+                    deferrable: false,
+                    initdeferred: false,
+                    transformed: false,
+                    concurrent: false,
+                    if_not_exists: false,
+                    reset_default_tblspc: false,
+                },
+            ),
+            range: 0..62,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0051@7.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0051@7.snap
@@ -1,0 +1,124 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE UNIQUE INDEX title_idx ON films (title) WITH (fillfactor = 70);"
+---
+Parse {
+    cst: SourceFile@0..71
+      Newline@0..1 "\n"
+      IndexStmt@1..71
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        Unique@8..14 "UNIQUE"
+        Whitespace@14..15 " "
+        Index@15..20 "INDEX"
+        Whitespace@20..21 " "
+        Ident@21..30 "title_idx"
+        Whitespace@30..31 " "
+        On@31..33 "ON"
+        Whitespace@33..34 " "
+        RangeVar@34..39
+          Ident@34..39 "films"
+        Whitespace@39..40 " "
+        Ascii40@40..41 "("
+        IndexElem@41..46
+          Ident@41..46 "title"
+        Ascii41@46..47 ")"
+        Whitespace@47..48 " "
+        With@48..52 "WITH"
+        Whitespace@52..53 " "
+        Ascii40@53..54 "("
+        DefElem@54..69
+          Ident@54..64 "fillfactor"
+          Whitespace@64..65 " "
+          Ascii61@65..66 "="
+          Whitespace@66..67 " "
+          Iconst@67..69 "70"
+        Ascii41@69..70 ")"
+        Ascii59@70..71 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: IndexStmt(
+                IndexStmt {
+                    idxname: "title_idx",
+                    relation: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "films",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 33,
+                        },
+                    ),
+                    access_method: "btree",
+                    table_space: "",
+                    index_params: [
+                        Node {
+                            node: Some(
+                                IndexElem(
+                                    IndexElem {
+                                        name: "title",
+                                        expr: None,
+                                        indexcolname: "",
+                                        collation: [],
+                                        opclass: [],
+                                        opclassopts: [],
+                                        ordering: SortbyDefault,
+                                        nulls_ordering: SortbyNullsDefault,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    index_including_params: [],
+                    options: [
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "fillfactor",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    Integer(
+                                                        Integer {
+                                                            ival: 70,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 53,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    where_clause: None,
+                    exclude_op_names: [],
+                    idxcomment: "",
+                    index_oid: 0,
+                    old_node: 0,
+                    old_create_subid: 0,
+                    old_first_relfilenode_subid: 0,
+                    unique: true,
+                    nulls_not_distinct: false,
+                    primary: false,
+                    isconstraint: false,
+                    deferrable: false,
+                    initdeferred: false,
+                    transformed: false,
+                    concurrent: false,
+                    if_not_exists: false,
+                    reset_default_tblspc: false,
+                },
+            ),
+            range: 0..70,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0051@8.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0051@8.snap
@@ -1,0 +1,144 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE INDEX gin_idx ON documents_table USING GIN (locations) WITH (fastupdate = off);"
+---
+Parse {
+    cst: SourceFile@0..87
+      Newline@0..1 "\n"
+      IndexStmt@1..87
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        Index@8..13 "INDEX"
+        Whitespace@13..14 " "
+        Ident@14..21 "gin_idx"
+        Whitespace@21..22 " "
+        On@22..24 "ON"
+        Whitespace@24..25 " "
+        RangeVar@25..40
+          Ident@25..40 "documents_table"
+        Whitespace@40..41 " "
+        Using@41..46 "USING"
+        Whitespace@46..47 " "
+        Ident@47..50 "GIN"
+        Whitespace@50..51 " "
+        Ascii40@51..52 "("
+        IndexElem@52..61
+          Ident@52..61 "locations"
+        Ascii41@61..62 ")"
+        Whitespace@62..63 " "
+        With@63..67 "WITH"
+        Whitespace@67..68 " "
+        Ascii40@68..69 "("
+        DefElem@69..85
+          Ident@69..79 "fastupdate"
+          Whitespace@79..80 " "
+          Ascii61@80..81 "="
+          Whitespace@81..82 " "
+          TypeName@82..85
+            Off@82..85 "off"
+        Ascii41@85..86 ")"
+        Ascii59@86..87 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: IndexStmt(
+                IndexStmt {
+                    idxname: "gin_idx",
+                    relation: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "documents_table",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 24,
+                        },
+                    ),
+                    access_method: "gin",
+                    table_space: "",
+                    index_params: [
+                        Node {
+                            node: Some(
+                                IndexElem(
+                                    IndexElem {
+                                        name: "locations",
+                                        expr: None,
+                                        indexcolname: "",
+                                        collation: [],
+                                        opclass: [],
+                                        opclassopts: [],
+                                        ordering: SortbyDefault,
+                                        nulls_ordering: SortbyNullsDefault,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    index_including_params: [],
+                    options: [
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "fastupdate",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    TypeName(
+                                                        TypeName {
+                                                            names: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "off",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            type_oid: 0,
+                                                            setof: false,
+                                                            pct_type: false,
+                                                            typmods: [],
+                                                            typemod: -1,
+                                                            array_bounds: [],
+                                                            location: 81,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 68,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    where_clause: None,
+                    exclude_op_names: [],
+                    idxcomment: "",
+                    index_oid: 0,
+                    old_node: 0,
+                    old_create_subid: 0,
+                    old_first_relfilenode_subid: 0,
+                    unique: false,
+                    nulls_not_distinct: false,
+                    primary: false,
+                    isconstraint: false,
+                    deferrable: false,
+                    initdeferred: false,
+                    transformed: false,
+                    concurrent: false,
+                    if_not_exists: false,
+                    reset_default_tblspc: false,
+                },
+            ),
+            range: 0..86,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0051@9.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0051@9.snap
@@ -1,0 +1,91 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "\nCREATE INDEX code_idx ON films (code) TABLESPACE indexspace;"
+---
+Parse {
+    cst: SourceFile@0..61
+      Newline@0..1 "\n"
+      IndexStmt@1..61
+        Create@1..7 "CREATE"
+        Whitespace@7..8 " "
+        Index@8..13 "INDEX"
+        Whitespace@13..14 " "
+        Ident@14..22 "code_idx"
+        Whitespace@22..23 " "
+        On@23..25 "ON"
+        Whitespace@25..26 " "
+        RangeVar@26..31
+          Ident@26..31 "films"
+        Whitespace@31..32 " "
+        Ascii40@32..33 "("
+        IndexElem@33..37
+          Ident@33..37 "code"
+        Ascii41@37..38 ")"
+        Whitespace@38..39 " "
+        Tablespace@39..49 "TABLESPACE"
+        Whitespace@49..50 " "
+        Ident@50..60 "indexspace"
+        Ascii59@60..61 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: IndexStmt(
+                IndexStmt {
+                    idxname: "code_idx",
+                    relation: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "films",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 25,
+                        },
+                    ),
+                    access_method: "btree",
+                    table_space: "indexspace",
+                    index_params: [
+                        Node {
+                            node: Some(
+                                IndexElem(
+                                    IndexElem {
+                                        name: "code",
+                                        expr: None,
+                                        indexcolname: "",
+                                        collation: [],
+                                        opclass: [],
+                                        opclassopts: [],
+                                        ordering: SortbyDefault,
+                                        nulls_ordering: SortbyNullsDefault,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    index_including_params: [],
+                    options: [],
+                    where_clause: None,
+                    exclude_op_names: [],
+                    idxcomment: "",
+                    index_oid: 0,
+                    old_node: 0,
+                    old_create_subid: 0,
+                    old_first_relfilenode_subid: 0,
+                    unique: false,
+                    nulls_not_distinct: false,
+                    primary: false,
+                    isconstraint: false,
+                    deferrable: false,
+                    initdeferred: false,
+                    transformed: false,
+                    concurrent: false,
+                    if_not_exists: false,
+                    reset_default_tblspc: false,
+                },
+            ),
+            range: 0..60,
+        },
+    ],
+}

--- a/crates/parser/tests/statement_parser_test.rs
+++ b/crates/parser/tests/statement_parser_test.rs
@@ -26,6 +26,8 @@ fn valid_statements() {
         let cases = split_with_parser(&contents).unwrap();
 
         for (i, case) in cases.iter().enumerate() {
+            let case = format!("{};", case);
+
             debug!("Parsing statement {}\n{}", test_name, case);
 
             let result = panic::catch_unwind(|| parse_source(&case));

--- a/crates/parser/tests/statement_parser_test.rs
+++ b/crates/parser/tests/statement_parser_test.rs
@@ -1,7 +1,10 @@
-use std::fs;
 mod common;
+
+use insta::{assert_debug_snapshot, Settings};
 use log::{debug, info};
 use parser::parse_source;
+use pg_query::split_with_parser;
+use std::{fs, panic};
 
 const VALID_STATEMENTS_PATH: &str = "tests/data/statements/valid/";
 
@@ -15,29 +18,38 @@ fn valid_statements() {
         .collect();
     paths.sort_by_key(|dir| dir.path());
 
-    paths.iter().for_each(|f| {
+    for f in paths.iter() {
         let path = f.path();
-        let file_name = path.file_name().unwrap();
-        let test_name = file_name.to_str().unwrap().replace(".sql", "");
+        let test_name = path.file_stem().unwrap().to_str().unwrap();
 
         let contents = fs::read_to_string(&path).unwrap();
+        let cases = split_with_parser(&contents).unwrap();
 
-        debug!("Parsing statement {}\n{}", test_name, contents);
+        for (i, case) in cases.iter().enumerate() {
+            debug!("Parsing statement {}\n{}", test_name, case);
 
-        let result = std::panic::catch_unwind(|| parse_source(&contents));
-        if result.is_err() {
-            assert!(
-                false,
-                "Failed to parse statement {}:\n{}",
-                test_name, contents
-            );
-        } else {
-            info!(
-                "Successfully parsed statement {}\n'{}'\n{:#?}",
-                test_name,
-                contents,
-                result.unwrap().cst
-            );
+            let result = panic::catch_unwind(|| parse_source(&case));
+
+            if result.is_err() {
+                assert!(false, "Failed to parse statement {}:\n{}", test_name, case);
+            } else {
+                info!(
+                    "Successfully parsed statement {}\n'{}'\n{:#?}",
+                    test_name,
+                    case,
+                    result.as_ref().unwrap().cst
+                );
+            }
+
+            let mut settings = Settings::clone_current();
+            settings.set_input_file(&path);
+            settings.set_prepend_module_to_snapshot(false);
+            settings.set_description(case.to_string());
+            settings.set_omit_expression(true);
+            settings.set_snapshot_path("snapshots/statements/valid");
+            settings.set_snapshot_suffix((i + 1).to_string());
+
+            settings.bind(|| assert_debug_snapshot!(test_name, result.unwrap()));
         }
-    });
+    }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

follow-up for #82

## What is the current behavior?

no snapshots test

## What is the new behavior?

added snapshots test back in [crates/parser/tests/statement_parser_test.rs][1]

## Additional context

With named tests, snapshots will be named like: `create_table@1.snap` (where `1` is the statement number in the file)

@psteinroe lmk what you think about the output

[1]: https://github.com/supabase/postgres_lsp/pull/87/files#diff-b9af3a2376fef543bc5a740ed028bea8b2e7f537923efd553369484ea2db941b