### PR TITLE
test: add support for create table as

### DIFF
--- a/crates/codegen/src/get_node_properties.rs
+++ b/crates/codegen/src/get_node_properties.rs
@@ -877,6 +877,10 @@ fn custom_handlers(node: &Node) -> TokenStream {
 
             if names.len() == 2 && names[0] == "pg_catalog" {
                 match names[1].as_str() {
+                    "float8" => {
+                        tokens.push(TokenProperty::from(Token::DoubleP));
+                        tokens.push(TokenProperty::from(Token::Precision));
+                    },
                     "interval" => {
                         // Adapted from https://github.com/postgres/postgres/blob/REL_15_STABLE/src/backend/utils/adt/timestamp.c#L1103
                         const HOUR: i32 = 10;

--- a/crates/parser/tests/data/statements/valid/0043.sql
+++ b/crates/parser/tests/data/statements/valid/0043.sql
@@ -4,8 +4,8 @@ CREATE TABLE types (a real, b double precision, c numeric(2, 3), d char(4), e ch
 CREATE TABLE types (a geometry(point) NOT NULL);
 CREATE TABLE tablename (colname int NOT NULL DEFAULT nextval('tablename_colname_seq'));
 CREATE TABLE capitals (state char(2)) INHERITS (cities);
-/* TODO: CREATE TEMPORARY TABLE temp AS SELECT c FROM t; */ SELECT 1;
-/* TODO: CREATE TABLE films2 AS SELECT * FROM films; */ SELECT 1;
+CREATE TEMPORARY TABLE temp AS SELECT c FROM t;
+CREATE TABLE films2 AS SELECT * FROM films;
 CREATE TEMPORARY TABLE films_recent ON COMMIT DROP AS SELECT * FROM films WHERE date_prod > $1;
 CREATE TABLE like_constraint_rename_cache (LIKE constraint_rename_cache INCLUDING ALL);
 CREATE TABLE distributors (did int, name varchar(40), UNIQUE (name) WITH (fillfactor=70)) WITH (fillfactor=70);

--- a/crates/parser/tests/snapshots/statements/valid/0043@7.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0043@7.snap
@@ -1,19 +1,41 @@
 ---
 source: crates/parser/tests/statement_parser_test.rs
-description: "/* TODO: CREATE TEMPORARY TABLE temp AS SELECT c FROM t; */ SELECT 1;"
+description: CREATE TEMPORARY TABLE temp AS SELECT c FROM t;
 ---
 Parse {
-    cst: SourceFile@0..68
-      CComment@0..59 "/* TODO: CREATE TEMPO ..."
-      SelectStmt@59..68
-        Select@59..65 "SELECT"
-        Whitespace@65..66 " "
-        ResTarget@66..67
-          AConst@66..67
-            Iconst@66..67 "1"
-        Ascii59@67..68 ";"
+    cst: SourceFile@0..46
+      Create@0..6 "CREATE"
+      Whitespace@6..7 " "
+      Temporary@7..16 "TEMPORARY"
+      Whitespace@16..17 " "
+      Table@17..22 "TABLE"
+      Whitespace@22..23 " "
+      Temp@23..27 "temp"
+      Whitespace@27..28 " "
+      As@28..30 "AS"
+      SelectStmt@30..46
+        Select@30..36 "SELECT"
+        Whitespace@36..37 " "
+        ResTarget@37..38
+          ColumnRef@37..38
+            Ident@37..38 "c"
+        Whitespace@38..39 " "
+        From@39..43 "FROM"
+        Whitespace@43..44 " "
+        RangeVar@44..45
+          Ident@44..45 "t"
+        Ascii59@45..46 ";"
     ,
-    errors: [],
+    errors: [
+        SyntaxError(
+            "Expected Ascii59, found Whitespace",
+            30..30,
+        ),
+        SyntaxError(
+            "Invalid statement: syntax error at end of input",
+            0..9,
+        ),
+    ],
     stmts: [
         RawStmt {
             stmt: SelectStmt(
@@ -30,17 +52,20 @@ Parse {
                                         val: Some(
                                             Node {
                                                 node: Some(
-                                                    AConst(
-                                                        AConst {
-                                                            isnull: false,
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "c",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
                                                             location: 7,
-                                                            val: Some(
-                                                                Ival(
-                                                                    Integer {
-                                                                        ival: 1,
-                                                                    },
-                                                                ),
-                                                            ),
                                                         },
                                                     ),
                                                 ),
@@ -52,7 +77,23 @@ Parse {
                             ),
                         },
                     ],
-                    from_clause: [],
+                    from_clause: [
+                        Node {
+                            node: Some(
+                                RangeVar(
+                                    RangeVar {
+                                        catalogname: "",
+                                        schemaname: "",
+                                        relname: "t",
+                                        inh: true,
+                                        relpersistence: "p",
+                                        alias: None,
+                                        location: 14,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
                     where_clause: None,
                     group_clause: [],
                     group_distinct: false,
@@ -71,7 +112,7 @@ Parse {
                     rarg: None,
                 },
             ),
-            range: 59..68,
+            range: 30..46,
         },
     ],
 }

--- a/crates/parser/tests/snapshots/statements/valid/0043@8.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0043@8.snap
@@ -1,19 +1,40 @@
 ---
 source: crates/parser/tests/statement_parser_test.rs
-description: "/* TODO: CREATE TABLE films2 AS SELECT * FROM films; */ SELECT 1;"
+description: CREATE TABLE films2 AS SELECT * FROM films;
 ---
 Parse {
-    cst: SourceFile@0..64
-      CComment@0..55 "/* TODO: CREATE TABLE ..."
-      SelectStmt@55..64
-        Select@55..61 "SELECT"
-        Whitespace@61..62 " "
-        ResTarget@62..63
-          AConst@62..63
-            Iconst@62..63 "1"
-        Ascii59@63..64 ";"
+    cst: SourceFile@0..42
+      Create@0..6 "CREATE"
+      Whitespace@6..7 " "
+      Table@7..12 "TABLE"
+      Whitespace@12..13 " "
+      Ident@13..19 "films2"
+      Whitespace@19..20 " "
+      As@20..22 "AS"
+      SelectStmt@22..42
+        Select@22..28 "SELECT"
+        Whitespace@28..29 " "
+        ResTarget@29..30
+          ColumnRef@29..30
+            AStar@29..30
+              Ascii42@29..30 "*"
+        Whitespace@30..31 " "
+        From@31..35 "FROM"
+        Whitespace@35..36 " "
+        RangeVar@36..41
+          Ident@36..41 "films"
+        Ascii59@41..42 ";"
     ,
-    errors: [],
+    errors: [
+        SyntaxError(
+            "Expected Ascii59, found Whitespace",
+            22..22,
+        ),
+        SyntaxError(
+            "Invalid statement: syntax error at end of input",
+            0..7,
+        ),
+    ],
     stmts: [
         RawStmt {
             stmt: SelectStmt(
@@ -30,17 +51,18 @@ Parse {
                                         val: Some(
                                             Node {
                                                 node: Some(
-                                                    AConst(
-                                                        AConst {
-                                                            isnull: false,
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AStar(
+                                                                            AStar,
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
                                                             location: 7,
-                                                            val: Some(
-                                                                Ival(
-                                                                    Integer {
-                                                                        ival: 1,
-                                                                    },
-                                                                ),
-                                                            ),
                                                         },
                                                     ),
                                                 ),
@@ -52,7 +74,23 @@ Parse {
                             ),
                         },
                     ],
-                    from_clause: [],
+                    from_clause: [
+                        Node {
+                            node: Some(
+                                RangeVar(
+                                    RangeVar {
+                                        catalogname: "",
+                                        schemaname: "",
+                                        relname: "films",
+                                        inh: true,
+                                        relpersistence: "p",
+                                        alias: None,
+                                        location: 14,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
                     where_clause: None,
                     group_clause: [],
                     group_distinct: false,
@@ -71,7 +109,7 @@ Parse {
                     rarg: None,
                 },
             ),
-            range: 55..64,
+            range: 22..42,
         },
     ],
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

add tests for `create table as`

## What is the current behavior?

parser collects errors after `as` keyword (see snapshots)

## What is the expected behavior?

parser returns without errors

## Additional context

same here, reproduction case cc @psteinroe 
