### PR TITLE
feat: support `transaction begin`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,3 @@
 [alias]
+snap = "insta test"
 xtask = "run --package xtask --"

--- a/crates/codegen/src/get_node_properties.rs
+++ b/crates/codegen/src/get_node_properties.rs
@@ -486,6 +486,7 @@ fn custom_handlers(node: &Node) -> TokenStream {
         },
         "TransactionStmt" => quote! {
             match n.kind() {
+                protobuf::TransactionStmtKind::TransStmtBegin => tokens.push(TokenProperty::from(Token::BeginP)),
                 protobuf::TransactionStmtKind::TransStmtCommit => tokens.push(TokenProperty::from(Token::Commit)),
                 _ => panic!("Unknown TransactionStmt {:#?}", n.kind())
             }

--- a/crates/parser/tests/skipped.txt
+++ b/crates/parser/tests/skipped.txt
@@ -1,4 +1,3 @@
-advisory_lock
 aggregates
 alter_generic
 alter_operator

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@1.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@1.snap
@@ -1,0 +1,32 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "--\n-- ADVISORY LOCKS\n--\n\nBEGIN;"
+---
+Parse {
+    cst: SourceFile@0..31
+      SqlComment@0..2 "--"
+      Newline@2..3 "\n"
+      SqlComment@3..20 "-- ADVISORY LOCKS"
+      Newline@20..21 "\n"
+      SqlComment@21..23 "--"
+      Newline@23..25 "\n\n"
+      TransactionStmt@25..31
+        BeginP@25..30 "BEGIN"
+        Ascii59@30..31 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: TransactionStmt(
+                TransactionStmt {
+                    kind: TransStmtBegin,
+                    options: [],
+                    savepoint_name: "",
+                    gid: "",
+                    chain: false,
+                },
+            ),
+            range: 24..30,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@10.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@10.snap
@@ -1,0 +1,363 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "-- holding both session and xact locks on the same objects, xact first\nSELECT\n\tpg_advisory_xact_lock(1), pg_advisory_xact_lock_shared(2),\n\tpg_advisory_xact_lock(1, 1), pg_advisory_xact_lock_shared(2, 2);"
+---
+Parse {
+    cst: SourceFile@0..203
+      SqlComment@0..70 "-- holding both sessi ..."
+      Newline@70..71 "\n"
+      SelectStmt@71..203
+        Select@71..77 "SELECT"
+        Newline@77..78 "\n"
+        Newline@78..79 "\t"
+        ResTarget@79..102
+          FuncCall@79..102
+            Ident@79..100 "pg_advisory_xact_lock"
+            Ascii40@100..101 "("
+            AConst@101..102
+              Iconst@101..102 "1"
+        Ascii41@102..103 ")"
+        Ascii44@103..104 ","
+        Whitespace@104..105 " "
+        ResTarget@105..135
+          FuncCall@105..135
+            Ident@105..133 "pg_advisory_xact_lock ..."
+            Ascii40@133..134 "("
+            AConst@134..135
+              Iconst@134..135 "2"
+        Ascii41@135..136 ")"
+        Ascii44@136..137 ","
+        Newline@137..138 "\n"
+        Newline@138..139 "\t"
+        ResTarget@139..165
+          FuncCall@139..165
+            Ident@139..160 "pg_advisory_xact_lock"
+            Ascii40@160..161 "("
+            AConst@161..162
+              Iconst@161..162 "1"
+            Ascii44@162..163 ","
+            Whitespace@163..164 " "
+            AConst@164..165
+              Iconst@164..165 "1"
+        Ascii41@165..166 ")"
+        Ascii44@166..167 ","
+        Whitespace@167..168 " "
+        ResTarget@168..201
+          FuncCall@168..201
+            Ident@168..196 "pg_advisory_xact_lock ..."
+            Ascii40@196..197 "("
+            AConst@197..198
+              Iconst@197..198 "2"
+            Ascii44@198..199 ","
+            Whitespace@199..200 " "
+            AConst@200..201
+              Iconst@200..201 "2"
+        Ascii41@201..202 ")"
+        Ascii59@202..203 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_xact_lock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 30,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 8,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 8,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_xact_lock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 63,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 34,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 34,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_xact_lock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 90,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 93,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 68,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 68,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_xact_lock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 126,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 129,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 97,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 97,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [],
+                    where_clause: None,
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 70..202,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@11.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@11.snap
@@ -1,0 +1,487 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "SELECT locktype, classid, objid, objsubid, mode, granted\n\tFROM pg_locks WHERE locktype = 'advisory'\n\tORDER BY classid, objid, objsubid;"
+---
+Parse {
+    cst: SourceFile@0..135
+      SelectStmt@0..135
+        Select@0..6 "SELECT"
+        Whitespace@6..7 " "
+        ResTarget@7..15
+          ColumnRef@7..15
+            Ident@7..15 "locktype"
+        Ascii44@15..16 ","
+        Whitespace@16..17 " "
+        ResTarget@17..24
+          ColumnRef@17..24
+            Ident@17..24 "classid"
+        Ascii44@24..25 ","
+        Whitespace@25..26 " "
+        ResTarget@26..31
+          ColumnRef@26..31
+            Ident@26..31 "objid"
+        Ascii44@31..32 ","
+        Whitespace@32..33 " "
+        ResTarget@33..41
+          ColumnRef@33..41
+            Ident@33..41 "objsubid"
+        Ascii44@41..42 ","
+        Whitespace@42..43 " "
+        ResTarget@43..47
+          ColumnRef@43..47
+            Mode@43..47 "mode"
+        Ascii44@47..48 ","
+        Whitespace@48..49 " "
+        ResTarget@49..56
+          ColumnRef@49..56
+            Granted@49..56 "granted"
+        Newline@56..57 "\n"
+        Newline@57..58 "\t"
+        From@58..62 "FROM"
+        Whitespace@62..63 " "
+        RangeVar@63..71
+          Ident@63..71 "pg_locks"
+        Whitespace@71..72 " "
+        Where@72..77 "WHERE"
+        Whitespace@77..78 " "
+        AExpr@78..99
+          ColumnRef@78..86
+            Ident@78..86 "locktype"
+          Whitespace@86..87 " "
+          Ascii61@87..88 "="
+          Whitespace@88..89 " "
+          AConst@89..99
+            Sconst@89..99 "'advisory'"
+        Newline@99..100 "\n"
+        Newline@100..101 "\t"
+        SortBy@101..117
+          Order@101..106 "ORDER"
+          Whitespace@106..107 " "
+          By@107..109 "BY"
+          Whitespace@109..110 " "
+          ColumnRef@110..117
+            Ident@110..117 "classid"
+        Ascii44@117..118 ","
+        Whitespace@118..119 " "
+        SortBy@119..124
+          ColumnRef@119..124
+            Ident@119..124 "objid"
+        Ascii44@124..125 ","
+        Whitespace@125..126 " "
+        SortBy@126..134
+          ColumnRef@126..134
+            Ident@126..134 "objsubid"
+        Ascii59@134..135 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "locktype",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 7,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "classid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 17,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 17,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 26,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 26,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objsubid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 33,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 33,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "mode",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 43,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 43,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "granted",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 49,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 49,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [
+                        Node {
+                            node: Some(
+                                RangeVar(
+                                    RangeVar {
+                                        catalogname: "",
+                                        schemaname: "",
+                                        relname: "pg_locks",
+                                        inh: true,
+                                        relpersistence: "p",
+                                        alias: None,
+                                        location: 63,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    where_clause: Some(
+                        Node {
+                            node: Some(
+                                AExpr(
+                                    AExpr {
+                                        kind: AexprOp,
+                                        name: [
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "=",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        lexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "locktype",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 78,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        rexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    AConst(
+                                                        AConst {
+                                                            isnull: false,
+                                                            location: 89,
+                                                            val: Some(
+                                                                Sval(
+                                                                    String {
+                                                                        sval: "advisory",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 87,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [
+                        Node {
+                            node: Some(
+                                SortBy(
+                                    SortBy {
+                                        node: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "classid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 110,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        sortby_dir: SortbyDefault,
+                                        sortby_nulls: SortbyNullsDefault,
+                                        use_op: [],
+                                        location: -1,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                SortBy(
+                                    SortBy {
+                                        node: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 119,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        sortby_dir: SortbyDefault,
+                                        sortby_nulls: SortbyNullsDefault,
+                                        use_op: [],
+                                        location: -1,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                SortBy(
+                                    SortBy {
+                                        node: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objsubid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 126,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        sortby_dir: SortbyDefault,
+                                        sortby_nulls: SortbyNullsDefault,
+                                        use_op: [],
+                                        location: -1,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..134,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@12.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@12.snap
@@ -1,0 +1,361 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "SELECT\n\tpg_advisory_lock(1), pg_advisory_lock_shared(2),\n\tpg_advisory_lock(1, 1), pg_advisory_lock_shared(2, 2);"
+---
+Parse {
+    cst: SourceFile@0..112
+      SelectStmt@0..112
+        Select@0..6 "SELECT"
+        Newline@6..7 "\n"
+        Newline@7..8 "\t"
+        ResTarget@8..26
+          FuncCall@8..26
+            Ident@8..24 "pg_advisory_lock"
+            Ascii40@24..25 "("
+            AConst@25..26
+              Iconst@25..26 "1"
+        Ascii41@26..27 ")"
+        Ascii44@27..28 ","
+        Whitespace@28..29 " "
+        ResTarget@29..54
+          FuncCall@29..54
+            Ident@29..52 "pg_advisory_lock_shared"
+            Ascii40@52..53 "("
+            AConst@53..54
+              Iconst@53..54 "2"
+        Ascii41@54..55 ")"
+        Ascii44@55..56 ","
+        Newline@56..57 "\n"
+        Newline@57..58 "\t"
+        ResTarget@58..79
+          FuncCall@58..79
+            Ident@58..74 "pg_advisory_lock"
+            Ascii40@74..75 "("
+            AConst@75..76
+              Iconst@75..76 "1"
+            Ascii44@76..77 ","
+            Whitespace@77..78 " "
+            AConst@78..79
+              Iconst@78..79 "1"
+        Ascii41@79..80 ")"
+        Ascii44@80..81 ","
+        Whitespace@81..82 " "
+        ResTarget@82..110
+          FuncCall@82..110
+            Ident@82..105 "pg_advisory_lock_shared"
+            Ascii40@105..106 "("
+            AConst@106..107
+              Iconst@106..107 "2"
+            Ascii44@107..108 ","
+            Whitespace@108..109 " "
+            AConst@109..110
+              Iconst@109..110 "2"
+        Ascii41@110..111 ")"
+        Ascii59@111..112 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_lock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 25,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 8,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 8,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_lock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 53,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 29,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 29,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_lock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 75,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 78,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 58,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 58,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_lock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 106,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 109,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 82,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 82,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [],
+                    where_clause: None,
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..111,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@13.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@13.snap
@@ -1,0 +1,12 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: ROLLBACK;
+---
+Parse {
+    cst: SourceFile@0..9
+      Rollback@0..8 "ROLLBACK"
+      Ascii59@8..9 ";"
+    ,
+    errors: [],
+    stmts: [],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@14.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@14.snap
@@ -1,0 +1,487 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "SELECT locktype, classid, objid, objsubid, mode, granted\n\tFROM pg_locks WHERE locktype = 'advisory'\n\tORDER BY classid, objid, objsubid;"
+---
+Parse {
+    cst: SourceFile@0..135
+      SelectStmt@0..135
+        Select@0..6 "SELECT"
+        Whitespace@6..7 " "
+        ResTarget@7..15
+          ColumnRef@7..15
+            Ident@7..15 "locktype"
+        Ascii44@15..16 ","
+        Whitespace@16..17 " "
+        ResTarget@17..24
+          ColumnRef@17..24
+            Ident@17..24 "classid"
+        Ascii44@24..25 ","
+        Whitespace@25..26 " "
+        ResTarget@26..31
+          ColumnRef@26..31
+            Ident@26..31 "objid"
+        Ascii44@31..32 ","
+        Whitespace@32..33 " "
+        ResTarget@33..41
+          ColumnRef@33..41
+            Ident@33..41 "objsubid"
+        Ascii44@41..42 ","
+        Whitespace@42..43 " "
+        ResTarget@43..47
+          ColumnRef@43..47
+            Mode@43..47 "mode"
+        Ascii44@47..48 ","
+        Whitespace@48..49 " "
+        ResTarget@49..56
+          ColumnRef@49..56
+            Granted@49..56 "granted"
+        Newline@56..57 "\n"
+        Newline@57..58 "\t"
+        From@58..62 "FROM"
+        Whitespace@62..63 " "
+        RangeVar@63..71
+          Ident@63..71 "pg_locks"
+        Whitespace@71..72 " "
+        Where@72..77 "WHERE"
+        Whitespace@77..78 " "
+        AExpr@78..99
+          ColumnRef@78..86
+            Ident@78..86 "locktype"
+          Whitespace@86..87 " "
+          Ascii61@87..88 "="
+          Whitespace@88..89 " "
+          AConst@89..99
+            Sconst@89..99 "'advisory'"
+        Newline@99..100 "\n"
+        Newline@100..101 "\t"
+        SortBy@101..117
+          Order@101..106 "ORDER"
+          Whitespace@106..107 " "
+          By@107..109 "BY"
+          Whitespace@109..110 " "
+          ColumnRef@110..117
+            Ident@110..117 "classid"
+        Ascii44@117..118 ","
+        Whitespace@118..119 " "
+        SortBy@119..124
+          ColumnRef@119..124
+            Ident@119..124 "objid"
+        Ascii44@124..125 ","
+        Whitespace@125..126 " "
+        SortBy@126..134
+          ColumnRef@126..134
+            Ident@126..134 "objsubid"
+        Ascii59@134..135 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "locktype",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 7,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "classid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 17,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 17,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 26,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 26,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objsubid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 33,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 33,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "mode",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 43,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 43,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "granted",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 49,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 49,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [
+                        Node {
+                            node: Some(
+                                RangeVar(
+                                    RangeVar {
+                                        catalogname: "",
+                                        schemaname: "",
+                                        relname: "pg_locks",
+                                        inh: true,
+                                        relpersistence: "p",
+                                        alias: None,
+                                        location: 63,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    where_clause: Some(
+                        Node {
+                            node: Some(
+                                AExpr(
+                                    AExpr {
+                                        kind: AexprOp,
+                                        name: [
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "=",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        lexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "locktype",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 78,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        rexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    AConst(
+                                                        AConst {
+                                                            isnull: false,
+                                                            location: 89,
+                                                            val: Some(
+                                                                Sval(
+                                                                    String {
+                                                                        sval: "advisory",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 87,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [
+                        Node {
+                            node: Some(
+                                SortBy(
+                                    SortBy {
+                                        node: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "classid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 110,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        sortby_dir: SortbyDefault,
+                                        sortby_nulls: SortbyNullsDefault,
+                                        use_op: [],
+                                        location: -1,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                SortBy(
+                                    SortBy {
+                                        node: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 119,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        sortby_dir: SortbyDefault,
+                                        sortby_nulls: SortbyNullsDefault,
+                                        use_op: [],
+                                        location: -1,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                SortBy(
+                                    SortBy {
+                                        node: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objsubid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 126,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        sortby_dir: SortbyDefault,
+                                        sortby_nulls: SortbyNullsDefault,
+                                        use_op: [],
+                                        location: -1,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..134,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@15.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@15.snap
@@ -1,0 +1,683 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "-- unlocking session locks\nSELECT\n\tpg_advisory_unlock(1), pg_advisory_unlock(1),\n\tpg_advisory_unlock_shared(2), pg_advisory_unlock_shared(2),\n\tpg_advisory_unlock(1, 1), pg_advisory_unlock(1, 1),\n\tpg_advisory_unlock_shared(2, 2), pg_advisory_unlock_shared(2, 2);"
+---
+Parse {
+    cst: SourceFile@0..261
+      SqlComment@0..26 "-- unlocking session  ..."
+      Newline@26..27 "\n"
+      SelectStmt@27..261
+        Select@27..33 "SELECT"
+        Newline@33..34 "\n"
+        Newline@34..35 "\t"
+        ResTarget@35..55
+          FuncCall@35..55
+            Ident@35..53 "pg_advisory_unlock"
+            Ascii40@53..54 "("
+            AConst@54..55
+              Iconst@54..55 "1"
+        Ascii41@55..56 ")"
+        Ascii44@56..57 ","
+        Whitespace@57..58 " "
+        ResTarget@58..78
+          FuncCall@58..78
+            Ident@58..76 "pg_advisory_unlock"
+            Ascii40@76..77 "("
+            AConst@77..78
+              Iconst@77..78 "1"
+        Ascii41@78..79 ")"
+        Ascii44@79..80 ","
+        Newline@80..81 "\n"
+        Newline@81..82 "\t"
+        ResTarget@82..109
+          FuncCall@82..109
+            Ident@82..107 "pg_advisory_unlock_sh ..."
+            Ascii40@107..108 "("
+            AConst@108..109
+              Iconst@108..109 "2"
+        Ascii41@109..110 ")"
+        Ascii44@110..111 ","
+        Whitespace@111..112 " "
+        ResTarget@112..139
+          FuncCall@112..139
+            Ident@112..137 "pg_advisory_unlock_sh ..."
+            Ascii40@137..138 "("
+            AConst@138..139
+              Iconst@138..139 "2"
+        Ascii41@139..140 ")"
+        Ascii44@140..141 ","
+        Newline@141..142 "\n"
+        Newline@142..143 "\t"
+        ResTarget@143..166
+          FuncCall@143..166
+            Ident@143..161 "pg_advisory_unlock"
+            Ascii40@161..162 "("
+            AConst@162..163
+              Iconst@162..163 "1"
+            Ascii44@163..164 ","
+            Whitespace@164..165 " "
+            AConst@165..166
+              Iconst@165..166 "1"
+        Ascii41@166..167 ")"
+        Ascii44@167..168 ","
+        Whitespace@168..169 " "
+        ResTarget@169..192
+          FuncCall@169..192
+            Ident@169..187 "pg_advisory_unlock"
+            Ascii40@187..188 "("
+            AConst@188..189
+              Iconst@188..189 "1"
+            Ascii44@189..190 ","
+            Whitespace@190..191 " "
+            AConst@191..192
+              Iconst@191..192 "1"
+        Ascii41@192..193 ")"
+        Ascii44@193..194 ","
+        Newline@194..195 "\n"
+        Newline@195..196 "\t"
+        ResTarget@196..226
+          FuncCall@196..226
+            Ident@196..221 "pg_advisory_unlock_sh ..."
+            Ascii40@221..222 "("
+            AConst@222..223
+              Iconst@222..223 "2"
+            Ascii44@223..224 ","
+            Whitespace@224..225 " "
+            AConst@225..226
+              Iconst@225..226 "2"
+        Ascii41@226..227 ")"
+        Ascii44@227..228 ","
+        Whitespace@228..229 " "
+        ResTarget@229..259
+          FuncCall@229..259
+            Ident@229..254 "pg_advisory_unlock_sh ..."
+            Ascii40@254..255 "("
+            AConst@255..256
+              Iconst@255..256 "2"
+            Ascii44@256..257 ","
+            Whitespace@257..258 " "
+            AConst@258..259
+              Iconst@258..259 "2"
+        Ascii41@259..260 ")"
+        Ascii59@260..261 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_unlock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 27,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 8,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 8,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_unlock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 50,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 31,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 31,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_unlock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 81,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 55,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 55,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_unlock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 111,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 85,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 85,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_unlock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 135,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 138,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 116,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 116,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_unlock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 161,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 164,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 142,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 142,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_unlock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 195,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 198,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 169,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 169,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_unlock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 228,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 231,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 202,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 202,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [],
+                    where_clause: None,
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 26..260,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@16.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@16.snap
@@ -1,0 +1,186 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "SELECT count(*) FROM pg_locks WHERE locktype = 'advisory';"
+---
+Parse {
+    cst: SourceFile@0..58
+      SelectStmt@0..58
+        Select@0..6 "SELECT"
+        Whitespace@6..7 " "
+        ResTarget@7..14
+          FuncCall@7..14
+            Ident@7..12 "count"
+            Ascii40@12..13 "("
+            Ascii42@13..14 "*"
+        Ascii41@14..15 ")"
+        Whitespace@15..16 " "
+        From@16..20 "FROM"
+        Whitespace@20..21 " "
+        RangeVar@21..29
+          Ident@21..29 "pg_locks"
+        Whitespace@29..30 " "
+        Where@30..35 "WHERE"
+        Whitespace@35..36 " "
+        AExpr@36..57
+          ColumnRef@36..44
+            Ident@36..44 "locktype"
+          Whitespace@44..45 " "
+          Ascii61@45..46 "="
+          Whitespace@46..47 " "
+          AConst@47..57
+            Sconst@47..57 "'advisory'"
+        Ascii59@57..58 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "count",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: true,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 7,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [
+                        Node {
+                            node: Some(
+                                RangeVar(
+                                    RangeVar {
+                                        catalogname: "",
+                                        schemaname: "",
+                                        relname: "pg_locks",
+                                        inh: true,
+                                        relpersistence: "p",
+                                        alias: None,
+                                        location: 21,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    where_clause: Some(
+                        Node {
+                            node: Some(
+                                AExpr(
+                                    AExpr {
+                                        kind: AexprOp,
+                                        name: [
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "=",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        lexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "locktype",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 36,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        rexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    AConst(
+                                                        AConst {
+                                                            isnull: false,
+                                                            location: 47,
+                                                            val: Some(
+                                                                Sval(
+                                                                    String {
+                                                                        sval: "advisory",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 45,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..57,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@17.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@17.snap
@@ -1,0 +1,26 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: BEGIN;
+---
+Parse {
+    cst: SourceFile@0..6
+      TransactionStmt@0..6
+        BeginP@0..5 "BEGIN"
+        Ascii59@5..6 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: TransactionStmt(
+                TransactionStmt {
+                    kind: TransStmtBegin,
+                    options: [],
+                    savepoint_name: "",
+                    gid: "",
+                    chain: false,
+                },
+            ),
+            range: 0..5,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@18.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@18.snap
@@ -1,0 +1,363 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "-- holding both session and xact locks on the same objects, session first\nSELECT\n\tpg_advisory_lock(1), pg_advisory_lock_shared(2),\n\tpg_advisory_lock(1, 1), pg_advisory_lock_shared(2, 2);"
+---
+Parse {
+    cst: SourceFile@0..186
+      SqlComment@0..73 "-- holding both sessi ..."
+      Newline@73..74 "\n"
+      SelectStmt@74..186
+        Select@74..80 "SELECT"
+        Newline@80..81 "\n"
+        Newline@81..82 "\t"
+        ResTarget@82..100
+          FuncCall@82..100
+            Ident@82..98 "pg_advisory_lock"
+            Ascii40@98..99 "("
+            AConst@99..100
+              Iconst@99..100 "1"
+        Ascii41@100..101 ")"
+        Ascii44@101..102 ","
+        Whitespace@102..103 " "
+        ResTarget@103..128
+          FuncCall@103..128
+            Ident@103..126 "pg_advisory_lock_shared"
+            Ascii40@126..127 "("
+            AConst@127..128
+              Iconst@127..128 "2"
+        Ascii41@128..129 ")"
+        Ascii44@129..130 ","
+        Newline@130..131 "\n"
+        Newline@131..132 "\t"
+        ResTarget@132..153
+          FuncCall@132..153
+            Ident@132..148 "pg_advisory_lock"
+            Ascii40@148..149 "("
+            AConst@149..150
+              Iconst@149..150 "1"
+            Ascii44@150..151 ","
+            Whitespace@151..152 " "
+            AConst@152..153
+              Iconst@152..153 "1"
+        Ascii41@153..154 ")"
+        Ascii44@154..155 ","
+        Whitespace@155..156 " "
+        ResTarget@156..184
+          FuncCall@156..184
+            Ident@156..179 "pg_advisory_lock_shared"
+            Ascii40@179..180 "("
+            AConst@180..181
+              Iconst@180..181 "2"
+            Ascii44@181..182 ","
+            Whitespace@182..183 " "
+            AConst@183..184
+              Iconst@183..184 "2"
+        Ascii41@184..185 ")"
+        Ascii59@185..186 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_lock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 25,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 8,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 8,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_lock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 53,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 29,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 29,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_lock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 75,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 78,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 58,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 58,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_lock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 106,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 109,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 82,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 82,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [],
+                    where_clause: None,
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 73..185,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@19.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@19.snap
@@ -1,0 +1,487 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "SELECT locktype, classid, objid, objsubid, mode, granted\n\tFROM pg_locks WHERE locktype = 'advisory'\n\tORDER BY classid, objid, objsubid;"
+---
+Parse {
+    cst: SourceFile@0..135
+      SelectStmt@0..135
+        Select@0..6 "SELECT"
+        Whitespace@6..7 " "
+        ResTarget@7..15
+          ColumnRef@7..15
+            Ident@7..15 "locktype"
+        Ascii44@15..16 ","
+        Whitespace@16..17 " "
+        ResTarget@17..24
+          ColumnRef@17..24
+            Ident@17..24 "classid"
+        Ascii44@24..25 ","
+        Whitespace@25..26 " "
+        ResTarget@26..31
+          ColumnRef@26..31
+            Ident@26..31 "objid"
+        Ascii44@31..32 ","
+        Whitespace@32..33 " "
+        ResTarget@33..41
+          ColumnRef@33..41
+            Ident@33..41 "objsubid"
+        Ascii44@41..42 ","
+        Whitespace@42..43 " "
+        ResTarget@43..47
+          ColumnRef@43..47
+            Mode@43..47 "mode"
+        Ascii44@47..48 ","
+        Whitespace@48..49 " "
+        ResTarget@49..56
+          ColumnRef@49..56
+            Granted@49..56 "granted"
+        Newline@56..57 "\n"
+        Newline@57..58 "\t"
+        From@58..62 "FROM"
+        Whitespace@62..63 " "
+        RangeVar@63..71
+          Ident@63..71 "pg_locks"
+        Whitespace@71..72 " "
+        Where@72..77 "WHERE"
+        Whitespace@77..78 " "
+        AExpr@78..99
+          ColumnRef@78..86
+            Ident@78..86 "locktype"
+          Whitespace@86..87 " "
+          Ascii61@87..88 "="
+          Whitespace@88..89 " "
+          AConst@89..99
+            Sconst@89..99 "'advisory'"
+        Newline@99..100 "\n"
+        Newline@100..101 "\t"
+        SortBy@101..117
+          Order@101..106 "ORDER"
+          Whitespace@106..107 " "
+          By@107..109 "BY"
+          Whitespace@109..110 " "
+          ColumnRef@110..117
+            Ident@110..117 "classid"
+        Ascii44@117..118 ","
+        Whitespace@118..119 " "
+        SortBy@119..124
+          ColumnRef@119..124
+            Ident@119..124 "objid"
+        Ascii44@124..125 ","
+        Whitespace@125..126 " "
+        SortBy@126..134
+          ColumnRef@126..134
+            Ident@126..134 "objsubid"
+        Ascii59@134..135 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "locktype",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 7,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "classid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 17,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 17,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 26,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 26,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objsubid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 33,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 33,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "mode",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 43,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 43,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "granted",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 49,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 49,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [
+                        Node {
+                            node: Some(
+                                RangeVar(
+                                    RangeVar {
+                                        catalogname: "",
+                                        schemaname: "",
+                                        relname: "pg_locks",
+                                        inh: true,
+                                        relpersistence: "p",
+                                        alias: None,
+                                        location: 63,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    where_clause: Some(
+                        Node {
+                            node: Some(
+                                AExpr(
+                                    AExpr {
+                                        kind: AexprOp,
+                                        name: [
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "=",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        lexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "locktype",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 78,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        rexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    AConst(
+                                                        AConst {
+                                                            isnull: false,
+                                                            location: 89,
+                                                            val: Some(
+                                                                Sval(
+                                                                    String {
+                                                                        sval: "advisory",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 87,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [
+                        Node {
+                            node: Some(
+                                SortBy(
+                                    SortBy {
+                                        node: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "classid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 110,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        sortby_dir: SortbyDefault,
+                                        sortby_nulls: SortbyNullsDefault,
+                                        use_op: [],
+                                        location: -1,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                SortBy(
+                                    SortBy {
+                                        node: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 119,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        sortby_dir: SortbyDefault,
+                                        sortby_nulls: SortbyNullsDefault,
+                                        use_op: [],
+                                        location: -1,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                SortBy(
+                                    SortBy {
+                                        node: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objsubid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 126,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        sortby_dir: SortbyDefault,
+                                        sortby_nulls: SortbyNullsDefault,
+                                        use_op: [],
+                                        location: -1,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..134,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@2.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@2.snap
@@ -1,0 +1,361 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "SELECT\n\tpg_advisory_xact_lock(1), pg_advisory_xact_lock_shared(2),\n\tpg_advisory_xact_lock(1, 1), pg_advisory_xact_lock_shared(2, 2);"
+---
+Parse {
+    cst: SourceFile@0..132
+      SelectStmt@0..132
+        Select@0..6 "SELECT"
+        Newline@6..7 "\n"
+        Newline@7..8 "\t"
+        ResTarget@8..31
+          FuncCall@8..31
+            Ident@8..29 "pg_advisory_xact_lock"
+            Ascii40@29..30 "("
+            AConst@30..31
+              Iconst@30..31 "1"
+        Ascii41@31..32 ")"
+        Ascii44@32..33 ","
+        Whitespace@33..34 " "
+        ResTarget@34..64
+          FuncCall@34..64
+            Ident@34..62 "pg_advisory_xact_lock ..."
+            Ascii40@62..63 "("
+            AConst@63..64
+              Iconst@63..64 "2"
+        Ascii41@64..65 ")"
+        Ascii44@65..66 ","
+        Newline@66..67 "\n"
+        Newline@67..68 "\t"
+        ResTarget@68..94
+          FuncCall@68..94
+            Ident@68..89 "pg_advisory_xact_lock"
+            Ascii40@89..90 "("
+            AConst@90..91
+              Iconst@90..91 "1"
+            Ascii44@91..92 ","
+            Whitespace@92..93 " "
+            AConst@93..94
+              Iconst@93..94 "1"
+        Ascii41@94..95 ")"
+        Ascii44@95..96 ","
+        Whitespace@96..97 " "
+        ResTarget@97..130
+          FuncCall@97..130
+            Ident@97..125 "pg_advisory_xact_lock ..."
+            Ascii40@125..126 "("
+            AConst@126..127
+              Iconst@126..127 "2"
+            Ascii44@127..128 ","
+            Whitespace@128..129 " "
+            AConst@129..130
+              Iconst@129..130 "2"
+        Ascii41@130..131 ")"
+        Ascii59@131..132 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_xact_lock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 30,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 8,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 8,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_xact_lock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 63,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 34,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 34,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_xact_lock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 90,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 93,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 68,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 68,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_xact_lock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 126,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 129,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 97,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 97,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [],
+                    where_clause: None,
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..131,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@20.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@20.snap
@@ -1,0 +1,361 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "SELECT\n\tpg_advisory_xact_lock(1), pg_advisory_xact_lock_shared(2),\n\tpg_advisory_xact_lock(1, 1), pg_advisory_xact_lock_shared(2, 2);"
+---
+Parse {
+    cst: SourceFile@0..132
+      SelectStmt@0..132
+        Select@0..6 "SELECT"
+        Newline@6..7 "\n"
+        Newline@7..8 "\t"
+        ResTarget@8..31
+          FuncCall@8..31
+            Ident@8..29 "pg_advisory_xact_lock"
+            Ascii40@29..30 "("
+            AConst@30..31
+              Iconst@30..31 "1"
+        Ascii41@31..32 ")"
+        Ascii44@32..33 ","
+        Whitespace@33..34 " "
+        ResTarget@34..64
+          FuncCall@34..64
+            Ident@34..62 "pg_advisory_xact_lock ..."
+            Ascii40@62..63 "("
+            AConst@63..64
+              Iconst@63..64 "2"
+        Ascii41@64..65 ")"
+        Ascii44@65..66 ","
+        Newline@66..67 "\n"
+        Newline@67..68 "\t"
+        ResTarget@68..94
+          FuncCall@68..94
+            Ident@68..89 "pg_advisory_xact_lock"
+            Ascii40@89..90 "("
+            AConst@90..91
+              Iconst@90..91 "1"
+            Ascii44@91..92 ","
+            Whitespace@92..93 " "
+            AConst@93..94
+              Iconst@93..94 "1"
+        Ascii41@94..95 ")"
+        Ascii44@95..96 ","
+        Whitespace@96..97 " "
+        ResTarget@97..130
+          FuncCall@97..130
+            Ident@97..125 "pg_advisory_xact_lock ..."
+            Ascii40@125..126 "("
+            AConst@126..127
+              Iconst@126..127 "2"
+            Ascii44@127..128 ","
+            Whitespace@128..129 " "
+            AConst@129..130
+              Iconst@129..130 "2"
+        Ascii41@130..131 ")"
+        Ascii59@131..132 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_xact_lock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 30,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 8,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 8,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_xact_lock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 63,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 34,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 34,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_xact_lock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 90,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 93,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 68,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 68,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_xact_lock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 126,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 129,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 97,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 97,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [],
+                    where_clause: None,
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..131,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@21.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@21.snap
@@ -1,0 +1,12 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: ROLLBACK;
+---
+Parse {
+    cst: SourceFile@0..9
+      Rollback@0..8 "ROLLBACK"
+      Ascii59@8..9 ";"
+    ,
+    errors: [],
+    stmts: [],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@22.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@22.snap
@@ -1,0 +1,487 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "SELECT locktype, classid, objid, objsubid, mode, granted\n\tFROM pg_locks WHERE locktype = 'advisory'\n\tORDER BY classid, objid, objsubid;"
+---
+Parse {
+    cst: SourceFile@0..135
+      SelectStmt@0..135
+        Select@0..6 "SELECT"
+        Whitespace@6..7 " "
+        ResTarget@7..15
+          ColumnRef@7..15
+            Ident@7..15 "locktype"
+        Ascii44@15..16 ","
+        Whitespace@16..17 " "
+        ResTarget@17..24
+          ColumnRef@17..24
+            Ident@17..24 "classid"
+        Ascii44@24..25 ","
+        Whitespace@25..26 " "
+        ResTarget@26..31
+          ColumnRef@26..31
+            Ident@26..31 "objid"
+        Ascii44@31..32 ","
+        Whitespace@32..33 " "
+        ResTarget@33..41
+          ColumnRef@33..41
+            Ident@33..41 "objsubid"
+        Ascii44@41..42 ","
+        Whitespace@42..43 " "
+        ResTarget@43..47
+          ColumnRef@43..47
+            Mode@43..47 "mode"
+        Ascii44@47..48 ","
+        Whitespace@48..49 " "
+        ResTarget@49..56
+          ColumnRef@49..56
+            Granted@49..56 "granted"
+        Newline@56..57 "\n"
+        Newline@57..58 "\t"
+        From@58..62 "FROM"
+        Whitespace@62..63 " "
+        RangeVar@63..71
+          Ident@63..71 "pg_locks"
+        Whitespace@71..72 " "
+        Where@72..77 "WHERE"
+        Whitespace@77..78 " "
+        AExpr@78..99
+          ColumnRef@78..86
+            Ident@78..86 "locktype"
+          Whitespace@86..87 " "
+          Ascii61@87..88 "="
+          Whitespace@88..89 " "
+          AConst@89..99
+            Sconst@89..99 "'advisory'"
+        Newline@99..100 "\n"
+        Newline@100..101 "\t"
+        SortBy@101..117
+          Order@101..106 "ORDER"
+          Whitespace@106..107 " "
+          By@107..109 "BY"
+          Whitespace@109..110 " "
+          ColumnRef@110..117
+            Ident@110..117 "classid"
+        Ascii44@117..118 ","
+        Whitespace@118..119 " "
+        SortBy@119..124
+          ColumnRef@119..124
+            Ident@119..124 "objid"
+        Ascii44@124..125 ","
+        Whitespace@125..126 " "
+        SortBy@126..134
+          ColumnRef@126..134
+            Ident@126..134 "objsubid"
+        Ascii59@134..135 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "locktype",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 7,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "classid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 17,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 17,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 26,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 26,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objsubid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 33,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 33,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "mode",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 43,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 43,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "granted",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 49,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 49,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [
+                        Node {
+                            node: Some(
+                                RangeVar(
+                                    RangeVar {
+                                        catalogname: "",
+                                        schemaname: "",
+                                        relname: "pg_locks",
+                                        inh: true,
+                                        relpersistence: "p",
+                                        alias: None,
+                                        location: 63,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    where_clause: Some(
+                        Node {
+                            node: Some(
+                                AExpr(
+                                    AExpr {
+                                        kind: AexprOp,
+                                        name: [
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "=",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        lexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "locktype",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 78,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        rexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    AConst(
+                                                        AConst {
+                                                            isnull: false,
+                                                            location: 89,
+                                                            val: Some(
+                                                                Sval(
+                                                                    String {
+                                                                        sval: "advisory",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 87,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [
+                        Node {
+                            node: Some(
+                                SortBy(
+                                    SortBy {
+                                        node: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "classid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 110,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        sortby_dir: SortbyDefault,
+                                        sortby_nulls: SortbyNullsDefault,
+                                        use_op: [],
+                                        location: -1,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                SortBy(
+                                    SortBy {
+                                        node: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 119,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        sortby_dir: SortbyDefault,
+                                        sortby_nulls: SortbyNullsDefault,
+                                        use_op: [],
+                                        location: -1,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                SortBy(
+                                    SortBy {
+                                        node: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objsubid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 126,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        sortby_dir: SortbyDefault,
+                                        sortby_nulls: SortbyNullsDefault,
+                                        use_op: [],
+                                        location: -1,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..134,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@23.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@23.snap
@@ -1,0 +1,92 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "-- releasing all session locks\nSELECT pg_advisory_unlock_all();"
+---
+Parse {
+    cst: SourceFile@0..63
+      SqlComment@0..30 "-- releasing all sess ..."
+      Newline@30..31 "\n"
+      SelectStmt@31..63
+        Select@31..37 "SELECT"
+        Whitespace@37..38 " "
+        ResTarget@38..60
+          FuncCall@38..60
+            Ident@38..60 "pg_advisory_unlock_all"
+        Ascii40@60..61 "("
+        Ascii41@61..62 ")"
+        Ascii59@62..63 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_unlock_all",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 7,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [],
+                    where_clause: None,
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 30..62,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@24.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@24.snap
@@ -1,0 +1,186 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "SELECT count(*) FROM pg_locks WHERE locktype = 'advisory';"
+---
+Parse {
+    cst: SourceFile@0..58
+      SelectStmt@0..58
+        Select@0..6 "SELECT"
+        Whitespace@6..7 " "
+        ResTarget@7..14
+          FuncCall@7..14
+            Ident@7..12 "count"
+            Ascii40@12..13 "("
+            Ascii42@13..14 "*"
+        Ascii41@14..15 ")"
+        Whitespace@15..16 " "
+        From@16..20 "FROM"
+        Whitespace@20..21 " "
+        RangeVar@21..29
+          Ident@21..29 "pg_locks"
+        Whitespace@29..30 " "
+        Where@30..35 "WHERE"
+        Whitespace@35..36 " "
+        AExpr@36..57
+          ColumnRef@36..44
+            Ident@36..44 "locktype"
+          Whitespace@44..45 " "
+          Ascii61@45..46 "="
+          Whitespace@46..47 " "
+          AConst@47..57
+            Sconst@47..57 "'advisory'"
+        Ascii59@57..58 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "count",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: true,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 7,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [
+                        Node {
+                            node: Some(
+                                RangeVar(
+                                    RangeVar {
+                                        catalogname: "",
+                                        schemaname: "",
+                                        relname: "pg_locks",
+                                        inh: true,
+                                        relpersistence: "p",
+                                        alias: None,
+                                        location: 21,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    where_clause: Some(
+                        Node {
+                            node: Some(
+                                AExpr(
+                                    AExpr {
+                                        kind: AexprOp,
+                                        name: [
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "=",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        lexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "locktype",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 36,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        rexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    AConst(
+                                                        AConst {
+                                                            isnull: false,
+                                                            location: 47,
+                                                            val: Some(
+                                                                Sval(
+                                                                    String {
+                                                                        sval: "advisory",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 45,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..57,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@25.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@25.snap
@@ -1,0 +1,26 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: BEGIN;
+---
+Parse {
+    cst: SourceFile@0..6
+      TransactionStmt@0..6
+        BeginP@0..5 "BEGIN"
+        Ascii59@5..6 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: TransactionStmt(
+                TransactionStmt {
+                    kind: TransStmtBegin,
+                    options: [],
+                    savepoint_name: "",
+                    gid: "",
+                    chain: false,
+                },
+            ),
+            range: 0..5,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@26.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@26.snap
@@ -1,0 +1,683 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "-- grabbing txn locks multiple times\n\nSELECT\n\tpg_advisory_xact_lock(1), pg_advisory_xact_lock(1),\n\tpg_advisory_xact_lock_shared(2), pg_advisory_xact_lock_shared(2),\n\tpg_advisory_xact_lock(1, 1), pg_advisory_xact_lock(1, 1),\n\tpg_advisory_xact_lock_shared(2, 2), pg_advisory_xact_lock_shared(2, 2);"
+---
+Parse {
+    cst: SourceFile@0..296
+      SqlComment@0..36 "-- grabbing txn locks ..."
+      Newline@36..38 "\n\n"
+      SelectStmt@38..296
+        Select@38..44 "SELECT"
+        Newline@44..45 "\n"
+        Newline@45..46 "\t"
+        ResTarget@46..69
+          FuncCall@46..69
+            Ident@46..67 "pg_advisory_xact_lock"
+            Ascii40@67..68 "("
+            AConst@68..69
+              Iconst@68..69 "1"
+        Ascii41@69..70 ")"
+        Ascii44@70..71 ","
+        Whitespace@71..72 " "
+        ResTarget@72..95
+          FuncCall@72..95
+            Ident@72..93 "pg_advisory_xact_lock"
+            Ascii40@93..94 "("
+            AConst@94..95
+              Iconst@94..95 "1"
+        Ascii41@95..96 ")"
+        Ascii44@96..97 ","
+        Newline@97..98 "\n"
+        Newline@98..99 "\t"
+        ResTarget@99..129
+          FuncCall@99..129
+            Ident@99..127 "pg_advisory_xact_lock ..."
+            Ascii40@127..128 "("
+            AConst@128..129
+              Iconst@128..129 "2"
+        Ascii41@129..130 ")"
+        Ascii44@130..131 ","
+        Whitespace@131..132 " "
+        ResTarget@132..162
+          FuncCall@132..162
+            Ident@132..160 "pg_advisory_xact_lock ..."
+            Ascii40@160..161 "("
+            AConst@161..162
+              Iconst@161..162 "2"
+        Ascii41@162..163 ")"
+        Ascii44@163..164 ","
+        Newline@164..165 "\n"
+        Newline@165..166 "\t"
+        ResTarget@166..192
+          FuncCall@166..192
+            Ident@166..187 "pg_advisory_xact_lock"
+            Ascii40@187..188 "("
+            AConst@188..189
+              Iconst@188..189 "1"
+            Ascii44@189..190 ","
+            Whitespace@190..191 " "
+            AConst@191..192
+              Iconst@191..192 "1"
+        Ascii41@192..193 ")"
+        Ascii44@193..194 ","
+        Whitespace@194..195 " "
+        ResTarget@195..221
+          FuncCall@195..221
+            Ident@195..216 "pg_advisory_xact_lock"
+            Ascii40@216..217 "("
+            AConst@217..218
+              Iconst@217..218 "1"
+            Ascii44@218..219 ","
+            Whitespace@219..220 " "
+            AConst@220..221
+              Iconst@220..221 "1"
+        Ascii41@221..222 ")"
+        Ascii44@222..223 ","
+        Newline@223..224 "\n"
+        Newline@224..225 "\t"
+        ResTarget@225..258
+          FuncCall@225..258
+            Ident@225..253 "pg_advisory_xact_lock ..."
+            Ascii40@253..254 "("
+            AConst@254..255
+              Iconst@254..255 "2"
+            Ascii44@255..256 ","
+            Whitespace@256..257 " "
+            AConst@257..258
+              Iconst@257..258 "2"
+        Ascii41@258..259 ")"
+        Ascii44@259..260 ","
+        Whitespace@260..261 " "
+        ResTarget@261..294
+          FuncCall@261..294
+            Ident@261..289 "pg_advisory_xact_lock ..."
+            Ascii40@289..290 "("
+            AConst@290..291
+              Iconst@290..291 "2"
+            Ascii44@291..292 ","
+            Whitespace@292..293 " "
+            AConst@293..294
+              Iconst@293..294 "2"
+        Ascii41@294..295 ")"
+        Ascii59@295..296 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_xact_lock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 30,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 8,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 8,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_xact_lock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 56,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 34,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 34,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_xact_lock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 90,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 61,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 61,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_xact_lock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 123,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 94,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 94,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_xact_lock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 150,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 153,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 128,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 128,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_xact_lock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 179,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 182,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 157,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 157,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_xact_lock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 216,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 219,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 187,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 187,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_xact_lock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 252,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 255,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 223,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 223,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [],
+                    where_clause: None,
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 37..295,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@27.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@27.snap
@@ -1,0 +1,487 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "SELECT locktype, classid, objid, objsubid, mode, granted\n\tFROM pg_locks WHERE locktype = 'advisory'\n\tORDER BY classid, objid, objsubid;"
+---
+Parse {
+    cst: SourceFile@0..135
+      SelectStmt@0..135
+        Select@0..6 "SELECT"
+        Whitespace@6..7 " "
+        ResTarget@7..15
+          ColumnRef@7..15
+            Ident@7..15 "locktype"
+        Ascii44@15..16 ","
+        Whitespace@16..17 " "
+        ResTarget@17..24
+          ColumnRef@17..24
+            Ident@17..24 "classid"
+        Ascii44@24..25 ","
+        Whitespace@25..26 " "
+        ResTarget@26..31
+          ColumnRef@26..31
+            Ident@26..31 "objid"
+        Ascii44@31..32 ","
+        Whitespace@32..33 " "
+        ResTarget@33..41
+          ColumnRef@33..41
+            Ident@33..41 "objsubid"
+        Ascii44@41..42 ","
+        Whitespace@42..43 " "
+        ResTarget@43..47
+          ColumnRef@43..47
+            Mode@43..47 "mode"
+        Ascii44@47..48 ","
+        Whitespace@48..49 " "
+        ResTarget@49..56
+          ColumnRef@49..56
+            Granted@49..56 "granted"
+        Newline@56..57 "\n"
+        Newline@57..58 "\t"
+        From@58..62 "FROM"
+        Whitespace@62..63 " "
+        RangeVar@63..71
+          Ident@63..71 "pg_locks"
+        Whitespace@71..72 " "
+        Where@72..77 "WHERE"
+        Whitespace@77..78 " "
+        AExpr@78..99
+          ColumnRef@78..86
+            Ident@78..86 "locktype"
+          Whitespace@86..87 " "
+          Ascii61@87..88 "="
+          Whitespace@88..89 " "
+          AConst@89..99
+            Sconst@89..99 "'advisory'"
+        Newline@99..100 "\n"
+        Newline@100..101 "\t"
+        SortBy@101..117
+          Order@101..106 "ORDER"
+          Whitespace@106..107 " "
+          By@107..109 "BY"
+          Whitespace@109..110 " "
+          ColumnRef@110..117
+            Ident@110..117 "classid"
+        Ascii44@117..118 ","
+        Whitespace@118..119 " "
+        SortBy@119..124
+          ColumnRef@119..124
+            Ident@119..124 "objid"
+        Ascii44@124..125 ","
+        Whitespace@125..126 " "
+        SortBy@126..134
+          ColumnRef@126..134
+            Ident@126..134 "objsubid"
+        Ascii59@134..135 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "locktype",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 7,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "classid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 17,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 17,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 26,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 26,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objsubid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 33,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 33,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "mode",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 43,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 43,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "granted",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 49,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 49,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [
+                        Node {
+                            node: Some(
+                                RangeVar(
+                                    RangeVar {
+                                        catalogname: "",
+                                        schemaname: "",
+                                        relname: "pg_locks",
+                                        inh: true,
+                                        relpersistence: "p",
+                                        alias: None,
+                                        location: 63,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    where_clause: Some(
+                        Node {
+                            node: Some(
+                                AExpr(
+                                    AExpr {
+                                        kind: AexprOp,
+                                        name: [
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "=",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        lexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "locktype",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 78,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        rexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    AConst(
+                                                        AConst {
+                                                            isnull: false,
+                                                            location: 89,
+                                                            val: Some(
+                                                                Sval(
+                                                                    String {
+                                                                        sval: "advisory",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 87,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [
+                        Node {
+                            node: Some(
+                                SortBy(
+                                    SortBy {
+                                        node: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "classid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 110,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        sortby_dir: SortbyDefault,
+                                        sortby_nulls: SortbyNullsDefault,
+                                        use_op: [],
+                                        location: -1,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                SortBy(
+                                    SortBy {
+                                        node: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 119,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        sortby_dir: SortbyDefault,
+                                        sortby_nulls: SortbyNullsDefault,
+                                        use_op: [],
+                                        location: -1,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                SortBy(
+                                    SortBy {
+                                        node: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objsubid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 126,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        sortby_dir: SortbyDefault,
+                                        sortby_nulls: SortbyNullsDefault,
+                                        use_op: [],
+                                        location: -1,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..134,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@28.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@28.snap
@@ -1,0 +1,26 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: COMMIT;
+---
+Parse {
+    cst: SourceFile@0..7
+      TransactionStmt@0..7
+        Commit@0..6 "COMMIT"
+        Ascii59@6..7 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: TransactionStmt(
+                TransactionStmt {
+                    kind: TransStmtCommit,
+                    options: [],
+                    savepoint_name: "",
+                    gid: "",
+                    chain: false,
+                },
+            ),
+            range: 0..6,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@29.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@29.snap
@@ -1,0 +1,186 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "SELECT count(*) FROM pg_locks WHERE locktype = 'advisory';"
+---
+Parse {
+    cst: SourceFile@0..58
+      SelectStmt@0..58
+        Select@0..6 "SELECT"
+        Whitespace@6..7 " "
+        ResTarget@7..14
+          FuncCall@7..14
+            Ident@7..12 "count"
+            Ascii40@12..13 "("
+            Ascii42@13..14 "*"
+        Ascii41@14..15 ")"
+        Whitespace@15..16 " "
+        From@16..20 "FROM"
+        Whitespace@20..21 " "
+        RangeVar@21..29
+          Ident@21..29 "pg_locks"
+        Whitespace@29..30 " "
+        Where@30..35 "WHERE"
+        Whitespace@35..36 " "
+        AExpr@36..57
+          ColumnRef@36..44
+            Ident@36..44 "locktype"
+          Whitespace@44..45 " "
+          Ascii61@45..46 "="
+          Whitespace@46..47 " "
+          AConst@47..57
+            Sconst@47..57 "'advisory'"
+        Ascii59@57..58 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "count",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: true,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 7,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [
+                        Node {
+                            node: Some(
+                                RangeVar(
+                                    RangeVar {
+                                        catalogname: "",
+                                        schemaname: "",
+                                        relname: "pg_locks",
+                                        inh: true,
+                                        relpersistence: "p",
+                                        alias: None,
+                                        location: 21,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    where_clause: Some(
+                        Node {
+                            node: Some(
+                                AExpr(
+                                    AExpr {
+                                        kind: AexprOp,
+                                        name: [
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "=",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        lexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "locktype",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 36,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        rexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    AConst(
+                                                        AConst {
+                                                            isnull: false,
+                                                            location: 47,
+                                                            val: Some(
+                                                                Sval(
+                                                                    String {
+                                                                        sval: "advisory",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 45,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..57,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@3.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@3.snap
@@ -1,0 +1,487 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "SELECT locktype, classid, objid, objsubid, mode, granted\n\tFROM pg_locks WHERE locktype = 'advisory'\n\tORDER BY classid, objid, objsubid;"
+---
+Parse {
+    cst: SourceFile@0..135
+      SelectStmt@0..135
+        Select@0..6 "SELECT"
+        Whitespace@6..7 " "
+        ResTarget@7..15
+          ColumnRef@7..15
+            Ident@7..15 "locktype"
+        Ascii44@15..16 ","
+        Whitespace@16..17 " "
+        ResTarget@17..24
+          ColumnRef@17..24
+            Ident@17..24 "classid"
+        Ascii44@24..25 ","
+        Whitespace@25..26 " "
+        ResTarget@26..31
+          ColumnRef@26..31
+            Ident@26..31 "objid"
+        Ascii44@31..32 ","
+        Whitespace@32..33 " "
+        ResTarget@33..41
+          ColumnRef@33..41
+            Ident@33..41 "objsubid"
+        Ascii44@41..42 ","
+        Whitespace@42..43 " "
+        ResTarget@43..47
+          ColumnRef@43..47
+            Mode@43..47 "mode"
+        Ascii44@47..48 ","
+        Whitespace@48..49 " "
+        ResTarget@49..56
+          ColumnRef@49..56
+            Granted@49..56 "granted"
+        Newline@56..57 "\n"
+        Newline@57..58 "\t"
+        From@58..62 "FROM"
+        Whitespace@62..63 " "
+        RangeVar@63..71
+          Ident@63..71 "pg_locks"
+        Whitespace@71..72 " "
+        Where@72..77 "WHERE"
+        Whitespace@77..78 " "
+        AExpr@78..99
+          ColumnRef@78..86
+            Ident@78..86 "locktype"
+          Whitespace@86..87 " "
+          Ascii61@87..88 "="
+          Whitespace@88..89 " "
+          AConst@89..99
+            Sconst@89..99 "'advisory'"
+        Newline@99..100 "\n"
+        Newline@100..101 "\t"
+        SortBy@101..117
+          Order@101..106 "ORDER"
+          Whitespace@106..107 " "
+          By@107..109 "BY"
+          Whitespace@109..110 " "
+          ColumnRef@110..117
+            Ident@110..117 "classid"
+        Ascii44@117..118 ","
+        Whitespace@118..119 " "
+        SortBy@119..124
+          ColumnRef@119..124
+            Ident@119..124 "objid"
+        Ascii44@124..125 ","
+        Whitespace@125..126 " "
+        SortBy@126..134
+          ColumnRef@126..134
+            Ident@126..134 "objsubid"
+        Ascii59@134..135 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "locktype",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 7,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "classid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 17,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 17,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 26,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 26,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objsubid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 33,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 33,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "mode",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 43,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 43,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "granted",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 49,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 49,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [
+                        Node {
+                            node: Some(
+                                RangeVar(
+                                    RangeVar {
+                                        catalogname: "",
+                                        schemaname: "",
+                                        relname: "pg_locks",
+                                        inh: true,
+                                        relpersistence: "p",
+                                        alias: None,
+                                        location: 63,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    where_clause: Some(
+                        Node {
+                            node: Some(
+                                AExpr(
+                                    AExpr {
+                                        kind: AexprOp,
+                                        name: [
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "=",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        lexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "locktype",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 78,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        rexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    AConst(
+                                                        AConst {
+                                                            isnull: false,
+                                                            location: 89,
+                                                            val: Some(
+                                                                Sval(
+                                                                    String {
+                                                                        sval: "advisory",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 87,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [
+                        Node {
+                            node: Some(
+                                SortBy(
+                                    SortBy {
+                                        node: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "classid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 110,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        sortby_dir: SortbyDefault,
+                                        sortby_nulls: SortbyNullsDefault,
+                                        use_op: [],
+                                        location: -1,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                SortBy(
+                                    SortBy {
+                                        node: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 119,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        sortby_dir: SortbyDefault,
+                                        sortby_nulls: SortbyNullsDefault,
+                                        use_op: [],
+                                        location: -1,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                SortBy(
+                                    SortBy {
+                                        node: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objsubid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 126,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        sortby_dir: SortbyDefault,
+                                        sortby_nulls: SortbyNullsDefault,
+                                        use_op: [],
+                                        location: -1,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..134,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@30.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@30.snap
@@ -1,0 +1,683 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "-- grabbing session locks multiple times\n\nSELECT\n\tpg_advisory_lock(1), pg_advisory_lock(1),\n\tpg_advisory_lock_shared(2), pg_advisory_lock_shared(2),\n\tpg_advisory_lock(1, 1), pg_advisory_lock(1, 1),\n\tpg_advisory_lock_shared(2, 2), pg_advisory_lock_shared(2, 2);"
+---
+Parse {
+    cst: SourceFile@0..260
+      SqlComment@0..40 "-- grabbing session l ..."
+      Newline@40..42 "\n\n"
+      SelectStmt@42..260
+        Select@42..48 "SELECT"
+        Newline@48..49 "\n"
+        Newline@49..50 "\t"
+        ResTarget@50..68
+          FuncCall@50..68
+            Ident@50..66 "pg_advisory_lock"
+            Ascii40@66..67 "("
+            AConst@67..68
+              Iconst@67..68 "1"
+        Ascii41@68..69 ")"
+        Ascii44@69..70 ","
+        Whitespace@70..71 " "
+        ResTarget@71..89
+          FuncCall@71..89
+            Ident@71..87 "pg_advisory_lock"
+            Ascii40@87..88 "("
+            AConst@88..89
+              Iconst@88..89 "1"
+        Ascii41@89..90 ")"
+        Ascii44@90..91 ","
+        Newline@91..92 "\n"
+        Newline@92..93 "\t"
+        ResTarget@93..118
+          FuncCall@93..118
+            Ident@93..116 "pg_advisory_lock_shared"
+            Ascii40@116..117 "("
+            AConst@117..118
+              Iconst@117..118 "2"
+        Ascii41@118..119 ")"
+        Ascii44@119..120 ","
+        Whitespace@120..121 " "
+        ResTarget@121..146
+          FuncCall@121..146
+            Ident@121..144 "pg_advisory_lock_shared"
+            Ascii40@144..145 "("
+            AConst@145..146
+              Iconst@145..146 "2"
+        Ascii41@146..147 ")"
+        Ascii44@147..148 ","
+        Newline@148..149 "\n"
+        Newline@149..150 "\t"
+        ResTarget@150..171
+          FuncCall@150..171
+            Ident@150..166 "pg_advisory_lock"
+            Ascii40@166..167 "("
+            AConst@167..168
+              Iconst@167..168 "1"
+            Ascii44@168..169 ","
+            Whitespace@169..170 " "
+            AConst@170..171
+              Iconst@170..171 "1"
+        Ascii41@171..172 ")"
+        Ascii44@172..173 ","
+        Whitespace@173..174 " "
+        ResTarget@174..195
+          FuncCall@174..195
+            Ident@174..190 "pg_advisory_lock"
+            Ascii40@190..191 "("
+            AConst@191..192
+              Iconst@191..192 "1"
+            Ascii44@192..193 ","
+            Whitespace@193..194 " "
+            AConst@194..195
+              Iconst@194..195 "1"
+        Ascii41@195..196 ")"
+        Ascii44@196..197 ","
+        Newline@197..198 "\n"
+        Newline@198..199 "\t"
+        ResTarget@199..227
+          FuncCall@199..227
+            Ident@199..222 "pg_advisory_lock_shared"
+            Ascii40@222..223 "("
+            AConst@223..224
+              Iconst@223..224 "2"
+            Ascii44@224..225 ","
+            Whitespace@225..226 " "
+            AConst@226..227
+              Iconst@226..227 "2"
+        Ascii41@227..228 ")"
+        Ascii44@228..229 ","
+        Whitespace@229..230 " "
+        ResTarget@230..258
+          FuncCall@230..258
+            Ident@230..253 "pg_advisory_lock_shared"
+            Ascii40@253..254 "("
+            AConst@254..255
+              Iconst@254..255 "2"
+            Ascii44@255..256 ","
+            Whitespace@256..257 " "
+            AConst@257..258
+              Iconst@257..258 "2"
+        Ascii41@258..259 ")"
+        Ascii59@259..260 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_lock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 25,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 8,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 8,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_lock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 46,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 29,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 29,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_lock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 75,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 51,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 51,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_lock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 103,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 79,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 79,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_lock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 125,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 128,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 108,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 108,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_lock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 149,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 152,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 132,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 132,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_lock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 181,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 184,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 157,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 157,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_lock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 212,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 215,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 188,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 188,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [],
+                    where_clause: None,
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 41..259,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@31.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@31.snap
@@ -1,0 +1,487 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "SELECT locktype, classid, objid, objsubid, mode, granted\n\tFROM pg_locks WHERE locktype = 'advisory'\n\tORDER BY classid, objid, objsubid;"
+---
+Parse {
+    cst: SourceFile@0..135
+      SelectStmt@0..135
+        Select@0..6 "SELECT"
+        Whitespace@6..7 " "
+        ResTarget@7..15
+          ColumnRef@7..15
+            Ident@7..15 "locktype"
+        Ascii44@15..16 ","
+        Whitespace@16..17 " "
+        ResTarget@17..24
+          ColumnRef@17..24
+            Ident@17..24 "classid"
+        Ascii44@24..25 ","
+        Whitespace@25..26 " "
+        ResTarget@26..31
+          ColumnRef@26..31
+            Ident@26..31 "objid"
+        Ascii44@31..32 ","
+        Whitespace@32..33 " "
+        ResTarget@33..41
+          ColumnRef@33..41
+            Ident@33..41 "objsubid"
+        Ascii44@41..42 ","
+        Whitespace@42..43 " "
+        ResTarget@43..47
+          ColumnRef@43..47
+            Mode@43..47 "mode"
+        Ascii44@47..48 ","
+        Whitespace@48..49 " "
+        ResTarget@49..56
+          ColumnRef@49..56
+            Granted@49..56 "granted"
+        Newline@56..57 "\n"
+        Newline@57..58 "\t"
+        From@58..62 "FROM"
+        Whitespace@62..63 " "
+        RangeVar@63..71
+          Ident@63..71 "pg_locks"
+        Whitespace@71..72 " "
+        Where@72..77 "WHERE"
+        Whitespace@77..78 " "
+        AExpr@78..99
+          ColumnRef@78..86
+            Ident@78..86 "locktype"
+          Whitespace@86..87 " "
+          Ascii61@87..88 "="
+          Whitespace@88..89 " "
+          AConst@89..99
+            Sconst@89..99 "'advisory'"
+        Newline@99..100 "\n"
+        Newline@100..101 "\t"
+        SortBy@101..117
+          Order@101..106 "ORDER"
+          Whitespace@106..107 " "
+          By@107..109 "BY"
+          Whitespace@109..110 " "
+          ColumnRef@110..117
+            Ident@110..117 "classid"
+        Ascii44@117..118 ","
+        Whitespace@118..119 " "
+        SortBy@119..124
+          ColumnRef@119..124
+            Ident@119..124 "objid"
+        Ascii44@124..125 ","
+        Whitespace@125..126 " "
+        SortBy@126..134
+          ColumnRef@126..134
+            Ident@126..134 "objsubid"
+        Ascii59@134..135 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "locktype",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 7,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "classid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 17,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 17,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 26,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 26,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objsubid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 33,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 33,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "mode",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 43,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 43,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "granted",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 49,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 49,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [
+                        Node {
+                            node: Some(
+                                RangeVar(
+                                    RangeVar {
+                                        catalogname: "",
+                                        schemaname: "",
+                                        relname: "pg_locks",
+                                        inh: true,
+                                        relpersistence: "p",
+                                        alias: None,
+                                        location: 63,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    where_clause: Some(
+                        Node {
+                            node: Some(
+                                AExpr(
+                                    AExpr {
+                                        kind: AexprOp,
+                                        name: [
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "=",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        lexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "locktype",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 78,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        rexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    AConst(
+                                                        AConst {
+                                                            isnull: false,
+                                                            location: 89,
+                                                            val: Some(
+                                                                Sval(
+                                                                    String {
+                                                                        sval: "advisory",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 87,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [
+                        Node {
+                            node: Some(
+                                SortBy(
+                                    SortBy {
+                                        node: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "classid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 110,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        sortby_dir: SortbyDefault,
+                                        sortby_nulls: SortbyNullsDefault,
+                                        use_op: [],
+                                        location: -1,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                SortBy(
+                                    SortBy {
+                                        node: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 119,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        sortby_dir: SortbyDefault,
+                                        sortby_nulls: SortbyNullsDefault,
+                                        use_op: [],
+                                        location: -1,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                SortBy(
+                                    SortBy {
+                                        node: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objsubid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 126,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        sortby_dir: SortbyDefault,
+                                        sortby_nulls: SortbyNullsDefault,
+                                        use_op: [],
+                                        location: -1,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..134,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@32.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@32.snap
@@ -1,0 +1,681 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "SELECT\n\tpg_advisory_unlock(1), pg_advisory_unlock(1),\n\tpg_advisory_unlock_shared(2), pg_advisory_unlock_shared(2),\n\tpg_advisory_unlock(1, 1), pg_advisory_unlock(1, 1),\n\tpg_advisory_unlock_shared(2, 2), pg_advisory_unlock_shared(2, 2);"
+---
+Parse {
+    cst: SourceFile@0..234
+      SelectStmt@0..234
+        Select@0..6 "SELECT"
+        Newline@6..7 "\n"
+        Newline@7..8 "\t"
+        ResTarget@8..28
+          FuncCall@8..28
+            Ident@8..26 "pg_advisory_unlock"
+            Ascii40@26..27 "("
+            AConst@27..28
+              Iconst@27..28 "1"
+        Ascii41@28..29 ")"
+        Ascii44@29..30 ","
+        Whitespace@30..31 " "
+        ResTarget@31..51
+          FuncCall@31..51
+            Ident@31..49 "pg_advisory_unlock"
+            Ascii40@49..50 "("
+            AConst@50..51
+              Iconst@50..51 "1"
+        Ascii41@51..52 ")"
+        Ascii44@52..53 ","
+        Newline@53..54 "\n"
+        Newline@54..55 "\t"
+        ResTarget@55..82
+          FuncCall@55..82
+            Ident@55..80 "pg_advisory_unlock_sh ..."
+            Ascii40@80..81 "("
+            AConst@81..82
+              Iconst@81..82 "2"
+        Ascii41@82..83 ")"
+        Ascii44@83..84 ","
+        Whitespace@84..85 " "
+        ResTarget@85..112
+          FuncCall@85..112
+            Ident@85..110 "pg_advisory_unlock_sh ..."
+            Ascii40@110..111 "("
+            AConst@111..112
+              Iconst@111..112 "2"
+        Ascii41@112..113 ")"
+        Ascii44@113..114 ","
+        Newline@114..115 "\n"
+        Newline@115..116 "\t"
+        ResTarget@116..139
+          FuncCall@116..139
+            Ident@116..134 "pg_advisory_unlock"
+            Ascii40@134..135 "("
+            AConst@135..136
+              Iconst@135..136 "1"
+            Ascii44@136..137 ","
+            Whitespace@137..138 " "
+            AConst@138..139
+              Iconst@138..139 "1"
+        Ascii41@139..140 ")"
+        Ascii44@140..141 ","
+        Whitespace@141..142 " "
+        ResTarget@142..165
+          FuncCall@142..165
+            Ident@142..160 "pg_advisory_unlock"
+            Ascii40@160..161 "("
+            AConst@161..162
+              Iconst@161..162 "1"
+            Ascii44@162..163 ","
+            Whitespace@163..164 " "
+            AConst@164..165
+              Iconst@164..165 "1"
+        Ascii41@165..166 ")"
+        Ascii44@166..167 ","
+        Newline@167..168 "\n"
+        Newline@168..169 "\t"
+        ResTarget@169..199
+          FuncCall@169..199
+            Ident@169..194 "pg_advisory_unlock_sh ..."
+            Ascii40@194..195 "("
+            AConst@195..196
+              Iconst@195..196 "2"
+            Ascii44@196..197 ","
+            Whitespace@197..198 " "
+            AConst@198..199
+              Iconst@198..199 "2"
+        Ascii41@199..200 ")"
+        Ascii44@200..201 ","
+        Whitespace@201..202 " "
+        ResTarget@202..232
+          FuncCall@202..232
+            Ident@202..227 "pg_advisory_unlock_sh ..."
+            Ascii40@227..228 "("
+            AConst@228..229
+              Iconst@228..229 "2"
+            Ascii44@229..230 ","
+            Whitespace@230..231 " "
+            AConst@231..232
+              Iconst@231..232 "2"
+        Ascii41@232..233 ")"
+        Ascii59@233..234 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_unlock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 27,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 8,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 8,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_unlock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 50,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 31,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 31,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_unlock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 81,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 55,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 55,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_unlock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 111,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 85,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 85,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_unlock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 135,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 138,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 116,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 116,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_unlock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 161,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 164,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 142,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 142,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_unlock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 195,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 198,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 169,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 169,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_unlock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 228,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 231,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 202,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 202,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [],
+                    where_clause: None,
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..233,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@33.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@33.snap
@@ -1,0 +1,186 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "SELECT count(*) FROM pg_locks WHERE locktype = 'advisory';"
+---
+Parse {
+    cst: SourceFile@0..58
+      SelectStmt@0..58
+        Select@0..6 "SELECT"
+        Whitespace@6..7 " "
+        ResTarget@7..14
+          FuncCall@7..14
+            Ident@7..12 "count"
+            Ascii40@12..13 "("
+            Ascii42@13..14 "*"
+        Ascii41@14..15 ")"
+        Whitespace@15..16 " "
+        From@16..20 "FROM"
+        Whitespace@20..21 " "
+        RangeVar@21..29
+          Ident@21..29 "pg_locks"
+        Whitespace@29..30 " "
+        Where@30..35 "WHERE"
+        Whitespace@35..36 " "
+        AExpr@36..57
+          ColumnRef@36..44
+            Ident@36..44 "locktype"
+          Whitespace@44..45 " "
+          Ascii61@45..46 "="
+          Whitespace@46..47 " "
+          AConst@47..57
+            Sconst@47..57 "'advisory'"
+        Ascii59@57..58 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "count",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: true,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 7,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [
+                        Node {
+                            node: Some(
+                                RangeVar(
+                                    RangeVar {
+                                        catalogname: "",
+                                        schemaname: "",
+                                        relname: "pg_locks",
+                                        inh: true,
+                                        relpersistence: "p",
+                                        alias: None,
+                                        location: 21,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    where_clause: Some(
+                        Node {
+                            node: Some(
+                                AExpr(
+                                    AExpr {
+                                        kind: AexprOp,
+                                        name: [
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "=",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        lexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "locktype",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 36,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        rexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    AConst(
+                                                        AConst {
+                                                            isnull: false,
+                                                            location: 47,
+                                                            val: Some(
+                                                                Sval(
+                                                                    String {
+                                                                        sval: "advisory",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 45,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..57,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@34.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@34.snap
@@ -1,0 +1,683 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "-- .. and releasing them all at once\n\nSELECT\n\tpg_advisory_lock(1), pg_advisory_lock(1),\n\tpg_advisory_lock_shared(2), pg_advisory_lock_shared(2),\n\tpg_advisory_lock(1, 1), pg_advisory_lock(1, 1),\n\tpg_advisory_lock_shared(2, 2), pg_advisory_lock_shared(2, 2);"
+---
+Parse {
+    cst: SourceFile@0..256
+      SqlComment@0..36 "-- .. and releasing t ..."
+      Newline@36..38 "\n\n"
+      SelectStmt@38..256
+        Select@38..44 "SELECT"
+        Newline@44..45 "\n"
+        Newline@45..46 "\t"
+        ResTarget@46..64
+          FuncCall@46..64
+            Ident@46..62 "pg_advisory_lock"
+            Ascii40@62..63 "("
+            AConst@63..64
+              Iconst@63..64 "1"
+        Ascii41@64..65 ")"
+        Ascii44@65..66 ","
+        Whitespace@66..67 " "
+        ResTarget@67..85
+          FuncCall@67..85
+            Ident@67..83 "pg_advisory_lock"
+            Ascii40@83..84 "("
+            AConst@84..85
+              Iconst@84..85 "1"
+        Ascii41@85..86 ")"
+        Ascii44@86..87 ","
+        Newline@87..88 "\n"
+        Newline@88..89 "\t"
+        ResTarget@89..114
+          FuncCall@89..114
+            Ident@89..112 "pg_advisory_lock_shared"
+            Ascii40@112..113 "("
+            AConst@113..114
+              Iconst@113..114 "2"
+        Ascii41@114..115 ")"
+        Ascii44@115..116 ","
+        Whitespace@116..117 " "
+        ResTarget@117..142
+          FuncCall@117..142
+            Ident@117..140 "pg_advisory_lock_shared"
+            Ascii40@140..141 "("
+            AConst@141..142
+              Iconst@141..142 "2"
+        Ascii41@142..143 ")"
+        Ascii44@143..144 ","
+        Newline@144..145 "\n"
+        Newline@145..146 "\t"
+        ResTarget@146..167
+          FuncCall@146..167
+            Ident@146..162 "pg_advisory_lock"
+            Ascii40@162..163 "("
+            AConst@163..164
+              Iconst@163..164 "1"
+            Ascii44@164..165 ","
+            Whitespace@165..166 " "
+            AConst@166..167
+              Iconst@166..167 "1"
+        Ascii41@167..168 ")"
+        Ascii44@168..169 ","
+        Whitespace@169..170 " "
+        ResTarget@170..191
+          FuncCall@170..191
+            Ident@170..186 "pg_advisory_lock"
+            Ascii40@186..187 "("
+            AConst@187..188
+              Iconst@187..188 "1"
+            Ascii44@188..189 ","
+            Whitespace@189..190 " "
+            AConst@190..191
+              Iconst@190..191 "1"
+        Ascii41@191..192 ")"
+        Ascii44@192..193 ","
+        Newline@193..194 "\n"
+        Newline@194..195 "\t"
+        ResTarget@195..223
+          FuncCall@195..223
+            Ident@195..218 "pg_advisory_lock_shared"
+            Ascii40@218..219 "("
+            AConst@219..220
+              Iconst@219..220 "2"
+            Ascii44@220..221 ","
+            Whitespace@221..222 " "
+            AConst@222..223
+              Iconst@222..223 "2"
+        Ascii41@223..224 ")"
+        Ascii44@224..225 ","
+        Whitespace@225..226 " "
+        ResTarget@226..254
+          FuncCall@226..254
+            Ident@226..249 "pg_advisory_lock_shared"
+            Ascii40@249..250 "("
+            AConst@250..251
+              Iconst@250..251 "2"
+            Ascii44@251..252 ","
+            Whitespace@252..253 " "
+            AConst@253..254
+              Iconst@253..254 "2"
+        Ascii41@254..255 ")"
+        Ascii59@255..256 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_lock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 25,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 8,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 8,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_lock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 46,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 29,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 29,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_lock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 75,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 51,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 51,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_lock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 103,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 79,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 79,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_lock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 125,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 128,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 108,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 108,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_lock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 149,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 152,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 132,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 132,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_lock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 181,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 184,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 157,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 157,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_lock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 212,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 215,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 188,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 188,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [],
+                    where_clause: None,
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 37..255,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@35.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@35.snap
@@ -1,0 +1,487 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "SELECT locktype, classid, objid, objsubid, mode, granted\n\tFROM pg_locks WHERE locktype = 'advisory'\n\tORDER BY classid, objid, objsubid;"
+---
+Parse {
+    cst: SourceFile@0..135
+      SelectStmt@0..135
+        Select@0..6 "SELECT"
+        Whitespace@6..7 " "
+        ResTarget@7..15
+          ColumnRef@7..15
+            Ident@7..15 "locktype"
+        Ascii44@15..16 ","
+        Whitespace@16..17 " "
+        ResTarget@17..24
+          ColumnRef@17..24
+            Ident@17..24 "classid"
+        Ascii44@24..25 ","
+        Whitespace@25..26 " "
+        ResTarget@26..31
+          ColumnRef@26..31
+            Ident@26..31 "objid"
+        Ascii44@31..32 ","
+        Whitespace@32..33 " "
+        ResTarget@33..41
+          ColumnRef@33..41
+            Ident@33..41 "objsubid"
+        Ascii44@41..42 ","
+        Whitespace@42..43 " "
+        ResTarget@43..47
+          ColumnRef@43..47
+            Mode@43..47 "mode"
+        Ascii44@47..48 ","
+        Whitespace@48..49 " "
+        ResTarget@49..56
+          ColumnRef@49..56
+            Granted@49..56 "granted"
+        Newline@56..57 "\n"
+        Newline@57..58 "\t"
+        From@58..62 "FROM"
+        Whitespace@62..63 " "
+        RangeVar@63..71
+          Ident@63..71 "pg_locks"
+        Whitespace@71..72 " "
+        Where@72..77 "WHERE"
+        Whitespace@77..78 " "
+        AExpr@78..99
+          ColumnRef@78..86
+            Ident@78..86 "locktype"
+          Whitespace@86..87 " "
+          Ascii61@87..88 "="
+          Whitespace@88..89 " "
+          AConst@89..99
+            Sconst@89..99 "'advisory'"
+        Newline@99..100 "\n"
+        Newline@100..101 "\t"
+        SortBy@101..117
+          Order@101..106 "ORDER"
+          Whitespace@106..107 " "
+          By@107..109 "BY"
+          Whitespace@109..110 " "
+          ColumnRef@110..117
+            Ident@110..117 "classid"
+        Ascii44@117..118 ","
+        Whitespace@118..119 " "
+        SortBy@119..124
+          ColumnRef@119..124
+            Ident@119..124 "objid"
+        Ascii44@124..125 ","
+        Whitespace@125..126 " "
+        SortBy@126..134
+          ColumnRef@126..134
+            Ident@126..134 "objsubid"
+        Ascii59@134..135 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "locktype",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 7,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "classid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 17,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 17,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 26,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 26,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objsubid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 33,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 33,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "mode",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 43,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 43,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "granted",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 49,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 49,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [
+                        Node {
+                            node: Some(
+                                RangeVar(
+                                    RangeVar {
+                                        catalogname: "",
+                                        schemaname: "",
+                                        relname: "pg_locks",
+                                        inh: true,
+                                        relpersistence: "p",
+                                        alias: None,
+                                        location: 63,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    where_clause: Some(
+                        Node {
+                            node: Some(
+                                AExpr(
+                                    AExpr {
+                                        kind: AexprOp,
+                                        name: [
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "=",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        lexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "locktype",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 78,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        rexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    AConst(
+                                                        AConst {
+                                                            isnull: false,
+                                                            location: 89,
+                                                            val: Some(
+                                                                Sval(
+                                                                    String {
+                                                                        sval: "advisory",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 87,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [
+                        Node {
+                            node: Some(
+                                SortBy(
+                                    SortBy {
+                                        node: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "classid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 110,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        sortby_dir: SortbyDefault,
+                                        sortby_nulls: SortbyNullsDefault,
+                                        use_op: [],
+                                        location: -1,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                SortBy(
+                                    SortBy {
+                                        node: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 119,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        sortby_dir: SortbyDefault,
+                                        sortby_nulls: SortbyNullsDefault,
+                                        use_op: [],
+                                        location: -1,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                SortBy(
+                                    SortBy {
+                                        node: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "objsubid",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 126,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        sortby_dir: SortbyDefault,
+                                        sortby_nulls: SortbyNullsDefault,
+                                        use_op: [],
+                                        location: -1,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..134,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@36.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@36.snap
@@ -1,0 +1,90 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: SELECT pg_advisory_unlock_all();
+---
+Parse {
+    cst: SourceFile@0..32
+      SelectStmt@0..32
+        Select@0..6 "SELECT"
+        Whitespace@6..7 " "
+        ResTarget@7..29
+          FuncCall@7..29
+            Ident@7..29 "pg_advisory_unlock_all"
+        Ascii40@29..30 "("
+        Ascii41@30..31 ")"
+        Ascii59@31..32 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_unlock_all",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 7,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [],
+                    where_clause: None,
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..31,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@37.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@37.snap
@@ -1,0 +1,186 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "SELECT count(*) FROM pg_locks WHERE locktype = 'advisory';"
+---
+Parse {
+    cst: SourceFile@0..58
+      SelectStmt@0..58
+        Select@0..6 "SELECT"
+        Whitespace@6..7 " "
+        ResTarget@7..14
+          FuncCall@7..14
+            Ident@7..12 "count"
+            Ascii40@12..13 "("
+            Ascii42@13..14 "*"
+        Ascii41@14..15 ")"
+        Whitespace@15..16 " "
+        From@16..20 "FROM"
+        Whitespace@20..21 " "
+        RangeVar@21..29
+          Ident@21..29 "pg_locks"
+        Whitespace@29..30 " "
+        Where@30..35 "WHERE"
+        Whitespace@35..36 " "
+        AExpr@36..57
+          ColumnRef@36..44
+            Ident@36..44 "locktype"
+          Whitespace@44..45 " "
+          Ascii61@45..46 "="
+          Whitespace@46..47 " "
+          AConst@47..57
+            Sconst@47..57 "'advisory'"
+        Ascii59@57..58 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "count",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: true,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 7,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [
+                        Node {
+                            node: Some(
+                                RangeVar(
+                                    RangeVar {
+                                        catalogname: "",
+                                        schemaname: "",
+                                        relname: "pg_locks",
+                                        inh: true,
+                                        relpersistence: "p",
+                                        alias: None,
+                                        location: 21,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    where_clause: Some(
+                        Node {
+                            node: Some(
+                                AExpr(
+                                    AExpr {
+                                        kind: AexprOp,
+                                        name: [
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "=",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        lexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "locktype",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 36,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        rexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    AConst(
+                                                        AConst {
+                                                            isnull: false,
+                                                            location: 47,
+                                                            val: Some(
+                                                                Sval(
+                                                                    String {
+                                                                        sval: "advisory",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 45,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..57,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@4.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@4.snap
@@ -1,0 +1,92 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "-- pg_advisory_unlock_all() shouldn't release xact locks\nSELECT pg_advisory_unlock_all();"
+---
+Parse {
+    cst: SourceFile@0..89
+      SqlComment@0..56 "-- pg_advisory_unlock ..."
+      Newline@56..57 "\n"
+      SelectStmt@57..89
+        Select@57..63 "SELECT"
+        Whitespace@63..64 " "
+        ResTarget@64..86
+          FuncCall@64..86
+            Ident@64..86 "pg_advisory_unlock_all"
+        Ascii40@86..87 "("
+        Ascii41@87..88 ")"
+        Ascii59@88..89 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_unlock_all",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 7,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [],
+                    where_clause: None,
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 56..88,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@5.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@5.snap
@@ -1,0 +1,186 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "SELECT count(*) FROM pg_locks WHERE locktype = 'advisory';"
+---
+Parse {
+    cst: SourceFile@0..58
+      SelectStmt@0..58
+        Select@0..6 "SELECT"
+        Whitespace@6..7 " "
+        ResTarget@7..14
+          FuncCall@7..14
+            Ident@7..12 "count"
+            Ascii40@12..13 "("
+            Ascii42@13..14 "*"
+        Ascii41@14..15 ")"
+        Whitespace@15..16 " "
+        From@16..20 "FROM"
+        Whitespace@20..21 " "
+        RangeVar@21..29
+          Ident@21..29 "pg_locks"
+        Whitespace@29..30 " "
+        Where@30..35 "WHERE"
+        Whitespace@35..36 " "
+        AExpr@36..57
+          ColumnRef@36..44
+            Ident@36..44 "locktype"
+          Whitespace@44..45 " "
+          Ascii61@45..46 "="
+          Whitespace@46..47 " "
+          AConst@47..57
+            Sconst@47..57 "'advisory'"
+        Ascii59@57..58 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "count",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: true,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 7,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [
+                        Node {
+                            node: Some(
+                                RangeVar(
+                                    RangeVar {
+                                        catalogname: "",
+                                        schemaname: "",
+                                        relname: "pg_locks",
+                                        inh: true,
+                                        relpersistence: "p",
+                                        alias: None,
+                                        location: 21,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    where_clause: Some(
+                        Node {
+                            node: Some(
+                                AExpr(
+                                    AExpr {
+                                        kind: AexprOp,
+                                        name: [
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "=",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        lexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "locktype",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 36,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        rexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    AConst(
+                                                        AConst {
+                                                            isnull: false,
+                                                            location: 47,
+                                                            val: Some(
+                                                                Sval(
+                                                                    String {
+                                                                        sval: "advisory",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 45,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..57,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@6.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@6.snap
@@ -1,0 +1,363 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "-- can't unlock xact locks\nSELECT\n\tpg_advisory_unlock(1), pg_advisory_unlock_shared(2),\n\tpg_advisory_unlock(1, 1), pg_advisory_unlock_shared(2, 2);"
+---
+Parse {
+    cst: SourceFile@0..147
+      SqlComment@0..26 "-- can't unlock xact  ..."
+      Newline@26..27 "\n"
+      SelectStmt@27..147
+        Select@27..33 "SELECT"
+        Newline@33..34 "\n"
+        Newline@34..35 "\t"
+        ResTarget@35..55
+          FuncCall@35..55
+            Ident@35..53 "pg_advisory_unlock"
+            Ascii40@53..54 "("
+            AConst@54..55
+              Iconst@54..55 "1"
+        Ascii41@55..56 ")"
+        Ascii44@56..57 ","
+        Whitespace@57..58 " "
+        ResTarget@58..85
+          FuncCall@58..85
+            Ident@58..83 "pg_advisory_unlock_sh ..."
+            Ascii40@83..84 "("
+            AConst@84..85
+              Iconst@84..85 "2"
+        Ascii41@85..86 ")"
+        Ascii44@86..87 ","
+        Newline@87..88 "\n"
+        Newline@88..89 "\t"
+        ResTarget@89..112
+          FuncCall@89..112
+            Ident@89..107 "pg_advisory_unlock"
+            Ascii40@107..108 "("
+            AConst@108..109
+              Iconst@108..109 "1"
+            Ascii44@109..110 ","
+            Whitespace@110..111 " "
+            AConst@111..112
+              Iconst@111..112 "1"
+        Ascii41@112..113 ")"
+        Ascii44@113..114 ","
+        Whitespace@114..115 " "
+        ResTarget@115..145
+          FuncCall@115..145
+            Ident@115..140 "pg_advisory_unlock_sh ..."
+            Ascii40@140..141 "("
+            AConst@141..142
+              Iconst@141..142 "2"
+            Ascii44@142..143 ","
+            Whitespace@143..144 " "
+            AConst@144..145
+              Iconst@144..145 "2"
+        Ascii41@145..146 ")"
+        Ascii59@146..147 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_unlock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 27,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 8,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 8,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_unlock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 57,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 31,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 31,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_unlock",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 81,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 84,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 1,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 62,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 62,
+                                    },
+                                ),
+                            ),
+                        },
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "pg_advisory_unlock_shared",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 114,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                                Node {
+                                                                    node: Some(
+                                                                        AConst(
+                                                                            AConst {
+                                                                                isnull: false,
+                                                                                location: 117,
+                                                                                val: Some(
+                                                                                    Ival(
+                                                                                        Integer {
+                                                                                            ival: 2,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: false,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 88,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 88,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [],
+                    where_clause: None,
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 26..146,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@7.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@7.snap
@@ -1,0 +1,28 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "-- automatically release xact locks at commit\nCOMMIT;"
+---
+Parse {
+    cst: SourceFile@0..53
+      SqlComment@0..45 "-- automatically rele ..."
+      Newline@45..46 "\n"
+      TransactionStmt@46..53
+        Commit@46..52 "COMMIT"
+        Ascii59@52..53 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: TransactionStmt(
+                TransactionStmt {
+                    kind: TransStmtCommit,
+                    options: [],
+                    savepoint_name: "",
+                    gid: "",
+                    chain: false,
+                },
+            ),
+            range: 45..52,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@8.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@8.snap
@@ -1,0 +1,186 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: "SELECT count(*) FROM pg_locks WHERE locktype = 'advisory';"
+---
+Parse {
+    cst: SourceFile@0..58
+      SelectStmt@0..58
+        Select@0..6 "SELECT"
+        Whitespace@6..7 " "
+        ResTarget@7..14
+          FuncCall@7..14
+            Ident@7..12 "count"
+            Ascii40@12..13 "("
+            Ascii42@13..14 "*"
+        Ascii41@14..15 ")"
+        Whitespace@15..16 " "
+        From@16..20 "FROM"
+        Whitespace@20..21 " "
+        RangeVar@21..29
+          Ident@21..29 "pg_locks"
+        Whitespace@29..30 " "
+        Where@30..35 "WHERE"
+        Whitespace@35..36 " "
+        AExpr@36..57
+          ColumnRef@36..44
+            Ident@36..44 "locktype"
+          Whitespace@44..45 " "
+          Ascii61@45..46 "="
+          Whitespace@46..47 " "
+          AConst@47..57
+            Sconst@47..57 "'advisory'"
+        Ascii59@57..58 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: SelectStmt(
+                SelectStmt {
+                    distinct_clause: [],
+                    into_clause: None,
+                    target_list: [
+                        Node {
+                            node: Some(
+                                ResTarget(
+                                    ResTarget {
+                                        name: "",
+                                        indirection: [],
+                                        val: Some(
+                                            Node {
+                                                node: Some(
+                                                    FuncCall(
+                                                        FuncCall {
+                                                            funcname: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "count",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            args: [],
+                                                            agg_order: [],
+                                                            agg_filter: None,
+                                                            over: None,
+                                                            agg_within_group: false,
+                                                            agg_star: true,
+                                                            agg_distinct: false,
+                                                            func_variadic: false,
+                                                            funcformat: CoerceExplicitCall,
+                                                            location: 7,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 7,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    from_clause: [
+                        Node {
+                            node: Some(
+                                RangeVar(
+                                    RangeVar {
+                                        catalogname: "",
+                                        schemaname: "",
+                                        relname: "pg_locks",
+                                        inh: true,
+                                        relpersistence: "p",
+                                        alias: None,
+                                        location: 21,
+                                    },
+                                ),
+                            ),
+                        },
+                    ],
+                    where_clause: Some(
+                        Node {
+                            node: Some(
+                                AExpr(
+                                    AExpr {
+                                        kind: AexprOp,
+                                        name: [
+                                            Node {
+                                                node: Some(
+                                                    String(
+                                                        String {
+                                                            sval: "=",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ],
+                                        lexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    ColumnRef(
+                                                        ColumnRef {
+                                                            fields: [
+                                                                Node {
+                                                                    node: Some(
+                                                                        String(
+                                                                            String {
+                                                                                sval: "locktype",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            location: 36,
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        rexpr: Some(
+                                            Node {
+                                                node: Some(
+                                                    AConst(
+                                                        AConst {
+                                                            isnull: false,
+                                                            location: 47,
+                                                            val: Some(
+                                                                Sval(
+                                                                    String {
+                                                                        sval: "advisory",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        location: 45,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                    group_clause: [],
+                    group_distinct: false,
+                    having_clause: None,
+                    window_clause: [],
+                    values_lists: [],
+                    sort_clause: [],
+                    limit_offset: None,
+                    limit_count: None,
+                    limit_option: Default,
+                    locking_clause: [],
+                    with_clause: None,
+                    op: SetopNone,
+                    all: false,
+                    larg: None,
+                    rarg: None,
+                },
+            ),
+            range: 0..57,
+        },
+    ],
+}

--- a/crates/parser/tests/snapshots/statements/valid/advisory_lock@9.snap
+++ b/crates/parser/tests/snapshots/statements/valid/advisory_lock@9.snap
@@ -1,0 +1,26 @@
+---
+source: crates/parser/tests/statement_parser_test.rs
+description: BEGIN;
+---
+Parse {
+    cst: SourceFile@0..6
+      TransactionStmt@0..6
+        BeginP@0..5 "BEGIN"
+        Ascii59@5..6 ";"
+    ,
+    errors: [],
+    stmts: [
+        RawStmt {
+            stmt: TransactionStmt(
+                TransactionStmt {
+                    kind: TransStmtBegin,
+                    options: [],
+                    savepoint_name: "",
+                    gid: "",
+                    chain: false,
+                },
+            ),
+            range: 0..5,
+        },
+    ],
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

add support for `transaction begin`

## What is the current behavior?

missing node tokens

## What is the new behavior?

added node tokens

## Additional context

fixes regress tests: 2/213 - [advisory_lock.sql][1]

[1]: https://github.com/pganalyze/libpg_query/blob/9b21e3295402a0d0ee9a50c468d426c2dbb73ee6/test/sql/postgres_regress/advisory_lock.sql