### PR TITLE
Fix typo in JSON configuration for plpgsqlCheck

### DIFF
--- a/docs/features/plpgsql.md
+++ b/docs/features/plpgsql.md
@@ -32,7 +32,7 @@ You can always disable the integration if you do not want the language server to
 
 ```json
 {
-  "plpqsqlCheck": {
+  "plpgsqlCheck": {
     "enabled": false
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Document typo change `plpqsqlCheck` to `plpgsqlCheck`

