### PR TITLE
feat: add support for type name

### DIFF
--- a/crates/codegen/src/get_node_properties.rs
+++ b/crates/codegen/src/get_node_properties.rs
@@ -869,6 +869,37 @@ fn custom_handlers(node: &Node) -> TokenStream {
                 tokens.push(TokenProperty::from(Token::Function));
             }
         },
+        "TypeName" => quote! {
+            let names = n.names
+                .iter()
+                .filter_map(|n| if let Some(NodeEnum::String(s)) = &n.node { Some(s.sval.clone()) } else { None })
+                .collect::<Vec<_>>();
+
+            if names.len() == 2 && names[0] == "pg_catalog" {
+                match names[1].as_str() {
+                    "interval" => {
+                        tokens.push(TokenProperty::from(Token::To)); //
+                        tokens.push(TokenProperty::from(Token::SecondP)); //
+                    },
+                    "timestamptz" => {
+                        tokens.push(TokenProperty::from(Token::With));
+                        tokens.push(TokenProperty::from(Token::Time));
+                        tokens.push(TokenProperty::from(Token::Zone));
+                    }
+                    "time" => {
+                        tokens.push(TokenProperty::from(Token::Time));
+                    },
+                    "timetz" => {
+                        tokens.push(TokenProperty::from(Token::Time));
+                        tokens.push(TokenProperty::from(Token::With));
+                        tokens.push(TokenProperty::from(Token::Time));
+                        tokens.push(TokenProperty::from(Token::Zone));
+                        tokens.push(TokenProperty::from(Token::Not)); //
+                    }
+                    _ => {}
+                }
+            }
+        },
         _ => quote! {},
     }
 }

