### PR TITLE
feat(completions): infrastructure for keyword support [4/6]

### DIFF
--- a/crates/pgls_completions/src/builder.rs
+++ b/crates/pgls_completions/src/builder.rs
@@ -32,10 +32,12 @@ impl<'a> CompletionBuilder<'a> {
     }
 
     pub fn finish(self) -> Vec<CompletionItem> {
+        let mut shared_tree = self.ctx.tree.clone();
+
         let mut items: Vec<PossibleCompletionItem> = self
             .items
             .into_iter()
-            .filter(|i| i.filter.is_relevant(self.ctx).is_some())
+            .filter(|i| i.filter.is_relevant(self.ctx, &mut shared_tree).is_some())
             .collect();
 
         for item in items.iter_mut() {

--- a/crates/pgls_completions/src/item.rs
+++ b/crates/pgls_completions/src/item.rs
@@ -13,6 +13,7 @@ pub enum CompletionItemKind {
     Schema,
     Policy,
     Role,
+    Keyword,
 }
 
 impl Display for CompletionItemKind {
@@ -24,6 +25,7 @@ impl Display for CompletionItemKind {
             CompletionItemKind::Schema => "Schema",
             CompletionItemKind::Policy => "Policy",
             CompletionItemKind::Role => "Role",
+            CompletionItemKind::Keyword => "Keyword",
         };
 
         write!(f, "{txt}")

--- a/crates/pgls_completions/src/providers/mod.rs
+++ b/crates/pgls_completions/src/providers/mod.rs
@@ -12,3 +12,11 @@ pub use policies::*;
 pub use roles::*;
 pub use schemas::*;
 pub use tables::*;
+
+/// Stub for SqlKeyword - full implementation in keywords.rs (PR5)
+#[derive(Debug, Clone, Copy)]
+pub struct SqlKeyword {
+    pub name: &'static str,
+    pub require_prefix: bool,
+    pub starts_statement: bool,
+}

--- a/crates/pgls_completions/src/relevance.rs
+++ b/crates/pgls_completions/src/relevance.rs
@@ -1,6 +1,8 @@
 pub(crate) mod filtering;
 pub(crate) mod scoring;
 
+use crate::providers::SqlKeyword;
+
 #[derive(Debug, Clone)]
 pub(crate) enum CompletionRelevanceData<'a> {
     Table(&'a pgls_schema_cache::Table),
@@ -9,4 +11,5 @@ pub(crate) enum CompletionRelevanceData<'a> {
     Schema(&'a pgls_schema_cache::Schema),
     Policy(&'a pgls_schema_cache::Policy),
     Role(&'a pgls_schema_cache::Role),
+    Keyword(&'static SqlKeyword),
 }

--- a/crates/pgls_completions/src/sanitization.rs
+++ b/crates/pgls_completions/src/sanitization.rs
@@ -124,6 +124,7 @@ where
             tree: Cow::Owned(tree),
         }
     }
+
     fn unadjusted(params: CompletionParams<'larger>) -> Self {
         Self {
             position: params.position,
@@ -146,7 +147,7 @@ fn cursor_inbetween_nodes(sql: &str, position: TextSize) -> bool {
     let mut chars = sql.chars();
 
     let previous_whitespace = chars
-        .nth(position - 1)
+        .nth(position.saturating_sub(1))
         .is_some_and(|c| c.is_ascii_whitespace());
 
     let current_whitespace = chars.next().is_some_and(|c| c.is_ascii_whitespace());
@@ -169,7 +170,9 @@ fn cursor_prepared_to_write_token_after_last_node(sql: &str, position: TextSize)
 
 fn cursor_on_a_dot(sql: &str, position: TextSize) -> bool {
     let position: usize = position.into();
-    sql.chars().nth(position - 1).is_some_and(|c| c == '.')
+    sql.chars()
+        .nth(position.saturating_sub(1))
+        .is_some_and(|c| c == '.')
 }
 
 fn cursor_before_semicolon(tree: &tree_sitter::Tree, position: TextSize) -> bool {
@@ -244,7 +247,11 @@ fn cursor_between_parentheses(sql: &str, position: TextSize) -> bool {
     // early check: '(|)'
     // however, we want to check this after the level nesting.
     let mut chars = sql.chars();
-    if chars.nth(position - 1).is_some_and(|c| c == '(') && chars.next().is_some_and(|c| c == ')') {
+    if chars
+        .nth(position.saturating_sub(1))
+        .is_some_and(|c| c == '(')
+        && chars.next().is_some_and(|c| c == ')')
+    {
         return true;
     }
 

--- a/crates/pgls_completions/src/test_helper.rs
+++ b/crates/pgls_completions/src/test_helper.rs
@@ -181,9 +181,10 @@ pub(crate) async fn assert_complete_results(
 
     assert!(
         items.len() >= existing.len(),
-        "Not enough items returned. Expected at least {} items, but got {}",
+        "Not enough items returned. Expected at least {} items, but got {}. query: {}",
         existing.len(),
-        items.len()
+        items.len(),
+        query
     );
 
     for item in &items {
@@ -204,6 +205,8 @@ pub(crate) async fn assert_no_complete_results(query: &str, setup: Option<&str>,
     let (tree, cache) = get_test_deps(setup, query.into(), pool).await;
     let params = get_test_params(&tree, &cache, query.into());
     let items = complete(params);
+
+    println!("Items returned: {:#?}", items);
 
     assert_eq!(items.len(), 0)
 }
@@ -555,7 +558,9 @@ impl TestCompletionsCase {
                 write!(writer, " - ").unwrap();
 
                 match item.kind {
-                    CompletionItemKind::Schema | CompletionItemKind::Role => {}
+                    CompletionItemKind::Schema
+                    | CompletionItemKind::Role
+                    | CompletionItemKind::Keyword => {}
                     _ => {
                         write!(writer, "{}.", item.description).unwrap();
                     }


### PR DESCRIPTION
## Summary
Prepare completions crate for keyword support.

- `item.rs`: add Keyword CompletionItemKind
- `relevance.rs`: add Keyword variant for CompletionRelevanceData
- `scoring.rs`: add keyword scoring logic
- `filtering.rs`: add keyword validation/filtering
- `sanitization.rs`, `builder.rs`, `test_helper.rs`: updates
- `providers/mod.rs`: stub SqlKeyword type (replaced in PR5)

This is PR 4/6 for keyword completions. **Builds on #643.**

## Test plan
- `cargo check -p pgls_completions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)