### PR TITLE
feat: add support for create table like

### DIFF
--- a/crates/codegen/src/get_node_properties.rs
+++ b/crates/codegen/src/get_node_properties.rs
@@ -365,7 +365,11 @@ fn custom_handlers(node: &Node) -> TokenStream {
                     tokens.push(TokenProperty::from(Token::Key));
                 },
                 protobuf::ConstrType::ConstrForeign => tokens.push(TokenProperty::from(Token::References)),
+                protobuf::ConstrType::ConstrUnique => tokens.push(TokenProperty::from(Token::Unique)),
                 _ => panic!("Unknown Constraint {:#?}", n.contype()),
+            };
+            if n.options.len() > 0 {
+                tokens.push(TokenProperty::from(Token::With));
             }
         },
         "PartitionSpec" => quote! {
@@ -438,6 +442,29 @@ fn custom_handlers(node: &Node) -> TokenStream {
                 tokens.push(TokenProperty::from(Token::Of));
                 tokens.push(TokenProperty::from(Token::For));
                 tokens.push(TokenProperty::from(Token::Values));
+            }
+            if let Some(n) = &n.relation {
+                match n.relpersistence.as_str() {
+                    // Unlogged
+                    "u" => tokens.push(TokenProperty::from(Token::Unlogged)),
+                    // Temporary
+                    "t" => tokens.push(TokenProperty::from(Token::Temporary)),
+                    _ => {},
+                }
+                if n.inh {
+                    tokens.push(TokenProperty::from(Token::Inherits));
+                }
+            }
+        },
+        "TableLikeClause" => quote! {
+            tokens.push(TokenProperty::from(Token::Like));
+            // CREATE_TABLE_LIKE_ALL
+            if n.options == 0x7FFFFFFF {
+                tokens.push(TokenProperty::from(Token::Including));
+                tokens.push(TokenProperty::from(Token::All));
+            } else {
+                tokens.push(TokenProperty::from(Token::Excluding));
+                tokens.push(TokenProperty::from(Token::All));
             }
         },
         "PartitionBoundSpec" => quote! {

--- a/crates/parser/tests/data/statements/valid/0043.sql
+++ b/crates/parser/tests/data/statements/valid/0043.sql
@@ -1,0 +1,11 @@
+CREATE UNLOGGED TABLE cities (name text, population real, altitude double, identifier smallint, postal_code int, foreign_id bigint);
+/* TODO: CREATE TABLE IF NOT EXISTS distributors (name varchar(40) DEFAULT 'Luso Films', len interval hour to second(3), name varchar(40) DEFAULT 'Luso Films', did int DEFAULT nextval('distributors_serial'), stamp timestamp DEFAULT now() NOT NULL, stamptz timestamp with time zone, "time" time NOT NULL, timetz time with time zone, CONSTRAINT name_len PRIMARY KEY (name, len)); */ SELECT 1;
+/* TODO: CREATE TABLE types (a real, b double precision, c numeric(2, 3), d char(4), e char(5), f varchar(6), g varchar(7)); */ SELECT 1;
+/* TODO: CREATE TABLE types (a geometry(point) NOT NULL); */ SELECT 1;
+CREATE TABLE tablename (colname int NOT NULL DEFAULT nextval('tablename_colname_seq'));
+CREATE TABLE capitals (state char(2)) INHERITS (cities);
+/* TODO: CREATE TEMPORARY TABLE temp AS SELECT c FROM t; */ SELECT 1;
+/* TODO: CREATE TABLE films2 AS SELECT * FROM films; */ SELECT 1;
+/* TODO: CREATE TEMPORARY TABLE films_recent ON COMMIT DROP AS SELECT * FROM films WHERE date_prod > $1; */ SELECT 1;
+CREATE TABLE like_constraint_rename_cache (LIKE constraint_rename_cache INCLUDING ALL);
+CREATE TABLE distributors (did int, name varchar(40), UNIQUE (name) WITH (fillfactor=70)) WITH (fillfactor=70);

--- a/crates/parser/tests/snapshots/statements/valid/0043@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0043@1.snap
@@ -1,0 +1,412 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "CREATE UNLOGGED TABLE cities (name text, population real, altitude double, identifier smallint, postal_code int, foreign_id bigint);"
+---
+Parse {
+    cst: SourceFile@0..132
+      CreateStmt@0..132
+        Create@0..6 "CREATE"
+        Whitespace@6..7 " "
+        Unlogged@7..15 "UNLOGGED"
+        Whitespace@15..16 " "
+        Table@16..21 "TABLE"
+        Whitespace@21..22 " "
+        RangeVar@22..28
+          Ident@22..28 "cities"
+        Whitespace@28..29 " "
+        Ascii40@29..30 "("
+        ColumnDef@30..39
+          NameP@30..34 "name"
+          Whitespace@34..35 " "
+          TypeName@35..39
+            TextP@35..39 "text"
+        Ascii44@39..40 ","
+        Whitespace@40..41 " "
+        ColumnDef@41..56
+          Ident@41..51 "population"
+          Whitespace@51..52 " "
+          TypeName@52..56
+            Real@52..56 "real"
+        Ascii44@56..57 ","
+        Whitespace@57..58 " "
+        ColumnDef@58..73
+          Ident@58..66 "altitude"
+          Whitespace@66..67 " "
+          TypeName@67..73
+            DoubleP@67..73 "double"
+        Ascii44@73..74 ","
+        Whitespace@74..75 " "
+        ColumnDef@75..94
+          Ident@75..85 "identifier"
+          Whitespace@85..86 " "
+          TypeName@86..94
+            Smallint@86..94 "smallint"
+        Ascii44@94..95 ","
+        Whitespace@95..96 " "
+        ColumnDef@96..111
+          Ident@96..107 "postal_code"
+          Whitespace@107..108 " "
+          TypeName@108..111
+            IntP@108..111 "int"
+        Ascii44@111..112 ","
+        Whitespace@112..113 " "
+        ColumnDef@113..130
+          Ident@113..123 "foreign_id"
+          Whitespace@123..124 " "
+          TypeName@124..130
+            Bigint@124..130 "bigint"
+        Ascii41@130..131 ")"
+        Ascii59@131..132 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateStmt(
+                CreateStmt {
+                    relation: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "cities",
+                            inh: true,
+                            relpersistence: "u",
+                            alias: None,
+                            location: 22,
+                        },
+                    ),
+                    table_elts: [
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "name",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "text",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 35,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [],
+                                        fdwoptions: [],
+                                        location: 30,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "population",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "float4",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 52,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [],
+                                        fdwoptions: [],
+                                        location: 41,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "altitude",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "double",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 67,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [],
+                                        fdwoptions: [],
+                                        location: 58,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "identifier",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "int2",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 86,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [],
+                                        fdwoptions: [],
+                                        location: 75,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "postal_code",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "int4",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 108,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [],
+                                        fdwoptions: [],
+                                        location: 96,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "foreign_id",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "int8",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 124,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [],
+                                        fdwoptions: [],
+                                        location: 113,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    inh_relations: [],
+                    partbound: None,
+                    partspec: None,
+                    of_typename: None,
+                    constraints: [],
+                    options: [],
+                    oncommit: OncommitNoop,
+                    tablespacename: "",
+                    access_method: "",
+                    if_not_exists: false,
+                },
+            ),
+            range: 0..131,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0043@10.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0043@10.snap
@@ -1,0 +1,82 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: CREATE TABLE like_constraint_rename_cache (LIKE constraint_rename_cache INCLUDING ALL);
+---
+Parse {
+    cst: SourceFile@0..87
+      CreateStmt@0..87
+        Create@0..6 "CREATE"
+        Whitespace@6..7 " "
+        Table@7..12 "TABLE"
+        Whitespace@12..13 " "
+        RangeVar@13..41
+          Ident@13..41 "like_constraint_renam ..."
+        Whitespace@41..42 " "
+        Ascii40@42..43 "("
+        TableLikeClause@43..85
+          Like@43..47 "LIKE"
+          Whitespace@47..48 " "
+          RangeVar@48..71
+            Ident@48..71 "constraint_rename_cache"
+          Whitespace@71..72 " "
+          Including@72..81 "INCLUDING"
+          Whitespace@81..82 " "
+          All@82..85 "ALL"
+        Ascii41@85..86 ")"
+        Ascii59@86..87 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateStmt(
+                CreateStmt {
+                    relation: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "like_constraint_rename_cache",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 13,
+                        },
+                    ),
+                    table_elts: [
+                        Node {
+                            node: Some(
+                                TableLikeClause(
+                                    TableLikeClause {
+                                        relation: Some(
+                                            RangeVar {
+                                                catalogname: "",
+                                                schemaname: "",
+                                                relname: "constraint_rename_cache",
+                                                inh: true,
+                                                relpersistence: "p",
+                                                alias: None,
+                                                location: 48,
+                                            },
+                                        ),
+                                        options: 2147483647,
+                                        relation_oid: 0,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    inh_relations: [],
+                    partbound: None,
+                    partspec: None,
+                    of_typename: None,
+                    constraints: [],
+                    options: [],
+                    oncommit: OncommitNoop,
+                    tablespacename: "",
+                    access_method: "",
+                    if_not_exists: false,
+                },
+            ),
+            range: 0..86,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0043@11.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0043@11.snap
@@ -1,0 +1,320 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "CREATE TABLE distributors (did int, name varchar(40), UNIQUE (name) WITH (fillfactor=70)) WITH (fillfactor=70);"
+---
+Parse {
+    cst: SourceFile@0..111
+      CreateStmt@0..111
+        Create@0..6 "CREATE"
+        Whitespace@6..7 " "
+        Table@7..12 "TABLE"
+        Whitespace@12..13 " "
+        RangeVar@13..25
+          Ident@13..25 "distributors"
+        Whitespace@25..26 " "
+        Ascii40@26..27 "("
+        ColumnDef@27..34
+          Ident@27..30 "did"
+          Whitespace@30..31 " "
+          TypeName@31..34
+            IntP@31..34 "int"
+        Ascii44@34..35 ","
+        Whitespace@35..36 " "
+        ColumnDef@36..51
+          NameP@36..40 "name"
+          Whitespace@40..41 " "
+          TypeName@41..51
+            Varchar@41..48 "varchar"
+            Ascii40@48..49 "("
+            AConst@49..51
+              Iconst@49..51 "40"
+        Ascii41@51..52 ")"
+        Ascii44@52..53 ","
+        Whitespace@53..54 " "
+        Constraint@54..87
+          Unique@54..60 "UNIQUE"
+          Whitespace@60..61 " "
+          Ascii40@61..62 "("
+          NameP@62..66 "name"
+          Ascii41@66..67 ")"
+          Whitespace@67..68 " "
+          With@68..72 "WITH"
+          Whitespace@72..73 " "
+          Ascii40@73..74 "("
+          DefElem@74..87
+            Ident@74..84 "fillfactor"
+            Ascii61@84..85 "="
+            Iconst@85..87 "70"
+        Ascii41@87..88 ")"
+        Ascii41@88..89 ")"
+        Whitespace@89..90 " "
+        With@90..94 "WITH"
+        Whitespace@94..95 " "
+        Ascii40@95..96 "("
+        DefElem@96..109
+          Ident@96..106 "fillfactor"
+          Ascii61@106..107 "="
+          Iconst@107..109 "70"
+        Ascii41@109..110 ")"
+        Ascii59@110..111 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateStmt(
+                CreateStmt {
+                    relation: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "distributors",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 13,
+                        },
+                    ),
+                    table_elts: [
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "did",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "int4",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 31,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [],
+                                        fdwoptions: [],
+                                        location: 27,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "name",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "varchar",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [
+                                                    Node {
+                                                        node: Some(
+                                                            AConst(
+                                                                AConst {
+                                                                    isnull: false,
+                                                                    location: 49,
+                                                                    val: Some(
+                                                                        Ival(
+                                                                            Integer {
+                                                                                ival: 40,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 41,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [],
+                                        fdwoptions: [],
+                                        location: 36,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                Constraint(
+                                    Constraint {
+                                        contype: ConstrUnique,
+                                        conname: "",
+                                        deferrable: false,
+                                        initdeferred: false,
+                                        location: 54,
+                                        is_no_inherit: false,
+                                        raw_expr: None,
+                                        cooked_expr: "",
+                                        generated_when: "",
+                                        nulls_not_distinct: false,
+                                        keys: [
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "name",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        including: [],
+                                        exclusions: [],
+                                        options: [
+                                            Node {
+                                                node: Some(
+                                                    DefElem(
+                                                        DefElem {
+                                                            defnamespace: "",
+                                                            defname: "fillfactor",
+                                                            arg: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        Integer(
+                                                                            Integer {
+                                                                                ival: 70,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            defaction: DefelemUnspec,
+                                                            location: 74,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        indexname: "",
+                                        indexspace: "",
+                                        reset_default_tblspc: false,
+                                        access_method: "",
+                                        where_clause: None,
+                                        pktable: None,
+                                        fk_attrs: [],
+                                        pk_attrs: [],
+                                        fk_matchtype: "",
+                                        fk_upd_action: "",
+                                        fk_del_action: "",
+                                        fk_del_set_cols: [],
+                                        old_conpfeqop: [],
+                                        old_pktable_oid: 0,
+                                        skip_validation: false,
+                                        initially_valid: false,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    inh_relations: [],
+                    partbound: None,
+                    partspec: None,
+                    of_typename: None,
+                    constraints: [],
+                    options: [
+                        Node {
+                            node: Some(
+                                DefElem(
+                                    DefElem {
+                                        defnamespace: "",
+                                        defname: "fillfactor",
+                                        arg: Some(
+                                            Node {
+                                                node: Some(
+                                                    Integer(
+                                                        Integer {
+                                                            ival: 70,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        defaction: DefelemUnspec,
+                                        location: 96,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    oncommit: OncommitNoop,
+                    tablespacename: "",
+                    access_method: "",
+                    if_not_exists: false,
+                },
+            ),
+            range: 0..110,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0043@2.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0043@2.snap
@@ -1,0 +1,77 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "/* TODO: CREATE TABLE IF NOT EXISTS distributors (name varchar(40) DEFAULT 'Luso Films', len interval hour to second(3), name varchar(40) DEFAULT 'Luso Films', did int DEFAULT nextval('distributors_serial'), stamp timestamp DEFAULT now() NOT NULL, stamptz timestamp with time zone, \"time\" time NOT NULL, timetz time with time zone, CONSTRAINT name_len PRIMARY KEY (name, len)); */ SELECT 1;"
+---
+Parse {
+    cst: SourceFile@0..389
+      CComment@0..380 "/* TODO: CREATE TABLE ..."
+      SelectStmt@380..389
+        Select@380..386 "SELECT"
+        Whitespace@386..387 " "
+        ResTarget@387..388
+          AConst@387..388
+            Iconst@387..388 "1"
+        Ascii59@388..389 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    AConst(
+                                                        AConst {
+                                                            isnull: false,
+                                                            location: 7,
+                                                            val: Some(
+                                                                Ival(
+                                                                    Integer {
+                                                                        ival: 1,
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [],
+                    where_clause: None,
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 380..389,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0043@3.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0043@3.snap
@@ -1,0 +1,77 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "/* TODO: CREATE TABLE types (a real, b double precision, c numeric(2, 3), d char(4), e char(5), f varchar(6), g varchar(7)); */ SELECT 1;"
+---
+Parse {
+    cst: SourceFile@0..136
+      CComment@0..127 "/* TODO: CREATE TABLE ..."
+      SelectStmt@127..136
+        Select@127..133 "SELECT"
+        Whitespace@133..134 " "
+        ResTarget@134..135
+          AConst@134..135
+            Iconst@134..135 "1"
+        Ascii59@135..136 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    AConst(
+                                                        AConst {
+                                                            isnull: false,
+                                                            location: 7,
+                                                            val: Some(
+                                                                Ival(
+                                                                    Integer {
+                                                                        ival: 1,
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [],
+                    where_clause: None,
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 127..136,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0043@4.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0043@4.snap
@@ -1,0 +1,77 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "/* TODO: CREATE TABLE types (a geometry(point) NOT NULL); */ SELECT 1;"
+---
+Parse {
+    cst: SourceFile@0..69
+      CComment@0..60 "/* TODO: CREATE TABLE ..."
+      SelectStmt@60..69
+        Select@60..66 "SELECT"
+        Whitespace@66..67 " "
+        ResTarget@67..68
+          AConst@67..68
+            Iconst@67..68 "1"
+        Ascii59@68..69 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    AConst(
+                                                        AConst {
+                                                            isnull: false,
+                                                            location: 7,
+                                                            val: Some(
+                                                                Ival(
+                                                                    Integer {
+                                                                        ival: 1,
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [],
+                    where_clause: None,
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 60..69,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0043@5.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0043@5.snap
@@ -1,0 +1,253 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "CREATE TABLE tablename (colname int NOT NULL DEFAULT nextval('tablename_colname_seq'));"
+---
+Parse {
+    cst: SourceFile@0..87
+      CreateStmt@0..87
+        Create@0..6 "CREATE"
+        Whitespace@6..7 " "
+        Table@7..12 "TABLE"
+        Whitespace@12..13 " "
+        RangeVar@13..22
+          Ident@13..22 "tablename"
+        Whitespace@22..23 " "
+        Ascii40@23..24 "("
+        ColumnDef@24..84
+          Ident@24..31 "colname"
+          Whitespace@31..32 " "
+          TypeName@32..35
+            IntP@32..35 "int"
+          Whitespace@35..36 " "
+          Constraint@36..44
+            Not@36..39 "NOT"
+            Whitespace@39..40 " "
+            NullP@40..44 "NULL"
+          Whitespace@44..45 " "
+          Constraint@45..84
+            Default@45..52 "DEFAULT"
+            Whitespace@52..53 " "
+            FuncCall@53..84
+              Ident@53..60 "nextval"
+              Ascii40@60..61 "("
+              AConst@61..84
+                Sconst@61..84 "'tablename_colname_seq'"
+        Ascii41@84..85 ")"
+        Ascii41@85..86 ")"
+        Ascii59@86..87 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateStmt(
+                CreateStmt {
+                    relation: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "tablename",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 13,
+                        },
+                    ),
+                    table_elts: [
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "colname",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "int4",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 32,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [
+                                            Node {
+                                                node: Some(
+                                                    Constraint(
+                                                        Constraint {
+                                                            contype: ConstrNotnull,
+                                                            conname: "",
+                                                            deferrable: false,
+                                                            initdeferred: false,
+                                                            location: 36,
+                                                            is_no_inherit: false,
+                                                            raw_expr: None,
+                                                            cooked_expr: "",
+                                                            generated_when: "",
+                                                            nulls_not_distinct: false,
+                                                            keys: [],
+                                                            including: [],
+                                                            exclusions: [],
+                                                            options: [],
+                                                            indexname: "",
+                                                            indexspace: "",
+                                                            reset_default_tblspc: false,
+                                                            access_method: "",
+                                                            where_clause: None,
+                                                            pktable: None,
+                                                            fk_attrs: [],
+                                                            pk_attrs: [],
+                                                            fk_matchtype: "",
+                                                            fk_upd_action: "",
+                                                            fk_del_action: "",
+                                                            fk_del_set_cols: [],
+                                                            old_conpfeqop: [],
+                                                            old_pktable_oid: 0,
+                                                            skip_validation: false,
+                                                            initially_valid: false,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                            Node {
+                                                node: Some(
+                                                    Constraint(
+                                                        Constraint {
+                                                            contype: ConstrDefault,
+                                                            conname: "",
+                                                            deferrable: false,
+                                                            initdeferred: false,
+                                                            location: 45,
+                                                            is_no_inherit: false,
+                                                            raw_expr: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        FuncCall(
+                                                                            FuncCall {
+                                                                                funcname: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: "nextval",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                args: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            AConst(
+                                                                                                AConst {
+                                                                                                    isnull: false,
+                                                                                                    location: 61,
+                                                                                                    val: Some(
+                                                                                                        Sval(
+                                                                                                            String {
+                                                                                                                sval: "tablename_colname_seq",
+                                                                                                            },
+                                                                                                        ),
+                                                                                                    ),
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                agg_order: [],
+                                                                                agg_filter: None,
+                                                                                over: None,
+                                                                                agg_within_group: false,
+                                                                                agg_star: false,
+                                                                                agg_distinct: false,
+                                                                                func_variadic: false,
+                                                                                funcformat: CoerceExplicitCall,
+                                                                                location: 53,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            cooked_expr: "",
+                                                            generated_when: "",
+                                                            nulls_not_distinct: false,
+                                                            keys: [],
+                                                            including: [],
+                                                            exclusions: [],
+                                                            options: [],
+                                                            indexname: "",
+                                                            indexspace: "",
+                                                            reset_default_tblspc: false,
+                                                            access_method: "",
+                                                            where_clause: None,
+                                                            pktable: None,
+                                                            fk_attrs: [],
+                                                            pk_attrs: [],
+                                                            fk_matchtype: "",
+                                                            fk_upd_action: "",
+                                                            fk_del_action: "",
+                                                            fk_del_set_cols: [],
+                                                            old_conpfeqop: [],
+                                                            old_pktable_oid: 0,
+                                                            skip_validation: false,
+                                                            initially_valid: false,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        fdwoptions: [],
+                                        location: 24,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    inh_relations: [],
+                    partbound: None,
+                    partspec: None,
+                    of_typename: None,
+                    constraints: [],
+                    options: [],
+                    oncommit: OncommitNoop,
+                    tablespacename: "",
+                    access_method: "",
+                    if_not_exists: false,
+                },
+            ),
+            range: 0..86,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0043@6.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0043@6.snap
@@ -1,0 +1,158 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: CREATE TABLE capitals (state char(2)) INHERITS (cities);
+---
+Parse {
+    cst: SourceFile@0..56
+      CreateStmt@0..56
+        Create@0..6 "CREATE"
+        Whitespace@6..7 " "
+        Table@7..12 "TABLE"
+        Whitespace@12..13 " "
+        RangeVar@13..21
+          Ident@13..21 "capitals"
+        Whitespace@21..22 " "
+        Ascii40@22..23 "("
+        ColumnDef@23..35
+          Ident@23..28 "state"
+          Whitespace@28..29 " "
+          TypeName@29..35
+            CharP@29..33 "char"
+            Ascii40@33..34 "("
+            AConst@34..35
+              Iconst@34..35 "2"
+        Ascii41@35..36 ")"
+        Ascii41@36..37 ")"
+        Whitespace@37..38 " "
+        Inherits@38..46 "INHERITS"
+        Whitespace@46..47 " "
+        Ascii40@47..48 "("
+        RangeVar@48..54
+          Ident@48..54 "cities"
+        Ascii41@54..55 ")"
+        Ascii59@55..56 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: CreateStmt(
+                CreateStmt {
+                    relation: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "capitals",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 13,
+                        },
+                    ),
+                    table_elts: [
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "state",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "bpchar",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [
+                                                    Node {
+                                                        node: Some(
+                                                            AConst(
+                                                                AConst {
+                                                                    isnull: false,
+                                                                    location: 34,
+                                                                    val: Some(
+                                                                        Ival(
+                                                                            Integer {
+                                                                                ival: 2,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 29,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [],
+                                        fdwoptions: [],
+                                        location: 23,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    inh_relations: [
+                        Node {
+                            node: Some(
+                                RangeVar(
+                                    RangeVar {
+                                        catalogname: "",
+                                        schemaname: "",
+                                        relname: "cities",
+                                        inh: true,
+                                        relpersistence: "p",
+                                        alias: None,
+                                        location: 48,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    partbound: None,
+                    partspec: None,
+                    of_typename: None,
+                    constraints: [],
+                    options: [],
+                    oncommit: OncommitNoop,
+                    tablespacename: "",
+                    access_method: "",
+                    if_not_exists: false,
+                },
+            ),
+            range: 0..55,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0043@7.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0043@7.snap
@@ -1,0 +1,77 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "/* TODO: CREATE TEMPORARY TABLE temp AS SELECT c FROM t; */ SELECT 1;"
+---
+Parse {
+    cst: SourceFile@0..68
+      CComment@0..59 "/* TODO: CREATE TEMPO ..."
+      SelectStmt@59..68
+        Select@59..65 "SELECT"
+        Whitespace@65..66 " "
+        ResTarget@66..67
+          AConst@66..67
+            Iconst@66..67 "1"
+        Ascii59@67..68 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    AConst(
+                                                        AConst {
+                                                            isnull: false,
+                                                            location: 7,
+                                                            val: Some(
+                                                                Ival(
+                                                                    Integer {
+                                                                        ival: 1,
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [],
+                    where_clause: None,
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 59..68,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0043@8.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0043@8.snap
@@ -1,0 +1,77 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "/* TODO: CREATE TABLE films2 AS SELECT * FROM films; */ SELECT 1;"
+---
+Parse {
+    cst: SourceFile@0..64
+      CComment@0..55 "/* TODO: CREATE TABLE ..."
+      SelectStmt@55..64
+        Select@55..61 "SELECT"
+        Whitespace@61..62 " "
+        ResTarget@62..63
+          AConst@62..63
+            Iconst@62..63 "1"
+        Ascii59@63..64 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    AConst(
+                                                        AConst {
+                                                            isnull: false,
+                                                            location: 7,
+                                                            val: Some(
+                                                                Ival(
+                                                                    Integer {
+                                                                        ival: 1,
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [],
+                    where_clause: None,
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 55..64,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/0043@9.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0043@9.snap
@@ -1,0 +1,77 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "/* TODO: CREATE TEMPORARY TABLE films_recent ON COMMIT DROP AS SELECT * FROM films WHERE date_prod > $1; */ SELECT 1;"
+---
+Parse {
+    cst: SourceFile@0..116
+      CComment@0..107 "/* TODO: CREATE TEMPO ..."
+      SelectStmt@107..116
+        Select@107..113 "SELECT"
+        Whitespace@113..114 " "
+        ResTarget@114..115
+          AConst@114..115
+            Iconst@114..115 "1"
+        Ascii59@115..116 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    AConst(
+                                                        AConst {
+                                                            isnull: false,
+                                                            location: 7,
+                                                            val: Some(
+                                                                Ival(
+                                                                    Integer {
+                                                                        ival: 1,
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [],
+                    where_clause: None,
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 107..116,
+        },
+    ],
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

add support for `create table like`

## What is the current behavior?

panics

## What is the new behavior?

parser returns

## Additional context

Last batch of PRs before pulling in the `postgres` regression tests
