### PR TITLE
feat: add datatypes aliases

### DIFF
--- a/crates/parser/src/parse/libpg_query_node.rs
+++ b/crates/parser/src/parse/libpg_query_node.rs
@@ -412,7 +412,23 @@ impl<'p> LibpgQueryNodeParser<'p> {
 }
 
 /// list of aliases from https://www.postgresql.org/docs/current/datatype.html
-const ALIASES: [&[&str]; 2] = [&["integer", "int", "int4"], &["real", "float4"]];
+const ALIASES: [&[&str]; 15] = [
+    &["bigint", "int8"],
+    &["bigserial", "serial8"],
+    &["bit varying", "varbit"],
+    &["boolean", "bool"],
+    &["character", "char"],
+    &["character varying", "varchar"],
+    &["double precision", "float8"],
+    &["integer", "int", "int4"],
+    &["numeric", "decimal"],
+    &["real", "float4"],
+    &["smallint", "int2"],
+    &["smallserial", "serial2"],
+    &["serial", "serial4"],
+    &["time with time zone", "timetz"],
+    &["timestamp with time zone", "timestamptz"],
+];
 
 fn cmp_tokens(p: &crate::codegen::TokenProperty, token: &crate::lexer::Token) -> bool {
     // TokenProperty has always either value or kind set

--- a/crates/parser/src/parse/libpg_query_node.rs
+++ b/crates/parser/src/parse/libpg_query_node.rs
@@ -412,22 +412,18 @@ impl<'p> LibpgQueryNodeParser<'p> {
 }
 
 /// list of aliases from https://www.postgresql.org/docs/current/datatype.html
-const ALIASES: [&[&str]; 15] = [
+/// NOTE: support for multi-word alias (e.g. time with time zone) requires parser change
+const ALIASES: [&[&str]; 10] = [
     &["bigint", "int8"],
     &["bigserial", "serial8"],
-    &["bit varying", "varbit"],
     &["boolean", "bool"],
     &["character", "char"],
-    &["character varying", "varchar"],
-    &["double precision", "float8"],
     &["integer", "int", "int4"],
     &["numeric", "decimal"],
     &["real", "float4"],
     &["smallint", "int2"],
     &["smallserial", "serial2"],
     &["serial", "serial4"],
-    &["time with time zone", "timetz"],
-    &["timestamp with time zone", "timestamptz"],
 ];
 
 fn cmp_tokens(p: &crate::codegen::TokenProperty, token: &crate::lexer::Token) -> bool {


### PR DESCRIPTION
## What kind of change does this PR introduce?

copy data types from https://www.postgresql.org/docs/current/datatype.html

## What is the current behavior?

missing aliases

## What is the new behavior?

added aliases

## Additional context

as per https://github.com/supabase/postgres_lsp/pull/109#discussion_r1445248208, multi-word type names (eg. `timestamp with time zone`) requires a larger change