### PR TITLE
fix(pgt_query): iter macros

### DIFF
--- a/crates/pgt_query_macros/src/iter_mut.rs
+++ b/crates/pgt_query_macros/src/iter_mut.rs
@@ -19,12 +19,17 @@ pub fn iter_mut_mod(analyser: ProtoAnalyzer) -> proc_macro2::TokenStream {
 
     for node in &nodes {
         // Use the enum variant name from the Node enum
-        if let Some(variant_name) = type_to_variant.get(&node.name) {
+        if let Some(variant_name) = type_to_variant.get(&node.enum_variant_name) {
             let variant_ident = format_ident!("{}", variant_name);
             node_variant_names.push(variant_ident);
 
             let property_handlers = property_handlers(node);
             node_property_handlers.push(property_handlers);
+        } else {
+            panic!(
+                "No enum variant found for node type: {}",
+                node.enum_variant_name
+            );
         }
     }
 

--- a/crates/pgt_query_macros/src/iter_ref.rs
+++ b/crates/pgt_query_macros/src/iter_ref.rs
@@ -17,7 +17,7 @@ pub fn iter_ref_mod(analyser: ProtoAnalyzer) -> proc_macro2::TokenStream {
     }
 
     for node in &nodes {
-        if let Some(variant_name) = type_to_variant.get(&node.name) {
+        if let Some(variant_name) = type_to_variant.get(&node.enum_variant_name) {
             let variant_ident = format_ident!("{}", variant_name);
             node_variant_names.push(variant_ident);
 
@@ -25,6 +25,11 @@ pub fn iter_ref_mod(analyser: ProtoAnalyzer) -> proc_macro2::TokenStream {
             node_property_handlers.push(quote! {
                 #(#property_handlers)*
             });
+        } else {
+            panic!(
+                "No enum variant found for node type: {}",
+                node.enum_variant_name
+            );
         }
     }
 

--- a/crates/pgt_query_macros/src/proto_analyser.rs
+++ b/crates/pgt_query_macros/src/proto_analyser.rs
@@ -38,8 +38,8 @@ pub(crate) struct Field {
 }
 
 pub(crate) struct Node {
-    pub name: String,
     #[allow(dead_code)]
+    pub name: String,
     pub enum_variant_name: String,
     pub fields: Vec<Field>,
 }


### PR DESCRIPTION
fixes a pretty critical bug in the macros that caused us to skip some nodes! stumbled upon this while working on the pretty printer. 