### PR TITLE
[4/7] feat(treesitter): add helper functions for keyword completion

### DIFF
--- a/crates/pgls_treesitter/src/context/mod.rs
+++ b/crates/pgls_treesitter/src/context/mod.rs
@@ -5,10 +5,11 @@ use std::{
 
 use crate::{
     context::ancestors::ScopeTracker,
-    parts_of_reference_query,
+    helper, parts_of_reference_query,
     queries::{self, QueryResult, TreeSitterQueriesExecutor},
 };
 use pgls_text_size::TextSize;
+use tree_sitter::Language;
 
 mod ancestors;
 
@@ -125,6 +126,10 @@ pub struct TreesitterContext<'a> {
     pub is_invocation: bool,
     pub wrapping_statement_range: Option<tree_sitter::Range>,
 
+    pub possible_keywords_at_position: Vec<&'static str>,
+    pub previous_clause: Option<tree_sitter::Node<'a>>,
+    pub current_clause: Option<tree_sitter::Node<'a>>,
+
     mentioned_relations: HashMap<Option<String>, HashSet<String>>,
     mentioned_table_aliases: HashMap<String, String>,
     mentioned_columns: HashMap<Option<WrappingClause<'a>>, HashSet<MentionedColumn>>,
@@ -148,10 +153,17 @@ impl<'a> TreesitterContext<'a> {
             mentioned_table_aliases: HashMap::new(),
             mentioned_columns: HashMap::new(),
             scope_tracker: ScopeTracker::new(),
+
+            possible_keywords_at_position: vec![],
+            current_clause: None,
+            previous_clause: None,
         };
 
         ctx.gather_tree_context();
         ctx.gather_info_from_ts_queries();
+        ctx.gather_possible_keywords_at_position();
+        ctx.check_previous_clause();
+        ctx.check_current_clause();
 
         ctx
     }
@@ -383,7 +395,7 @@ impl<'a> TreesitterContext<'a> {
             "alter_table" => Some(WrappingClause::AlterTable),
             "set_statement" => Some(WrappingClause::SetStatement),
             "revoke_statement" => Some(WrappingClause::RevokeStatement),
-            "grant_statement" => Some(WrappingClause::RevokeStatement),
+            "grant_statement" => Some(WrappingClause::GrantStatement),
             "column_definitions" => Some(WrappingClause::ColumnDefinitions),
             "create_policy" => Some(WrappingClause::CreatePolicy),
             "alter_policy" => Some(WrappingClause::AlterPolicy),
@@ -403,6 +415,36 @@ impl<'a> TreesitterContext<'a> {
                 Some(WrappingClause::Join { on_node })
             }
             _ => None,
+        }
+    }
+
+    fn check_current_clause(&mut self) {
+        self.current_clause = helper::goto_closest_unfinished_parent_clause(self.node_under_cursor);
+    }
+
+    fn check_previous_clause(&mut self) {
+        if let Some(previous_leaf) = helper::goto_previous_leaf(self.node_under_cursor) {
+            self.previous_clause = helper::goto_closest_unfinished_parent_clause(previous_leaf);
+        };
+    }
+
+    fn gather_possible_keywords_at_position(&mut self) {
+        let parse_state = if self.node_under_cursor.kind() == "ERROR" {
+            if self.node_under_cursor.child_count() > 0 {
+                self.node_under_cursor.child(0).unwrap().parse_state()
+            } else {
+                self.node_under_cursor.parse_state()
+            }
+        } else {
+            self.node_under_cursor.parse_state()
+        };
+
+        let language: Language = pgls_treesitter_grammar::LANGUAGE.into();
+        if let Some(mut lookahead_iterator) = language.lookahead_iterator(parse_state) {
+            self.possible_keywords_at_position = lookahead_iterator
+                .iter_names()
+                .filter_map(|kw| kw.strip_prefix("keyword_"))
+                .collect();
         }
     }
 

