### PR TITLE
chore(pgt_query): support system build

### DIFF
--- a/crates/pgt_query/build.rs
+++ b/crates/pgt_query/build.rs
@@ -227,7 +227,7 @@ fn compile_c_if_needed(layout: &Layout, is_emscripten: bool, target: &str) {
         }
     }
 
-    println!("cargo:rustc-link-lib=static={}", LIB_NAME);
+    println!("cargo:rustc-link-lib=static={LIB_NAME}");
     cc.compile(LIB_NAME);
 }
 
@@ -241,7 +241,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rustc-link-search=native={}", out_dir.display());
 
     let layout = if let Ok(p) = env::var("LIBPG_QUERY_PATH") {
-        println!("using system libpg_query at {}", p);
+        println!("using system libpg_query at {p}");
         system_layout(Path::new(&p))?
     } else {
         println!("using vendored libpg_query (submodule)");
@@ -251,7 +251,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     if let Some(lib_dir) = &layout.lib_dir {
         println!("cargo:rustc-link-search=native={}", lib_dir.display());
-        println!("cargo:rustc-link-lib={}", LIB_NAME);
+        println!("cargo:rustc-link-lib={LIB_NAME}");
     }
 
     compile_c_if_needed(&layout, is_emscripten, &target);


### PR DESCRIPTION
after reviewing the comments on our first attempt to add this project to homebrew (https://github.com/Homebrew/homebrew-core/pull/218049), i realised that we can significantly improve the build in our homebrew recipe if we add `libpg_query` as a homebrew dependency (yes, it is available there as a formula).

this PR adds a "dual build" to the build script of `pgt_query`. If `LIBPG_QUERY_PATH` is set, we link the library directly and skip the build.

tested this locally.

once this is merged, I will publish a new release and create the pr for homebrew. 