### PR TITLE
test(completions): update tests & snapshots for keywords [6/6]

### DIFF
--- a/crates/pgls_completions/src/providers/columns.rs
+++ b/crates/pgls_completions/src/providers/columns.rs
@@ -51,9 +51,12 @@ fn get_completion_text(ctx: &TreesitterContext, col: &Column) -> CompletionText 
 #[cfg(test)]
 mod tests {
 
+    use pgls_test_utils::QueryWithCursorPosition;
     use sqlx::PgPool;
 
-    use crate::test_helper::{TestCompletionsCase, TestCompletionsSuite};
+    use crate::test_helper::{
+        TestCompletionsCase, TestCompletionsSuite, assert_no_complete_results,
+    };
 
     #[sqlx::test(migrator = "pgls_test_utils::MIGRATIONS")]
     async fn handles_nested_queries(pool: PgPool) {
@@ -440,7 +443,7 @@ mod tests {
                         "select name from instruments i join others o on i.z = o.a <sql>",
                     )
                     .type_sql("where o.<1>a = <2>i.z and <3>i.id > 5;")
-                    .comment("should respect alias speciifcation")
+                    .comment("should respect alias specification")
                     .comment("should not prioritize suggest columns or schemas (right side of binary expression)")
                     .comment("should prioritize columns that aren't already mentioned"),
             )

--- a/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__after_from_clause.snap
+++ b/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__after_from_clause.snap
@@ -1,0 +1,87 @@
+---
+source: crates/pgls_completions/src/test_helper.rs
+expression: final_snapshot
+---
+***Setup***
+
+create table public.users (
+    id serial primary key,
+    email varchar(255)
+);
+
+
+--------------
+
+select email from users |
+
+Results:
+cross - cross (Keyword)
+full - full (Keyword)
+group - group (Keyword)
+inner - inner (Keyword)
+join - join (Keyword)
+
+--------------
+
+select email from users w|
+
+Results:
+where - where (Keyword)
+window - window (Keyword)
+
+--------------
+
+select email from users where |
+
+Results:
+email - public.users.email (Column)
+id - public.users.id (Column)
+abbrev - pg_catalog.pg_timezone_abbrevs.abbrev (Column)
+action_condition - information_schema.triggers.action_condition (Column)
+action_order - information_schema.triggers.action_order (Column)
+
+--------------
+
+select email from users where i|
+
+Results:
+id - public.users.id (Column)
+email - public.users.email (Column)
+ident - pg_catalog.pg_backend_memory_contexts.ident (Column)
+identity_cycle - information_schema.columns.identity_cycle (Column)
+identity_generation - information_schema.columns.identity_generation (Column)
+
+--------------
+
+select email from users where id |
+
+Results:
+group - group (Keyword)
+limit - limit (Keyword)
+order - order (Keyword)
+window - window (Keyword)
+
+--------------
+
+select email from users where id = |
+
+Results:
+email - public.users.email (Column)
+id - public.users.id (Column)
+abbrev - pg_catalog.pg_timezone_abbrevs.abbrev (Column)
+action_condition - information_schema.triggers.action_condition (Column)
+action_order - information_schema.triggers.action_order (Column)
+
+--------------
+
+select email from users where id = 1|
+select email from users where id = 1; |
+
+Results:
+insert - insert (Keyword)
+reset - reset (Keyword)
+select - select (Keyword)
+set - set (Keyword)
+truncate - truncate (Keyword)
+
+--------------

--- a/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__completes_in_join_on_clause.snap
+++ b/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__completes_in_join_on_clause.snap
@@ -56,6 +56,16 @@ user_id - auth.posts.user_id (Column)
 --------------
 
 select u.id, auth.posts.content from auth.users u join auth.posts p on p.user_id |
+
+Results:
+cross - cross (Keyword)
+full - full (Keyword)
+group - group (Keyword)
+inner - inner (Keyword)
+join - join (Keyword)
+
+--------------
+
 select u.id, auth.posts.content from auth.users u join auth.posts p on p.user_id = |
 
 Results:
@@ -86,3 +96,12 @@ uid - auth.users.uid (Column)
 --------------
 
 select u.id, auth.posts.content from auth.users u join auth.posts p on p.user_id = u.uid; |
+
+Results:
+insert - insert (Keyword)
+reset - reset (Keyword)
+select - select (Keyword)
+set - set (Keyword)
+truncate - truncate (Keyword)
+
+--------------

--- a/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__completes_join_kw.snap
+++ b/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__completes_join_kw.snap
@@ -1,0 +1,16 @@
+---
+source: crates/pgls_completions/src/test_helper.rs
+expression: final_snapshot
+---
+***Setup***
+
+create table public.users (
+    id serial primary key,
+    email varchar(255)
+);
+
+
+--------------
+
+select email from users left |
+select email from users left j |

--- a/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__completes_quoted_columns.snap
+++ b/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__completes_quoted_columns.snap
@@ -17,6 +17,15 @@ create table private.users (
 --------------
 
 s|
+
+Results:
+select - select (Keyword)
+set - set (Keyword)
+insert - insert (Keyword)
+reset - reset (Keyword)
+
+--------------
+
 select |
 
 Results:
@@ -62,7 +71,19 @@ encoding - pg_catalog.pg_database.encoding (Column)
 --------------
 
 select "email" |
+
+Results:
+from - from (Keyword)
+
+--------------
+
 select "email" f|
+
+Results:
+from - from (Keyword)
+
+--------------
+
 select "email" from |
 
 Results:
@@ -116,3 +137,12 @@ users - private.users (Table)
 
 select "email" from "private".u|
 select "email" from "private".users; |
+
+Results:
+insert - insert (Keyword)
+reset - reset (Keyword)
+select - select (Keyword)
+set - set (Keyword)
+truncate - truncate (Keyword)
+
+--------------

--- a/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__completes_quoted_columns_with_aliases.snap
+++ b/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__completes_quoted_columns_with_aliases.snap
@@ -24,6 +24,15 @@ create table public.names (
 ***Case 1:***
 
 s|
+
+Results:
+select - select (Keyword)
+set - set (Keyword)
+insert - insert (Keyword)
+reset - reset (Keyword)
+
+--------------
+
 select |
 
 Results:
@@ -73,7 +82,19 @@ select "pr"."|
 select "pr"."|"
 select "pr"."e|"
 select "pr"."email" |
+
+Results:
+from - from (Keyword)
+
+--------------
+
 select "pr"."email" f|
+
+Results:
+from - from (Keyword)
+
+--------------
+
 select "pr"."email" from |
 
 Results:
@@ -111,10 +132,30 @@ users - private.users (Table)
 --------------
 
 select "pr"."email" from private.users |
+
+Results:
+cross - cross (Keyword)
+full - full (Keyword)
+group - group (Keyword)
+inner - inner (Keyword)
+join - join (Keyword)
+
+--------------
+
 select "pr"."email" from private.users "|
 select "pr"."email" from private.users "|"
 select "pr"."email" from private.users "p|"
 select "pr"."email" from private.users "pr" |
+
+Results:
+cross - cross (Keyword)
+full - full (Keyword)
+group - group (Keyword)
+inner - inner (Keyword)
+join - join (Keyword)
+
+--------------
+
 
 
 

--- a/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__does_not_complete_cols_in_join_clauses.snap
+++ b/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__does_not_complete_cols_in_join_clauses.snap
@@ -24,6 +24,15 @@ create table auth.posts (
 --------------
 
 s|
+
+Results:
+select - select (Keyword)
+set - set (Keyword)
+insert - insert (Keyword)
+reset - reset (Keyword)
+
+--------------
+
 select |
 
 Results:
@@ -51,7 +60,19 @@ pid - auth.posts.pid (Column)
 select u.uid, p.|
 select u.uid, p.c|
 select u.uid, p.content |
+
+Results:
+from - from (Keyword)
+
+--------------
+
 select u.uid, p.content f|
+
+Results:
+from - from (Keyword)
+
+--------------
+
 select u.uid, p.content from |
 **Schema suggestions should be prioritized, since we want to push users to specify them.**
 
@@ -94,8 +115,34 @@ users - auth.users (Table)
 --------------
 
 select u.uid, p.content from auth.users |
+
+Results:
+cross - cross (Keyword)
+full - full (Keyword)
+group - group (Keyword)
+inner - inner (Keyword)
+join - join (Keyword)
+
+--------------
+
 select u.uid, p.content from auth.users u |
+
+Results:
+cross - cross (Keyword)
+full - full (Keyword)
+group - group (Keyword)
+inner - inner (Keyword)
+join - join (Keyword)
+
+--------------
+
 select u.uid, p.content from auth.users u j|
+
+Results:
+join - join (Keyword)
+
+--------------
+
 select u.uid, p.content from auth.users u join |
 
 Results:
@@ -134,8 +181,28 @@ posts - auth.posts (Table)
 --------------
 
 select u.uid, p.content from auth.users u join auth.posts |
+
+Results:
+on - on (Keyword)
+using - using (Keyword)
+
+--------------
+
 select u.uid, p.content from auth.users u join auth.posts p |
+
+Results:
+on - on (Keyword)
+using - using (Keyword)
+
+--------------
+
 select u.uid, p.content from auth.users u join auth.posts p o|
+
+Results:
+on - on (Keyword)
+
+--------------
+
 select u.uid, p.content from auth.users u join auth.posts p on |
 
 Results:
@@ -164,6 +231,16 @@ uid - auth.users.uid (Column)
 --------------
 
 select u.uid, p.content from auth.users u join auth.posts p on u.uid |
+
+Results:
+cross - cross (Keyword)
+full - full (Keyword)
+group - group (Keyword)
+inner - inner (Keyword)
+join - join (Keyword)
+
+--------------
+
 select u.uid, p.content from auth.users u join auth.posts p on u.uid = |
 
 Results:
@@ -194,3 +271,12 @@ user_id - auth.posts.user_id (Column)
 --------------
 
 select u.uid, p.content from auth.users u join auth.posts p on u.uid = p.user_id |
+
+Results:
+cross - cross (Keyword)
+full - full (Keyword)
+group - group (Keyword)
+inner - inner (Keyword)
+join - join (Keyword)
+
+--------------

--- a/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__filters_out_by_aliases_in_join_on.snap
+++ b/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__filters_out_by_aliases_in_join_on.snap
@@ -24,7 +24,20 @@ create table auth.posts (
 --------------
 
 select u.id, p.content from auth.users u join auth.posts p |
+
+Results:
+on - on (Keyword)
+using - using (Keyword)
+
+--------------
+
 select u.id, p.content from auth.users u join auth.posts p o|
+
+Results:
+on - on (Keyword)
+
+--------------
+
 select u.id, p.content from auth.users u join auth.posts p on |
 **Should prefer primary indices here.**
 
@@ -55,6 +68,16 @@ email - auth.users.email (Column)
 --------------
 
 select u.id, p.content from auth.users u join auth.posts p on u.id |
+
+Results:
+cross - cross (Keyword)
+full - full (Keyword)
+group - group (Keyword)
+inner - inner (Keyword)
+join - join (Keyword)
+
+--------------
+
 select u.id, p.content from auth.users u join auth.posts p on u.id = |
 
 Results:
@@ -86,3 +109,12 @@ user_id - auth.posts.user_id (Column)
 --------------
 
 select u.id, p.content from auth.users u join auth.posts p on u.id = p.user_id |
+
+Results:
+cross - cross (Keyword)
+full - full (Keyword)
+group - group (Keyword)
+inner - inner (Keyword)
+join - join (Keyword)
+
+--------------

--- a/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__ignores_cols_in_from_clause.snap
+++ b/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__ignores_cols_in_from_clause.snap
@@ -56,3 +56,12 @@ users - private.users (Table)
 --------------
 
 select * from private.users |
+
+Results:
+cross - cross (Keyword)
+full - full (Keyword)
+group - group (Keyword)
+inner - inner (Keyword)
+join - join (Keyword)
+
+--------------

--- a/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__prefers_not_mentioned_columns.snap
+++ b/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__prefers_not_mentioned_columns.snap
@@ -116,8 +116,8 @@ Results:
 c - public.two.c (Column)
 cache_size - pg_catalog.pg_sequences.cache_size (Column)
 calls - pg_catalog.pg_stat_user_functions.calls (Column)
+cast - cast (Keyword)
 castcontext - pg_catalog.pg_cast.castcontext (Column)
-castfunc - pg_catalog.pg_cast.castfunc (Column)
 
 --------------
 
@@ -268,8 +268,8 @@ Results:
 c - public.two.c (Column)
 cache_size - pg_catalog.pg_sequences.cache_size (Column)
 calls - pg_catalog.pg_stat_user_functions.calls (Column)
+cast - cast (Keyword)
 castcontext - pg_catalog.pg_cast.castcontext (Column)
-castfunc - pg_catalog.pg_cast.castfunc (Column)
 
 --------------
 

--- a/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__shows_multiple_columns_if_no_relation_specified.snap
+++ b/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__shows_multiple_columns_if_no_relation_specified.snap
@@ -25,6 +25,15 @@ create table private.audio_books (
 --------------
 
 s|
+
+Results:
+select - select (Keyword)
+set - set (Keyword)
+insert - insert (Keyword)
+reset - reset (Keyword)
+
+--------------
+
 select |
 **Should suggest all columns with n first**
 
@@ -44,9 +53,14 @@ Results:
 name - public.users.name (Column)
 narrator - public.audio_books.narrator (Column)
 narrator_id - private.audio_books.narrator_id (Column)
+null - null (Keyword)
 name - Schema: pg_catalog.name (Function)
-nameconcatoid - Schema: pg_catalog.nameconcatoid (Function)
 
 --------------
 
 select narrator_id |
+
+Results:
+from - from (Keyword)
+
+--------------

--- a/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__suggests_columns_in_alter_table_and_drop_table.snap
+++ b/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__suggests_columns_in_alter_table_and_drop_table.snap
@@ -17,6 +17,13 @@ create table instruments (
 ***Case 1:***
 
 a|
+
+Results:
+truncate - truncate (Keyword)
+update - update (Keyword)
+
+--------------
+
 alter |
 alter t|
 alter table |
@@ -95,6 +102,13 @@ alter table instruments drop column name |
 ***Case 2:***
 
 a|
+
+Results:
+truncate - truncate (Keyword)
+update - update (Keyword)
+
+--------------
+
 alter |
 alter t|
 alter table |
@@ -197,6 +211,13 @@ alter table instruments drop column if exists name |
 ***Case 3:***
 
 a|
+
+Results:
+truncate - truncate (Keyword)
+update - update (Keyword)
+
+--------------
+
 alter |
 alter t|
 alter table |
@@ -230,7 +251,7 @@ created_at - public.instruments.created_at (Column)
 id - public.instruments.id (Column)
 name - public.instruments.name (Column)
 z - public.instruments.z (Column)
-abbrev - pg_catalog.pg_timezone_abbrevs.abbrev (Column)
+column - column (Keyword)
 
 --------------
 
@@ -238,10 +259,10 @@ alter table instruments alter c|
 
 Results:
 created_at - public.instruments.created_at (Column)
+column - column (Keyword)
 cache_size - pg_catalog.pg_sequences.cache_size (Column)
 calls - pg_catalog.pg_stat_user_functions.calls (Column)
 castcontext - pg_catalog.pg_cast.castcontext (Column)
-castfunc - pg_catalog.pg_cast.castfunc (Column)
 
 --------------
 
@@ -289,6 +310,13 @@ instruments - public.instruments (Table)
 ***Case 4:***
 
 a|
+
+Results:
+truncate - truncate (Keyword)
+update - update (Keyword)
+
+--------------
+
 alter |
 alter t|
 alter table |
@@ -322,7 +350,7 @@ created_at - public.instruments.created_at (Column)
 id - public.instruments.id (Column)
 name - public.instruments.name (Column)
 z - public.instruments.z (Column)
-abbrev - pg_catalog.pg_timezone_abbrevs.abbrev (Column)
+column - column (Keyword)
 
 --------------
 
@@ -330,10 +358,10 @@ alter table instruments alter n|
 
 Results:
 name - public.instruments.name (Column)
+column - column (Keyword)
 n_dead_tup - pg_catalog.pg_stat_all_tables.n_dead_tup (Column)
 n_distinct - pg_catalog.pg_stats.n_distinct (Column)
 n_ins_since_vacuum - pg_catalog.pg_stat_all_tables.n_ins_since_vacuum (Column)
-n_live_tup - pg_catalog.pg_stat_all_tables.n_live_tup (Column)
 
 --------------
 
@@ -359,6 +387,13 @@ instruments - public.instruments (Table)
 ***Case 5:***
 
 a|
+
+Results:
+truncate - truncate (Keyword)
+update - update (Keyword)
+
+--------------
+
 alter |
 alter t|
 alter table |
@@ -408,7 +443,7 @@ created_at - public.instruments.created_at (Column)
 id - public.instruments.id (Column)
 name - public.instruments.name (Column)
 z - public.instruments.z (Column)
-abbrev - pg_catalog.pg_timezone_abbrevs.abbrev (Column)
+column - column (Keyword)
 
 --------------
 
@@ -416,10 +451,10 @@ alter table public.instruments alter c|
 
 Results:
 created_at - public.instruments.created_at (Column)
+column - column (Keyword)
 cache_size - pg_catalog.pg_sequences.cache_size (Column)
 calls - pg_catalog.pg_stat_user_functions.calls (Column)
 castcontext - pg_catalog.pg_cast.castcontext (Column)
-castfunc - pg_catalog.pg_cast.castfunc (Column)
 
 --------------
 
@@ -453,6 +488,13 @@ alter table public.instruments alter column name |
 ***Case 6:***
 
 a|
+
+Results:
+truncate - truncate (Keyword)
+update - update (Keyword)
+
+--------------
+
 alter |
 alter t|
 alter table |
@@ -486,7 +528,7 @@ created_at - public.instruments.created_at (Column)
 id - public.instruments.id (Column)
 name - public.instruments.name (Column)
 z - public.instruments.z (Column)
-abbrev - pg_catalog.pg_timezone_abbrevs.abbrev (Column)
+column - column (Keyword)
 
 --------------
 
@@ -494,10 +536,10 @@ alter table instruments alter n|
 
 Results:
 name - public.instruments.name (Column)
+column - column (Keyword)
 n_dead_tup - pg_catalog.pg_stat_all_tables.n_dead_tup (Column)
 n_distinct - pg_catalog.pg_stats.n_distinct (Column)
 n_ins_since_vacuum - pg_catalog.pg_stat_all_tables.n_ins_since_vacuum (Column)
-n_live_tup - pg_catalog.pg_stat_all_tables.n_live_tup (Column)
 
 --------------
 
@@ -509,6 +551,13 @@ alter table instruments alter name |
 ***Case 7:***
 
 a|
+
+Results:
+truncate - truncate (Keyword)
+update - update (Keyword)
+
+--------------
+
 alter |
 alter t|
 alter table |
@@ -542,7 +591,7 @@ created_at - public.instruments.created_at (Column)
 id - public.instruments.id (Column)
 name - public.instruments.name (Column)
 z - public.instruments.z (Column)
-abbrev - pg_catalog.pg_timezone_abbrevs.abbrev (Column)
+column - column (Keyword)
 
 --------------
 
@@ -550,15 +599,27 @@ alter table instruments rename n|
 
 Results:
 name - public.instruments.name (Column)
+column - column (Keyword)
 n_dead_tup - pg_catalog.pg_stat_all_tables.n_dead_tup (Column)
 n_distinct - pg_catalog.pg_stats.n_distinct (Column)
 n_ins_since_vacuum - pg_catalog.pg_stat_all_tables.n_ins_since_vacuum (Column)
-n_live_tup - pg_catalog.pg_stat_all_tables.n_live_tup (Column)
 
 --------------
 
 alter table instruments rename name |
+
+Results:
+to - to (Keyword)
+
+--------------
+
 alter table instruments rename name t|
+
+Results:
+to - to (Keyword)
+
+--------------
+
 alter table instruments rename name to |
 alter table instruments rename name to n|
 alter table instruments rename name to new_col |
@@ -569,6 +630,13 @@ alter table instruments rename name to new_col |
 ***Case 8:***
 
 a|
+
+Results:
+truncate - truncate (Keyword)
+update - update (Keyword)
+
+--------------
+
 alter |
 alter t|
 alter table |
@@ -618,7 +686,7 @@ created_at - public.instruments.created_at (Column)
 id - public.instruments.id (Column)
 name - public.instruments.name (Column)
 z - public.instruments.z (Column)
-abbrev - pg_catalog.pg_timezone_abbrevs.abbrev (Column)
+column - column (Keyword)
 
 --------------
 
@@ -626,10 +694,10 @@ alter table public.instruments rename c|
 
 Results:
 created_at - public.instruments.created_at (Column)
+column - column (Keyword)
 cache_size - pg_catalog.pg_sequences.cache_size (Column)
 calls - pg_catalog.pg_stat_user_functions.calls (Column)
 castcontext - pg_catalog.pg_cast.castcontext (Column)
-castfunc - pg_catalog.pg_cast.castfunc (Column)
 
 --------------
 
@@ -656,7 +724,19 @@ n_live_tup - pg_catalog.pg_stat_all_tables.n_live_tup (Column)
 --------------
 
 alter table public.instruments rename column name |
+
+Results:
+to - to (Keyword)
+
+--------------
+
 alter table public.instruments rename column name t|
+
+Results:
+to - to (Keyword)
+
+--------------
+
 alter table public.instruments rename column name to |
 alter table public.instruments rename column name to n|
 alter table public.instruments rename column name to new_col |

--- a/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__suggests_columns_in_insert_clause.snap
+++ b/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__suggests_columns_in_insert_clause.snap
@@ -22,8 +22,26 @@ create table others (
 ***Case 1:***
 
 i|
+
+Results:
+insert - insert (Keyword)
+
+--------------
+
 insert |
+
+Results:
+into - into (Keyword)
+
+--------------
+
 insert i|
+
+Results:
+into - into (Keyword)
+
+--------------
+
 insert into |
 
 Results:
@@ -47,6 +65,13 @@ pg_catalog.pg_ident_file_mappings - pg_catalog.pg_ident_file_mappings (Table)
 --------------
 
 insert into instruments |
+
+Results:
+select - select (Keyword)
+values - values (Keyword)
+
+--------------
+
 insert into instruments (|
 insert into instruments (|)
 
@@ -54,8 +79,8 @@ Results:
 id - public.instruments.id (Column)
 name - public.instruments.name (Column)
 z - public.instruments.z (Column)
+select - select (Keyword)
 a - public.others.a (Column)
-b - public.others.b (Column)
 
 --------------
 
@@ -93,7 +118,20 @@ n_live_tup - pg_catalog.pg_stat_all_tables.n_live_tup (Column)
 --------------
 
 insert into instruments (id, name) |
+
+Results:
+select - select (Keyword)
+values - values (Keyword)
+
+--------------
+
 insert into instruments (id, name) v|
+
+Results:
+values - values (Keyword)
+
+--------------
+
 insert into instruments (id, name) values |
 insert into instruments (id, name) values (|
 insert into instruments (id, name) values (|)
@@ -102,8 +140,8 @@ Results:
 z - public.instruments.z (Column)
 id - public.instruments.id (Column)
 name - public.instruments.name (Column)
+default - default (Keyword)
 a - public.others.a (Column)
-b - public.others.b (Column)
 
 --------------
 
@@ -114,13 +152,23 @@ Results:
 z - public.instruments.z (Column)
 id - public.instruments.id (Column)
 name - public.instruments.name (Column)
+default - default (Keyword)
 a - public.others.a (Column)
-b - public.others.b (Column)
 
 --------------
 
 insert into instruments (id, name) values (1, '|)
 insert into instruments (id, name) values (1, 'my_bass'); |
+
+Results:
+insert - insert (Keyword)
+reset - reset (Keyword)
+select - select (Keyword)
+set - set (Keyword)
+truncate - truncate (Keyword)
+
+--------------
+
 
 
 
@@ -128,8 +176,26 @@ insert into instruments (id, name) values (1, 'my_bass'); |
 ***Case 2:***
 
 i|
+
+Results:
+insert - insert (Keyword)
+
+--------------
+
 insert |
+
+Results:
+into - into (Keyword)
+
+--------------
+
 insert i|
+
+Results:
+into - into (Keyword)
+
+--------------
+
 insert into |
 
 Results:
@@ -153,6 +219,13 @@ pg_catalog.pg_ident_file_mappings - pg_catalog.pg_ident_file_mappings (Table)
 --------------
 
 insert into instruments |
+
+Results:
+select - select (Keyword)
+values - values (Keyword)
+
+--------------
+
 insert into instruments (|
 insert into instruments (|)
 
@@ -160,8 +233,8 @@ Results:
 id - public.instruments.id (Column)
 name - public.instruments.name (Column)
 z - public.instruments.z (Column)
+select - select (Keyword)
 a - public.others.a (Column)
-b - public.others.b (Column)
 
 --------------
 
@@ -221,7 +294,20 @@ n_live_tup - pg_catalog.pg_stat_all_tables.n_live_tup (Column)
 --------------
 
 insert into instruments ("id", "name") |
+
+Results:
+select - select (Keyword)
+values - values (Keyword)
+
+--------------
+
 insert into instruments ("id", "name") v|
+
+Results:
+values - values (Keyword)
+
+--------------
+
 insert into instruments ("id", "name") values |
 insert into instruments ("id", "name") values (|
 insert into instruments ("id", "name") values (|)
@@ -230,8 +316,8 @@ Results:
 id - public.instruments.id (Column)
 name - public.instruments.name (Column)
 z - public.instruments.z (Column)
+default - default (Keyword)
 a - public.others.a (Column)
-b - public.others.b (Column)
 
 --------------
 
@@ -242,13 +328,23 @@ Results:
 id - public.instruments.id (Column)
 name - public.instruments.name (Column)
 z - public.instruments.z (Column)
+default - default (Keyword)
 a - public.others.a (Column)
-b - public.others.b (Column)
 
 --------------
 
 insert into instruments ("id", "name") values (1, '|)
 insert into instruments ("id", "name") values (1, 'my_bass'); |
+
+Results:
+insert - insert (Keyword)
+reset - reset (Keyword)
+select - select (Keyword)
+set - set (Keyword)
+truncate - truncate (Keyword)
+
+--------------
+
 
 
 

--- a/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__suggests_columns_in_where_clause.snap
+++ b/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__suggests_columns_in_where_clause.snap
@@ -21,7 +21,24 @@ create table others (
 --------------
 
 select name from instruments i join others o on i.z = o.a |
+
+Results:
+cross - cross (Keyword)
+full - full (Keyword)
+group - group (Keyword)
+inner - inner (Keyword)
+join - join (Keyword)
+
+--------------
+
 select name from instruments i join others o on i.z = o.a w|
+
+Results:
+where - where (Keyword)
+window - window (Keyword)
+
+--------------
+
 select name from instruments i join others o on i.z = o.a where |
 
 Results:
@@ -34,7 +51,7 @@ i.id - public.instruments.id (Column)
 --------------
 
 select name from instruments i join others o on i.z = o.a where o.|
-**should respect alias speciifcation**
+**should respect alias specification**
 
 Results:
 a - public.others.a (Column)
@@ -44,15 +61,24 @@ c - public.others.c (Column)
 --------------
 
 select name from instruments i join others o on i.z = o.a where o.a |
+
+Results:
+group - group (Keyword)
+limit - limit (Keyword)
+order - order (Keyword)
+window - window (Keyword)
+
+--------------
+
 select name from instruments i join others o on i.z = o.a where o.a = |
 **should not prioritize suggest columns or schemas (right side of binary expression)**
 
 Results:
-instruments - public.instruments (Table)
-others - public.others (Table)
-_sqlx_migrations - public._sqlx_migrations (Table)
-information_schema - information_schema (Schema)
-pg_catalog - pg_catalog (Schema)
+o.b - public.others.b (Column)
+o.c - public.others.c (Column)
+i.created_at - public.instruments.created_at (Column)
+i.id - public.instruments.id (Column)
+i.name - public.instruments.name (Column)
 
 --------------
 
@@ -67,6 +93,15 @@ z - public.instruments.z (Column)
 --------------
 
 select name from instruments i join others o on i.z = o.a where o.a = i.z |
+
+Results:
+group - group (Keyword)
+limit - limit (Keyword)
+order - order (Keyword)
+window - window (Keyword)
+
+--------------
+
 select name from instruments i join others o on i.z = o.a where o.a = i.z a|
 select name from instruments i join others o on i.z = o.a where o.a = i.z and |
 **should prioritize columns that aren't already mentioned**
@@ -98,16 +133,34 @@ id - public.instruments.id (Column)
 --------------
 
 select name from instruments i join others o on i.z = o.a where o.a = i.z and i.id |
+
+Results:
+group - group (Keyword)
+limit - limit (Keyword)
+order - order (Keyword)
+window - window (Keyword)
+
+--------------
+
 select name from instruments i join others o on i.z = o.a where o.a = i.z and i.id > |
 
 Results:
-instruments - public.instruments (Table)
-others - public.others (Table)
-_sqlx_migrations - public._sqlx_migrations (Table)
-information_schema - information_schema (Schema)
-pg_catalog - pg_catalog (Schema)
+o.b - public.others.b (Column)
+o.c - public.others.c (Column)
+i.created_at - public.instruments.created_at (Column)
+i.name - public.instruments.name (Column)
+i.z - public.instruments.z (Column)
 
 --------------
 
 select name from instruments i join others o on i.z = o.a where o.a = i.z and i.id > 5|
 select name from instruments i join others o on i.z = o.a where o.a = i.z and i.id > 5; |
+
+Results:
+insert - insert (Keyword)
+reset - reset (Keyword)
+select - select (Keyword)
+set - set (Keyword)
+truncate - truncate (Keyword)
+
+--------------

--- a/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__suggests_columns_policy_using_clause.snap
+++ b/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__suggests_columns_policy_using_clause.snap
@@ -31,10 +31,10 @@ create policy "my_pol" on public.instruments for select using (i|)
 
 Results:
 id - public.instruments.id (Column)
+interval - interval (Keyword)
 ident - pg_catalog.pg_backend_memory_contexts.ident (Column)
 identity_cycle - information_schema.columns.identity_cycle (Column)
 identity_generation - information_schema.columns.identity_generation (Column)
-identity_increment - information_schema.columns.identity_increment (Column)
 
 --------------
 
@@ -67,10 +67,10 @@ create policy "my_pol" on public.instruments for select using (id = 1 and c|)
 
 Results:
 created_at - public.instruments.created_at (Column)
+cast - cast (Keyword)
 cache_size - pg_catalog.pg_sequences.cache_size (Column)
 calls - pg_catalog.pg_stat_user_functions.calls (Column)
 castcontext - pg_catalog.pg_cast.castcontext (Column)
-castfunc - pg_catalog.pg_cast.castfunc (Column)
 
 --------------
 
@@ -99,10 +99,10 @@ create policy "my_pol" on public.instruments for insert with check (i|)
 
 Results:
 id - public.instruments.id (Column)
+interval - interval (Keyword)
 ident - pg_catalog.pg_backend_memory_contexts.ident (Column)
 identity_cycle - information_schema.columns.identity_cycle (Column)
 identity_generation - information_schema.columns.identity_generation (Column)
-identity_increment - information_schema.columns.identity_increment (Column)
 
 --------------
 
@@ -135,10 +135,10 @@ create policy "my_pol" on public.instruments for insert with check (id = 1 and c
 
 Results:
 created_at - public.instruments.created_at (Column)
+cast - cast (Keyword)
 cache_size - pg_catalog.pg_sequences.cache_size (Column)
 calls - pg_catalog.pg_stat_user_functions.calls (Column)
 castcontext - pg_catalog.pg_cast.castcontext (Column)
-castfunc - pg_catalog.pg_cast.castfunc (Column)
 
 --------------
 

--- a/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__suggests_relevant_columns_without_letters.snap
+++ b/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__suggests_relevant_columns_without_letters.snap
@@ -15,6 +15,15 @@ create table users (
 --------------
 
 s|
+
+Results:
+select - select (Keyword)
+set - set (Keyword)
+insert - insert (Keyword)
+reset - reset (Keyword)
+
+--------------
+
 select |
 
 Results:
@@ -30,15 +39,27 @@ select n|
 
 Results:
 name - public.users.name (Column)
+null - null (Keyword)
+name - Schema: pg_catalog.name (Function)
 nameconcatoid - Schema: pg_catalog.nameconcatoid (Function)
 nameeq - Schema: pg_catalog.nameeq (Function)
-nameeqtext - Schema: pg_catalog.nameeqtext (Function)
-namege - Schema: pg_catalog.namege (Function)
 
 --------------
 
 select name |
+
+Results:
+from - from (Keyword)
+
+--------------
+
 select name f|
+
+Results:
+from - from (Keyword)
+
+--------------
+
 select name from |
 
 Results:
@@ -62,3 +83,12 @@ information_schema.user_defined_types - information_schema.user_defined_types (T
 --------------
 
 select name from users |
+
+Results:
+cross - cross (Keyword)
+full - full (Keyword)
+group - group (Keyword)
+inner - inner (Keyword)
+join - join (Keyword)
+
+--------------

--- a/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__suggests_tables_in_alter_statements.snap
+++ b/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__suggests_tables_in_alter_statements.snap
@@ -1,0 +1,103 @@
+---
+source: crates/pgls_completions/src/test_helper.rs
+expression: final_snapshot
+---
+***Setup***
+
+create schema auth;
+
+create table auth.users (
+    uid serial primary key,
+    name text not null,
+    email text unique not null
+);
+
+create table auth.posts (
+    pid serial primary key,
+    user_id int not null references auth.users(uid),
+    title text not null,
+    content text,
+    created_at timestamp default now()
+);
+
+
+--------------
+
+a|
+
+Results:
+truncate - truncate (Keyword)
+update - update (Keyword)
+
+--------------
+
+alter |
+alter t|
+alter table |
+
+Results:
+auth - auth (Schema)
+auth.posts - auth.posts (Table)
+auth.users - auth.users (Table)
+_sqlx_migrations - public._sqlx_migrations (Table)
+information_schema - information_schema (Schema)
+
+--------------
+
+alter table i|
+
+Results:
+information_schema - information_schema (Schema)
+information_schema.information_schema_catalog_name - information_schema.information_schema_catalog_name (Table)
+public - public (Schema)
+pg_catalog.pg_ident_file_mappings - pg_catalog.pg_ident_file_mappings (Table)
+pg_catalog.pg_index - pg_catalog.pg_index (Table)
+
+--------------
+
+alter table if |
+alter table if e|
+
+Results:
+exists - exists (Keyword)
+
+--------------
+
+alter table if exists |
+
+Results:
+auth - auth (Schema)
+auth.posts - auth.posts (Table)
+auth.users - auth.users (Table)
+_sqlx_migrations - public._sqlx_migrations (Table)
+information_schema - information_schema (Schema)
+
+--------------
+
+alter table if exists a|
+
+Results:
+auth - auth (Schema)
+information_schema.administrable_role_authorizations - information_schema.administrable_role_authorizations (Table)
+information_schema.applicable_roles - information_schema.applicable_roles (Table)
+information_schema.attributes - information_schema.attributes (Table)
+information_schema.collation_character_set_applicability - information_schema.collation_character_set_applicability (Table)
+
+--------------
+
+alter table if exists auth.|
+
+Results:
+posts - auth.posts (Table)
+users - auth.users (Table)
+
+--------------
+
+alter table if exists auth.p|
+
+Results:
+posts - auth.posts (Table)
+
+--------------
+
+alter table if exists auth.posts |

--- a/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__suggests_tables_in_drop_statements.snap
+++ b/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__suggests_tables_in_drop_statements.snap
@@ -1,0 +1,102 @@
+---
+source: crates/pgls_completions/src/test_helper.rs
+expression: final_snapshot
+---
+***Setup***
+
+create schema auth;
+
+create table auth.users (
+    uid serial primary key,
+    name text not null,
+    email text unique not null
+);
+
+create table auth.posts (
+    pid serial primary key,
+    user_id int not null references auth.users(uid),
+    title text not null,
+    content text,
+    created_at timestamp default now()
+);
+
+
+--------------
+
+d|
+
+Results:
+update - update (Keyword)
+
+--------------
+
+drop |
+drop t|
+drop table |
+
+Results:
+auth - auth (Schema)
+auth.posts - auth.posts (Table)
+auth.users - auth.users (Table)
+_sqlx_migrations - public._sqlx_migrations (Table)
+information_schema - information_schema (Schema)
+
+--------------
+
+drop table i|
+
+Results:
+information_schema - information_schema (Schema)
+information_schema.information_schema_catalog_name - information_schema.information_schema_catalog_name (Table)
+public - public (Schema)
+pg_catalog.pg_ident_file_mappings - pg_catalog.pg_ident_file_mappings (Table)
+pg_catalog.pg_index - pg_catalog.pg_index (Table)
+
+--------------
+
+drop table if |
+drop table if e|
+drop table if exists |
+
+Results:
+auth - auth (Schema)
+auth.posts - auth.posts (Table)
+auth.users - auth.users (Table)
+_sqlx_migrations - public._sqlx_migrations (Table)
+information_schema - information_schema (Schema)
+
+--------------
+
+drop table if exists a|
+
+Results:
+auth - auth (Schema)
+information_schema.administrable_role_authorizations - information_schema.administrable_role_authorizations (Table)
+information_schema.applicable_roles - information_schema.applicable_roles (Table)
+information_schema.attributes - information_schema.attributes (Table)
+information_schema.collation_character_set_applicability - information_schema.collation_character_set_applicability (Table)
+
+--------------
+
+drop table if exists auth.|
+
+Results:
+posts - auth.posts (Table)
+users - auth.users (Table)
+
+--------------
+
+drop table if exists auth.p|
+
+Results:
+posts - auth.posts (Table)
+
+--------------
+
+drop table if exists auth.posts |
+
+Results:
+cascade - cascade (Keyword)
+restrict - restrict (Keyword)
+
+--------------

--- a/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__suggests_tables_in_join.snap
+++ b/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__suggests_tables_in_join.snap
@@ -1,0 +1,53 @@
+---
+source: crates/pgls_completions/src/test_helper.rs
+expression: final_snapshot
+---
+***Setup***
+
+create schema auth;
+
+create table auth.users (
+    uid serial primary key,
+    name text not null,
+    email text unique not null
+);
+
+create table auth.posts (
+    pid serial primary key,
+    user_id int not null references auth.users(uid),
+    title text not null,
+    content text,
+    created_at timestamp default now()
+);
+
+
+--------------
+
+select * from auth.users u |
+
+Results:
+cross - cross (Keyword)
+full - full (Keyword)
+group - group (Keyword)
+inner - inner (Keyword)
+join - join (Keyword)
+
+--------------
+
+select * from auth.users u j|
+
+Results:
+join - join (Keyword)
+
+--------------
+
+select * from auth.users u join |
+
+Results:
+auth - auth (Schema)
+information_schema - information_schema (Schema)
+pg_catalog - pg_catalog (Schema)
+pg_toast - pg_toast (Schema)
+auth.posts - auth.posts (Table)
+
+--------------

--- a/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__suggests_tables_in_update.snap
+++ b/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__suggests_tables_in_update.snap
@@ -1,0 +1,155 @@
+---
+source: crates/pgls_completions/src/test_helper.rs
+expression: final_snapshot
+---
+***Setup***
+
+create table coos (
+  id serial primary key,
+  name text
+);
+
+
+--------------
+
+u|
+
+Results:
+update - update (Keyword)
+truncate - truncate (Keyword)
+
+--------------
+
+update |
+
+Results:
+coos - public.coos (Table)
+_sqlx_migrations - public._sqlx_migrations (Table)
+information_schema - information_schema (Schema)
+pg_catalog - pg_catalog (Schema)
+pg_toast - pg_toast (Schema)
+
+--------------
+
+update p|
+
+Results:
+public - public (Schema)
+pg_catalog - pg_catalog (Schema)
+pg_toast - pg_toast (Schema)
+information_schema.parameters - information_schema.parameters (Table)
+pg_catalog.pg_aggregate - pg_catalog.pg_aggregate (Table)
+
+--------------
+
+update public.|
+
+Results:
+coos - public.coos (Table)
+_sqlx_migrations - public._sqlx_migrations (Table)
+
+--------------
+
+update public.c|
+
+Results:
+coos - public.coos (Table)
+
+--------------
+
+update public.coos |
+
+Results:
+set - set (Keyword)
+
+--------------
+
+update public.coos s|
+
+Results:
+set - set (Keyword)
+
+--------------
+
+update public.coos set |
+
+Results:
+id - public.coos.id (Column)
+name - public.coos.name (Column)
+information_schema - information_schema (Schema)
+pg_catalog - pg_catalog (Schema)
+pg_toast - pg_toast (Schema)
+
+--------------
+
+update public.coos set n|
+
+Results:
+name - public.coos.name (Column)
+information_schema - information_schema (Schema)
+n_dead_tup - pg_catalog.pg_stat_all_tables.n_dead_tup (Column)
+n_distinct - pg_catalog.pg_stats.n_distinct (Column)
+n_ins_since_vacuum - pg_catalog.pg_stat_all_tables.n_ins_since_vacuum (Column)
+
+--------------
+
+update public.coos set name |
+update public.coos set name = |
+
+Results:
+coos - public.coos (Table)
+id - public.coos.id (Column)
+name - public.coos.name (Column)
+_sqlx_migrations - public._sqlx_migrations (Table)
+information_schema - information_schema (Schema)
+
+--------------
+
+update public.coos set name = '|
+update public.coos set name = 'cool' |
+update public.coos set name = 'cool' w|
+update public.coos set name = 'cool' where |
+
+Results:
+id - public.coos.id (Column)
+name - public.coos.name (Column)
+abbrev - pg_catalog.pg_timezone_abbrevs.abbrev (Column)
+action_condition - information_schema.triggers.action_condition (Column)
+action_order - information_schema.triggers.action_order (Column)
+
+--------------
+
+update public.coos set name = 'cool' where i|
+
+Results:
+id - public.coos.id (Column)
+ident - pg_catalog.pg_backend_memory_contexts.ident (Column)
+identity_cycle - information_schema.columns.identity_cycle (Column)
+identity_generation - information_schema.columns.identity_generation (Column)
+identity_increment - information_schema.columns.identity_increment (Column)
+
+--------------
+
+update public.coos set name = 'cool' where id |
+update public.coos set name = 'cool' where id = |
+
+Results:
+name - public.coos.name (Column)
+id - public.coos.id (Column)
+abbrev - pg_catalog.pg_timezone_abbrevs.abbrev (Column)
+action_condition - information_schema.triggers.action_condition (Column)
+action_order - information_schema.triggers.action_order (Column)
+
+--------------
+
+update public.coos set name = 'cool' where id = 5|
+update public.coos set name = 'cool' where id = 5; |
+
+Results:
+insert - insert (Keyword)
+reset - reset (Keyword)
+select - select (Keyword)
+set - set (Keyword)
+truncate - truncate (Keyword)
+
+--------------

--- a/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__works_in_session_authorization_statement.snap
+++ b/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__works_in_session_authorization_statement.snap
@@ -1,0 +1,61 @@
+---
+source: crates/pgls_completions/src/test_helper.rs
+expression: final_snapshot
+---
+***Setup***
+
+create table users (
+  id serial primary key,
+  email varchar,
+  address text
+);
+
+
+--------------
+
+s|
+
+Results:
+select - select (Keyword)
+set - set (Keyword)
+insert - insert (Keyword)
+reset - reset (Keyword)
+
+--------------
+
+set |
+set s|
+set session |
+set session a|
+set session authorization |
+
+Results:
+anon - anon (Role)
+authenticated - authenticated (Role)
+owner - owner (Role)
+service_role - service_role (Role)
+test_login - test_login (Role)
+
+--------------
+
+set session authorization a|
+
+Results:
+anon - anon (Role)
+authenticated - authenticated (Role)
+pg_read_all_data - pg_read_all_data (Role)
+pg_read_all_settings - pg_read_all_settings (Role)
+pg_read_all_stats - pg_read_all_stats (Role)
+
+--------------
+
+set session authorization authenticated; |
+
+Results:
+insert - insert (Keyword)
+reset - reset (Keyword)
+select - select (Keyword)
+set - set (Keyword)
+truncate - truncate (Keyword)
+
+--------------

--- a/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__works_in_set_role_statement.snap
+++ b/crates/pgls_completions/src/snapshots/pgls_completions__test_helper__works_in_set_role_statement.snap
@@ -1,0 +1,59 @@
+---
+source: crates/pgls_completions/src/test_helper.rs
+expression: final_snapshot
+---
+***Setup***
+
+create table users (
+  id serial primary key,
+  email varchar,
+  address text
+);
+
+
+--------------
+
+s|
+
+Results:
+select - select (Keyword)
+set - set (Keyword)
+insert - insert (Keyword)
+reset - reset (Keyword)
+
+--------------
+
+set |
+set r|
+set role |
+
+Results:
+anon - anon (Role)
+authenticated - authenticated (Role)
+owner - owner (Role)
+service_role - service_role (Role)
+test_login - test_login (Role)
+
+--------------
+
+set role a|
+
+Results:
+anon - anon (Role)
+authenticated - authenticated (Role)
+pg_read_all_data - pg_read_all_data (Role)
+pg_read_all_settings - pg_read_all_settings (Role)
+pg_read_all_stats - pg_read_all_stats (Role)
+
+--------------
+
+set role anon; |
+
+Results:
+insert - insert (Keyword)
+reset - reset (Keyword)
+select - select (Keyword)
+set - set (Keyword)
+truncate - truncate (Keyword)
+
+--------------

--- a/crates/pgls_test_utils/src/bin/tree_print.rs
+++ b/crates/pgls_test_utils/src/bin/tree_print.rs
@@ -27,7 +27,7 @@ fn main() {
         .expect("Failed to parse query.");
 
     let mut result = String::new();
-    print_ts_tree(&tree.root_node(), &query, 0, &mut result);
+    print_ts_tree(&tree.root_node(), &query, &mut result);
 
     print!("{result}")
 }


### PR DESCRIPTION
## Summary
Update tests and snapshots for keyword completions.

- `tables.rs`, `roles.rs`, `columns.rs`: test updates
- All snapshot updates for existing tests (now include keywords)
- `pgls_test_utils`: lib.rs and tree_print.rs updates

This is PR 6/6 for keyword completions. **Builds on #645.**

This PR should target `main` for final merge.

## Test plan
- `cargo test -p pgls_completions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)