--- a/crates/pgls_treesitter/src/helper.rs
+++ b/crates/pgls_treesitter/src/helper.rs
@@ -1,0 +1,120 @@
+use tree_sitter::{Node, Tree};
+
+pub static SINGLE_TOKEN_RULES: &[&'static str] = &[
+    "any_identifier",
+    "column_identifier",
+    "schema_identifier",
+    "table_identifier",
+    "function_identifier",
+    "type_identifier",
+    "type",
+    "role_identifier",
+    "policy_identifier",
+    "object_reference",
+    "table_reference",
+    "column_reference",
+    "function_reference",
+    "type_reference",
+    "composite_reference",
+    "literal",
+    "term",
+    "parameter",
+    "direction",
+    "field",
+    "bang",
+    "op_other",
+    "op_unary_other",
+    "comment",
+    "marginalia",
+];
+
+pub fn goto_node_at_position(tree: &Tree, position: usize) -> Option<Node<'_>> {
+    let root = tree.root_node();
+
+    if position >= root.end_byte() || position < root.start_byte() {
+        return None;
+    }
+
+    let mut cursor = tree.root_node().walk();
+
+    while cursor.goto_first_child_for_byte(position).is_some() {}
+
+    Some(cursor.node())
+}
+
+pub fn goto_previous_leaf(node: Node<'_>) -> Option<Node<'_>> {
+    let mut node_with_sibs = Some(node);
+
+    while node_with_sibs
+        .is_some_and(|node| node.kind() != "program" && node.prev_sibling().is_none())
+    {
+        node_with_sibs = node_with_sibs.unwrap().parent();
+    }
+
+    node_with_sibs.and_then(|node| {
+        node.prev_sibling().map(|sib| {
+            let mut cursor = sib.walk();
+            while cursor.goto_last_child() {}
+            cursor.node()
+        })
+    })
+}
+
+pub fn goto_closest_unfinished_parent_clause(node: Node<'_>) -> Option<Node<'_>> {
+    let mut parent = Some(node);
+
+    while let Some(investigated) = parent {
+        let kind = investigated.kind();
+
+        // The top level node for all possible trees.
+        if kind == "program" {
+            break;
+        }
+
+        let explicit_skip = SINGLE_TOKEN_RULES.contains(&kind);
+        let is_parent = investigated.child_count() > 0;
+        let is_finished = investigated.child_by_field_name("end").is_some();
+
+        if !explicit_skip && is_parent && !is_finished {
+            return Some(investigated);
+        }
+
+        parent = investigated.parent();
+    }
+
+    None
+}
+
+pub fn previous_sibling_completed(node: tree_sitter::Node) -> bool {
+    if let Some(prev) = node.prev_sibling() {
+        let explicit_skip = SINGLE_TOKEN_RULES.contains(&prev.kind());
+        let is_parent = prev.child_count() > 0;
+        let is_finished = prev.child_by_field_name("end").is_some();
+
+        if explicit_skip || !is_parent {
+            return true;
+        }
+
+        is_finished && last_children_completed(prev)
+    } else {
+        false
+    }
+}
+
+fn last_children_completed(node: tree_sitter::Node) -> bool {
+    let mut cursor = node.walk();
+
+    if let Some(last_child) = node.children(&mut cursor).last() {
+        let explicit_skip = SINGLE_TOKEN_RULES.contains(&last_child.kind());
+        let is_parent = last_child.child_count() > 0;
+        let is_finished = last_child.child_by_field_name("end").is_some();
+
+        if explicit_skip || !is_parent {
+            return true;
+        }
+
+        is_finished && last_children_completed(last_child)
+    } else {
+        true
+    }
+}

--- a/crates/pgls_treesitter/src/lib.rs
+++ b/crates/pgls_treesitter/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod context;
+pub mod helper;
 pub mod queries;
 
 pub use context::*;
+pub use helper::*;
 pub use queries::*;


### PR DESCRIPTION
## Summary
- Adds `helper.rs` with treesitter utility functions
- Functions: `goto_node_at_position`, `goto_previous_leaf`, `goto_closest_unfinished_parent_clause`, `previous_sibling_completed`
- Extends `TreesitterContext` with `possible_keywords_at_position`, `previous_clause`, `current_clause`
- Fixes `grant_statement` mapping (was incorrectly mapped to `RevokeStatement`)

## Part of stacked PRs
This is PR 4/7 splitting #629 into smaller reviewable chunks.
Base: stack/2-grammar-improvements

## Test plan
- [x] Crate compiles
- [x] Workspace builds