--- a/crates/codegen/src/get_node_properties.rs
+++ b/crates/codegen/src/get_node_properties.rs
@@ -878,23 +878,37 @@ fn custom_handlers(node: &Node) -> TokenStream {
             if names.len() == 2 && names[0] == "pg_catalog" {
                 match names[1].as_str() {
                     "interval" => {
-                        tokens.push(TokenProperty::from(Token::To)); //
-                        tokens.push(TokenProperty::from(Token::SecondP)); //
+                        // Adapted from https://github.com/postgres/postgres/blob/REL_15_STABLE/src/backend/utils/adt/timestamp.c#L1103
+                        const HOUR: i32 = 10;
+                        const MINUTE: i32 = 11;
+                        const SECOND: i32 = 12;
+
+                        let fields = &n.typmods.first()
+                            .and_then(|node| node.node.as_ref())
+                            .and_then(|node| if let NodeEnum::AConst(n) = node { n.val.clone() } else { None })
+                            .and_then(|node| if let protobuf::a_const::Val::Ival(n) = node { Some(n.ival) } else { None });
+
+                        if let Some(fields) = fields {
+                            match fields.clone() {
+                                i if i == 1 << HOUR | 1 << MINUTE | 1 << SECOND => {
+                                    tokens.push(TokenProperty::from(Token::To));
+                                    tokens.push(TokenProperty::from(Token::SecondP));
+                                },
+                                _ => panic!("Unknown Interval fields {:#?}", fields),
+                            }
+                        }
                     },
                     "timestamptz" => {
+                        tokens.push(TokenProperty::from(Token::Timestamp));
                         tokens.push(TokenProperty::from(Token::With));
                         tokens.push(TokenProperty::from(Token::Time));
                         tokens.push(TokenProperty::from(Token::Zone));
                     }
-                    "time" => {
-                        tokens.push(TokenProperty::from(Token::Time));
-                    },
                     "timetz" => {
                         tokens.push(TokenProperty::from(Token::Time));
                         tokens.push(TokenProperty::from(Token::With));
                         tokens.push(TokenProperty::from(Token::Time));
                         tokens.push(TokenProperty::from(Token::Zone));
-                        tokens.push(TokenProperty::from(Token::Not)); //
                     }
                     _ => {}
                 }

--- a/crates/parser/tests/data/statements/valid/0043.sql
+++ b/crates/parser/tests/data/statements/valid/0043.sql
@@ -1,5 +1,5 @@
 CREATE UNLOGGED TABLE cities (name text, population real, altitude double, identifier smallint, postal_code int, foreign_id bigint);
-/* TODO: CREATE TABLE IF NOT EXISTS distributors (name varchar(40) DEFAULT 'Luso Films', len interval hour to second(3), name varchar(40) DEFAULT 'Luso Films', did int DEFAULT nextval('distributors_serial'), stamp timestamp DEFAULT now() NOT NULL, stamptz timestamp with time zone, "time" time NOT NULL, timetz time with time zone, CONSTRAINT name_len PRIMARY KEY (name, len)); */ SELECT 1;
+CREATE TABLE IF NOT EXISTS distributors (name varchar(40) DEFAULT 'Luso Films', len interval hour to second(3), name varchar(40) DEFAULT 'Luso Films', did int DEFAULT nextval('distributors_serial'), stamp timestamp DEFAULT now() NOT NULL, stamptz timestamp with time zone, "time" time NOT NULL, timetz time with time zone, CONSTRAINT name_len PRIMARY KEY (name, len));
 CREATE TABLE types (a real, b double precision, c numeric(2, 3), d char(4), e char(5), f varchar(6), g varchar(7));
 CREATE TABLE types (a geometry(point) NOT NULL);
 CREATE TABLE tablename (colname int NOT NULL DEFAULT nextval('tablename_colname_seq'));

--- a/crates/parser/tests/snapshots/statements/valid/0043@2.snap
+++ b/crates/parser/tests/snapshots/statements/valid/0043@2.snap
@@ -1,77 +1,1123 @@
 ---
 source: crates/parser/tests/statement_parser_test.rs
-description: "/* TODO: CREATE TABLE IF NOT EXISTS distributors (name varchar(40) DEFAULT 'Luso Films', len interval hour to second(3), name varchar(40) DEFAULT 'Luso Films', did int DEFAULT nextval('distributors_serial'), stamp timestamp DEFAULT now() NOT NULL, stamptz timestamp with time zone, \"time\" time NOT NULL, timetz time with time zone, CONSTRAINT name_len PRIMARY KEY (name, len)); */ SELECT 1;"
+description: "CREATE TABLE IF NOT EXISTS distributors (name varchar(40) DEFAULT 'Luso Films', len interval hour to second(3), name varchar(40) DEFAULT 'Luso Films', did int DEFAULT nextval('distributors_serial'), stamp timestamp DEFAULT now() NOT NULL, stamptz timestamp with time zone, \"time\" time NOT NULL, timetz time with time zone, CONSTRAINT name_len PRIMARY KEY (name, len));"
 ---
 Parse {
-    cst: SourceFile@0..389
-      CComment@0..380 "/* TODO: CREATE TABLE ..."
-      SelectStmt@380..389
-        Select@380..386 "SELECT"
-        Whitespace@386..387 " "
-        ResTarget@387..388
-          AConst@387..388
-            Iconst@387..388 "1"
-        Ascii59@388..389 ";"
+    cst: SourceFile@0..368
+      CreateStmt@0..368
+        Create@0..6 "CREATE"
+        Whitespace@6..7 " "
+        Table@7..12 "TABLE"
+        Whitespace@12..13 " "
+        IfP@13..15 "IF"
+        Whitespace@15..16 " "
+        Not@16..19 "NOT"
+        Whitespace@19..20 " "
+        Exists@20..26 "EXISTS"
+        Whitespace@26..27 " "
+        RangeVar@27..39
+          Ident@27..39 "distributors"
+        Whitespace@39..40 " "
+        Ascii40@40..41 "("
+        ColumnDef@41..78
+          NameP@41..45 "name"
+          Whitespace@45..46 " "
+          TypeName@46..56
+            Varchar@46..53 "varchar"
+            Ascii40@53..54 "("
+            AConst@54..56
+              Iconst@54..56 "40"
+          Ascii41@56..57 ")"
+          Whitespace@57..58 " "
+          Constraint@58..78
+            Default@58..65 "DEFAULT"
+            Whitespace@65..66 " "
+            AConst@66..78
+              Sconst@66..78 "'Luso Films'"
+        Ascii44@78..79 ","
+        Whitespace@79..80 " "
+        ColumnDef@80..109
+          Ident@80..83 "len"
+          Whitespace@83..84 " "
+          TypeName@84..109
+            Interval@84..92 "interval"
+            Whitespace@92..93 " "
+            AConst@93..97
+              HourP@93..97 "hour"
+            Whitespace@97..98 " "
+            To@98..100 "to"
+            Whitespace@100..101 " "
+            SecondP@101..107 "second"
+            Ascii40@107..108 "("
+            AConst@108..109
+              Iconst@108..109 "3"
+        Ascii41@109..110 ")"
+        Ascii44@110..111 ","
+        Whitespace@111..112 " "
+        ColumnDef@112..149
+          NameP@112..116 "name"
+          Whitespace@116..117 " "
+          TypeName@117..127
+            Varchar@117..124 "varchar"
+            Ascii40@124..125 "("
+            AConst@125..127
+              Iconst@125..127 "40"
+          Ascii41@127..128 ")"
+          Whitespace@128..129 " "
+          Constraint@129..149
+            Default@129..136 "DEFAULT"
+            Whitespace@136..137 " "
+            AConst@137..149
+              Sconst@137..149 "'Luso Films'"
+        Ascii44@149..150 ","
+        Whitespace@150..151 " "
+        ColumnDef@151..196
+          Ident@151..154 "did"
+          Whitespace@154..155 " "
+          TypeName@155..158
+            IntP@155..158 "int"
+          Whitespace@158..159 " "
+          Constraint@159..196
+            Default@159..166 "DEFAULT"
+            Whitespace@166..167 " "
+            FuncCall@167..196
+              Ident@167..174 "nextval"
+              Ascii40@174..175 "("
+              AConst@175..196
+                Sconst@175..196 "'distributors_serial'"
+        Ascii41@196..197 ")"
+        Ascii44@197..198 ","
+        Whitespace@198..199 " "
+        ColumnDef@199..237
+          Ident@199..204 "stamp"
+          Whitespace@204..205 " "
+          TypeName@205..214
+            Timestamp@205..214 "timestamp"
+          Whitespace@214..215 " "
+          Constraint@215..226
+            Default@215..222 "DEFAULT"
+            Whitespace@222..223 " "
+            FuncCall@223..226
+              Ident@223..226 "now"
+          Ascii40@226..227 "("
+          Ascii41@227..228 ")"
+          Whitespace@228..229 " "
+          Constraint@229..237
+            Not@229..232 "NOT"
+            Whitespace@232..233 " "
+            NullP@233..237 "NULL"
+        Ascii44@237..238 ","
+        Whitespace@238..239 " "
+        ColumnDef@239..271
+          Ident@239..246 "stamptz"
+          Whitespace@246..247 " "
+          TypeName@247..271
+            Timestamp@247..256 "timestamp"
+            Whitespace@256..257 " "
+            With@257..261 "with"
+            Whitespace@261..262 " "
+            Time@262..266 "time"
+            Whitespace@266..267 " "
+            Zone@267..271 "zone"
+        Ascii44@271..272 ","
+        Whitespace@272..273 " "
+        ColumnDef@273..293
+          Ident@273..279 "\"time\""
+          Whitespace@279..280 " "
+          TypeName@280..284
+            Time@280..284 "time"
+          Whitespace@284..285 " "
+          Constraint@285..293
+            Not@285..288 "NOT"
+            Whitespace@288..289 " "
+            NullP@289..293 "NULL"
+        Ascii44@293..294 ","
+        Whitespace@294..295 " "
+        ColumnDef@295..321
+          Ident@295..301 "timetz"
+          Whitespace@301..302 " "
+          TypeName@302..321
+            Time@302..306 "time"
+            Whitespace@306..307 " "
+            With@307..311 "with"
+            Whitespace@311..312 " "
+            Time@312..316 "time"
+            Whitespace@316..317 " "
+            Zone@317..321 "zone"
+        Ascii44@321..322 ","
+        Whitespace@322..323 " "
+        Constraint@323..365
+          Constraint@323..333 "CONSTRAINT"
+          Whitespace@333..334 " "
+          Ident@334..342 "name_len"
+          Whitespace@342..343 " "
+          Primary@343..350 "PRIMARY"
+          Whitespace@350..351 " "
+          Key@351..354 "KEY"
+          Whitespace@354..355 " "
+          Ascii40@355..356 "("
+          NameP@356..360 "name"
+          Ascii44@360..361 ","
+          Whitespace@361..362 " "
+          Ident@362..365 "len"
+        Ascii41@365..366 ")"
+        Ascii41@366..367 ")"
+        Ascii59@367..368 ";"
     ,
     errors: [],
     stmts: [
         RawStmt {
-            stmt: SelectStmt(
-                SelectStmt {
-                    distinct_clause: [],
-                    into_clause: None,
-                    target_list: [
+            stmt: CreateStmt(
+                CreateStmt {
+                    relation: Some(
+                        RangeVar {
+                            catalogname: "",
+                            schemaname: "",
+                            relname: "distributors",
+                            inh: true,
+                            relpersistence: "p",
+                            alias: None,
+                            location: 27,
+                        },
+                    ),
+                    table_elts: [
                         Node {
                             node: Some(
-                                ResTarget(
-                                    ResTarget {
-                                        name: "",
-                                        indirection: [],
-                                        val: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "name",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "varchar",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [
+                                                    Node {
+                                                        node: Some(
+                                                            AConst(
+                                                                AConst {
+                                                                    isnull: false,
+                                                                    location: 54,
+                                                                    val: Some(
+                                                                        Ival(
+                                                                            Integer {
+                                                                                ival: 40,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 46,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [
                                             Node {
                                                 node: Some(
-                                                    AConst(
-                                                        AConst {
-                                                            isnull: false,
-                                                            location: 7,
-                                                            val: Some(
-                                                                Ival(
-                                                                    Integer {
-                                                                        ival: 1,
-                                                                    },
-                                                                ),
+                                                    Constraint(
+                                                        Constraint {
+                                                            contype: ConstrDefault,
+                                                            conname: "",
+                                                            deferrable: false,
+                                                            initdeferred: false,
+                                                            location: 58,
+                                                            is_no_inherit: false,
+                                                            raw_expr: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 66,
+                                                                                val: Some(
+                                                                                    Sval(
+                                                                                        String {
+                                                                                            sval: "Luso Films",
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
                                                             ),
+                                                            cooked_expr: "",
+                                                            generated_when: "",
+                                                            nulls_not_distinct: false,
+                                                            keys: [],
+                                                            including: [],
+                                                            exclusions: [],
+                                                            options: [],
+                                                            indexname: "",
+                                                            indexspace: "",
+                                                            reset_default_tblspc: false,
+                                                            access_method: "",
+                                                            where_clause: None,
+                                                            pktable: None,
+                                                            fk_attrs: [],
+                                                            pk_attrs: [],
+                                                            fk_matchtype: "",
+                                                            fk_upd_action: "",
+                                                            fk_del_action: "",
+                                                            fk_del_set_cols: [],
+                                                            old_conpfeqop: [],
+                                                            old_pktable_oid: 0,
+                                                            skip_validation: false,
+                                                            initially_valid: false,
                                                         },
                                                     ),
                                                 ),
                                             },
+                                        ],
+                                        fdwoptions: [],
+                                        location: 41,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "len",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "interval",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [
+                                                    Node {
+                                                        node: Some(
+                                                            AConst(
+                                                                AConst {
+                                                                    isnull: false,
+                                                                    location: 93,
+                                                                    val: Some(
+                                                                        Ival(
+                                                                            Integer {
+                                                                                ival: 7168,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            AConst(
+                                                                AConst {
+                                                                    isnull: false,
+                                                                    location: 108,
+                                                                    val: Some(
+                                                                        Ival(
+                                                                            Integer {
+                                                                                ival: 3,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 84,
+                                            },
                                         ),
-                                        location: 7,
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [],
+                                        fdwoptions: [],
+                                        location: 80,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "name",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "varchar",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [
+                                                    Node {
+                                                        node: Some(
+                                                            AConst(
+                                                                AConst {
+                                                                    isnull: false,
+                                                                    location: 125,
+                                                                    val: Some(
+                                                                        Ival(
+                                                                            Integer {
+                                                                                ival: 40,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 117,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [
+                                            Node {
+                                                node: Some(
+                                                    Constraint(
+                                                        Constraint {
+                                                            contype: ConstrDefault,
+                                                            conname: "",
+                                                            deferrable: false,
+                                                            initdeferred: false,
+                                                            location: 129,
+                                                            is_no_inherit: false,
+                                                            raw_expr: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 137,
+                                                                                val: Some(
+                                                                                    Sval(
+                                                                                        String {
+                                                                                            sval: "Luso Films",
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            cooked_expr: "",
+                                                            generated_when: "",
+                                                            nulls_not_distinct: false,
+                                                            keys: [],
+                                                            including: [],
+                                                            exclusions: [],
+                                                            options: [],
+                                                            indexname: "",
+                                                            indexspace: "",
+                                                            reset_default_tblspc: false,
+                                                            access_method: "",
+                                                            where_clause: None,
+                                                            pktable: None,
+                                                            fk_attrs: [],
+                                                            pk_attrs: [],
+                                                            fk_matchtype: "",
+                                                            fk_upd_action: "",
+                                                            fk_del_action: "",
+                                                            fk_del_set_cols: [],
+                                                            old_conpfeqop: [],
+                                                            old_pktable_oid: 0,
+                                                            skip_validation: false,
+                                                            initially_valid: false,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        fdwoptions: [],
+                                        location: 112,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "did",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "int4",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 155,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [
+                                            Node {
+                                                node: Some(
+                                                    Constraint(
+                                                        Constraint {
+                                                            contype: ConstrDefault,
+                                                            conname: "",
+                                                            deferrable: false,
+                                                            initdeferred: false,
+                                                            location: 159,
+                                                            is_no_inherit: false,
+                                                            raw_expr: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        FuncCall(
+                                                                            FuncCall {
+                                                                                funcname: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: "nextval",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                args: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            AConst(
+                                                                                                AConst {
+                                                                                                    isnull: false,
+                                                                                                    location: 175,
+                                                                                                    val: Some(
+                                                                                                        Sval(
+                                                                                                            String {
+                                                                                                                sval: "distributors_serial",
+                                                                                                            },
+                                                                                                        ),
+                                                                                                    ),
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                agg_order: [],
+                                                                                agg_filter: None,
+                                                                                over: None,
+                                                                                agg_within_group: false,
+                                                                                agg_star: false,
+                                                                                agg_distinct: false,
+                                                                                func_variadic: false,
+                                                                                funcformat: CoerceExplicitCall,
+                                                                                location: 167,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            cooked_expr: "",
+                                                            generated_when: "",
+                                                            nulls_not_distinct: false,
+                                                            keys: [],
+                                                            including: [],
+                                                            exclusions: [],
+                                                            options: [],
+                                                            indexname: "",
+                                                            indexspace: "",
+                                                            reset_default_tblspc: false,
+                                                            access_method: "",
+                                                            where_clause: None,
+                                                            pktable: None,
+                                                            fk_attrs: [],
+                                                            pk_attrs: [],
+                                                            fk_matchtype: "",
+                                                            fk_upd_action: "",
+                                                            fk_del_action: "",
+                                                            fk_del_set_cols: [],
+                                                            old_conpfeqop: [],
+                                                            old_pktable_oid: 0,
+                                                            skip_validation: false,
+                                                            initially_valid: false,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        fdwoptions: [],
+                                        location: 151,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "stamp",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "timestamp",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 205,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [
+                                            Node {
+                                                node: Some(
+                                                    Constraint(
+                                                        Constraint {
+                                                            contype: ConstrDefault,
+                                                            conname: "",
+                                                            deferrable: false,
+                                                            initdeferred: false,
+                                                            location: 215,
+                                                            is_no_inherit: false,
+                                                            raw_expr: Some(
+                                                                Node {
+                                                                    node: Some(
+                                                                        FuncCall(
+                                                                            FuncCall {
+                                                                                funcname: [
+                                                                                    Node {
+                                                                                        node: Some(
+                                                                                            String(
+                                                                                                String {
+                                                                                                    sval: "now",
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                args: [],
+                                                                                agg_order: [],
+                                                                                agg_filter: None,
+                                                                                over: None,
+                                                                                agg_within_group: false,
+                                                                                agg_star: false,
+                                                                                agg_distinct: false,
+                                                                                func_variadic: false,
+                                                                                funcformat: CoerceExplicitCall,
+                                                                                location: 223,
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            cooked_expr: "",
+                                                            generated_when: "",
+                                                            nulls_not_distinct: false,
+                                                            keys: [],
+                                                            including: [],
+                                                            exclusions: [],
+                                                            options: [],
+                                                            indexname: "",
+                                                            indexspace: "",
+                                                            reset_default_tblspc: false,
+                                                            access_method: "",
+                                                            where_clause: None,
+                                                            pktable: None,
+                                                            fk_attrs: [],
+                                                            pk_attrs: [],
+                                                            fk_matchtype: "",
+                                                            fk_upd_action: "",
+                                                            fk_del_action: "",
+                                                            fk_del_set_cols: [],
+                                                            old_conpfeqop: [],
+                                                            old_pktable_oid: 0,
+                                                            skip_validation: false,
+                                                            initially_valid: false,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                            Node {
+                                                node: Some(
+                                                    Constraint(
+                                                        Constraint {
+                                                            contype: ConstrNotnull,
+                                                            conname: "",
+                                                            deferrable: false,
+                                                            initdeferred: false,
+                                                            location: 229,
+                                                            is_no_inherit: false,
+                                                            raw_expr: None,
+                                                            cooked_expr: "",
+                                                            generated_when: "",
+                                                            nulls_not_distinct: false,
+                                                            keys: [],
+                                                            including: [],
+                                                            exclusions: [],
+                                                            options: [],
+                                                            indexname: "",
+                                                            indexspace: "",
+                                                            reset_default_tblspc: false,
+                                                            access_method: "",
+                                                            where_clause: None,
+                                                            pktable: None,
+                                                            fk_attrs: [],
+                                                            pk_attrs: [],
+                                                            fk_matchtype: "",
+                                                            fk_upd_action: "",
+                                                            fk_del_action: "",
+                                                            fk_del_set_cols: [],
+                                                            old_conpfeqop: [],
+                                                            old_pktable_oid: 0,
+                                                            skip_validation: false,
+                                                            initially_valid: false,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        fdwoptions: [],
+                                        location: 199,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "stamptz",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "timestamptz",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 247,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [],
+                                        fdwoptions: [],
+                                        location: 239,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "time",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "time",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 280,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [
+                                            Node {
+                                                node: Some(
+                                                    Constraint(
+                                                        Constraint {
+                                                            contype: ConstrNotnull,
+                                                            conname: "",
+                                                            deferrable: false,
+                                                            initdeferred: false,
+                                                            location: 285,
+                                                            is_no_inherit: false,
+                                                            raw_expr: None,
+                                                            cooked_expr: "",
+                                                            generated_when: "",
+                                                            nulls_not_distinct: false,
+                                                            keys: [],
+                                                            including: [],
+                                                            exclusions: [],
+                                                            options: [],
+                                                            indexname: "",
+                                                            indexspace: "",
+                                                            reset_default_tblspc: false,
+                                                            access_method: "",
+                                                            where_clause: None,
+                                                            pktable: None,
+                                                            fk_attrs: [],
+                                                            pk_attrs: [],
+                                                            fk_matchtype: "",
+                                                            fk_upd_action: "",
+                                                            fk_del_action: "",
+                                                            fk_del_set_cols: [],
+                                                            old_conpfeqop: [],
+                                                            old_pktable_oid: 0,
+                                                            skip_validation: false,
+                                                            initially_valid: false,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        fdwoptions: [],
+                                        location: 273,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ColumnDef(
+                                    ColumnDef {
+                                        colname: "timetz",
+                                        type_name: Some(
+                                            TypeName {
+                                                names: [
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "pg_catalog",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    Node {
+                                                        node: Some(
+                                                            String(
+                                                                String {
+                                                                    sval: "timetz",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ],
+                                                type_oid: 0,
+                                                setof: false,
+                                                pct_type: false,
+                                                typmods: [],
+                                                typemod: -1,
+                                                array_bounds: [],
+                                                location: 302,
+                                            },
+                                        ),
+                                        compression: "",
+                                        inhcount: 0,
+                                        is_local: true,
+                                        is_not_null: false,
+                                        is_from_type: false,
+                                        storage: "",
+                                        raw_default: None,
+                                        cooked_default: None,
+                                        identity: "",
+                                        identity_sequence: None,
+                                        generated: "",
+                                        coll_clause: None,
+                                        coll_oid: 0,
+                                        constraints: [],
+                                        fdwoptions: [],
+                                        location: 295,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                Constraint(
+                                    Constraint {
+                                        contype: ConstrPrimary,
+                                        conname: "name_len",
+                                        deferrable: false,
+                                        initdeferred: false,
+                                        location: 323,
+                                        is_no_inherit: false,
+                                        raw_expr: None,
+                                        cooked_expr: "",
+                                        generated_when: "",
+                                        nulls_not_distinct: false,
+                                        keys: [
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "name",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "len",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        including: [],
+                                        exclusions: [],
+                                        options: [],
+                                        indexname: "",
+                                        indexspace: "",
+                                        reset_default_tblspc: false,
+                                        access_method: "",
+                                        where_clause: None,
+                                        pktable: None,
+                                        fk_attrs: [],
+                                        pk_attrs: [],
+                                        fk_matchtype: "",
+                                        fk_upd_action: "",
+                                        fk_del_action: "",
+                                        fk_del_set_cols: [],
+                                        old_conpfeqop: [],
+                                        old_pktable_oid: 0,
+                                        skip_validation: false,
+                                        initially_valid: false,
                                     },
                                 ),
                             ),
                         },
                     ],
-                    from_clause: [],
-                    where_clause: None,
-                    group_clause: [],
-                    group_distinct: false,
-                    having_clause: None,
-                    window_clause: [],
-                    values_lists: [],
-                    sort_clause: [],
-                    limit_offset: None,
-                    limit_count: None,
-                    limit_option: Default,
-                    locking_clause: [],
-                    with_clause: None,
-                    op: SetopNone,
-                    all: false,
-                    larg: None,
-                    rarg: None,
+                    inh_relations: [],
+                    partbound: None,
+                    partspec: None,
+                    of_typename: None,
+                    constraints: [],
+                    options: [],
+                    oncommit: OncommitNoop,
+                    tablespacename: "",
+                    access_method: "",
+                    if_not_exists: true,
                 },
             ),
-            range: 380..389,
+            range: 0..367,
         },
     ],
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

add support for "some" `typename`

## What is the current behavior?

parser panics

## What is the new behavior?

parser returns

## Additional context

as I understands it, the case that causes panics are: 
- multi-word type name, eg: `timestamp with time zone`
- and interval options, eg: `hour to second(3)`

single-word type name, looks ok but I will have to double-check. cc @psteinroe 