### PR TITLE
docs: fix comma and extra space in JSON in configuration.md

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,9 +19,9 @@ A configuration file is usually placed in your project’s root folder. It is or
   },
   "typecheck": {
     "enabled": true
-  }
+  },
   "plpgsqlCheck": {
-    "enabled" : true
+    "enabled": true
   }
 }
 ```


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds a missing comma and removes an extra space from some of the JSON in docs/configuration.md
