### PR TITLE
bump shlex to fix a dependabot alert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,9 +1115,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"


### PR DESCRIPTION
Fix this dependabot alert: https://github.com/supabase/postgres_lsp/security/dependabot/4