### PR TITLE
fix: skip already present npm package versions on publish

### DIFF
--- a/.github/workflows/publish.reusable.yml
+++ b/.github/workflows/publish.reusable.yml
@@ -38,16 +38,7 @@ jobs:
         if: inputs.is-prerelease == 'true'
         run: |
           for package in packages/@postgrestools/*; do
-            package_basename=$(basename "$package")
-            package_name="@postgrestools/$package_basename"
-            package_version="${{ inputs.release-tag }}"
-
-            if npm view "$package_name@$package_version" version 2>/dev/null; then
-              echo "Package $package_name@$package_version already exists, skipping..."
-            else
-              echo "Publishing $package_name@$package_version..."
-              npm publish "$package" --tag nightly --access public --provenance
-            fi
+            npm publish "$package" --tag nightly --access public --provenance
           done
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} #


### PR DESCRIPTION
to fix our current issue. tested locally. 