### PR TITLE
[5/7] feat(test): improve test infrastructure with TestCompletionsSuite

### DIFF
--- a/crates/pgls_completions/src/test_helper.rs
+++ b/crates/pgls_completions/src/test_helper.rs
@@ -181,9 +181,10 @@ pub(crate) async fn assert_complete_results(
 
     assert!(
         items.len() >= existing.len(),
-        "Not enough items returned. Expected at least {} items, but got {}",
+        "Not enough items returned. Expected at least {} items, but got {}. query: {}",
         existing.len(),
-        items.len()
+        items.len(),
+        query
     );
 
     for item in &items {
@@ -555,7 +556,9 @@ impl TestCompletionsCase {
                 write!(writer, " - ").unwrap();
 
                 match item.kind {
-                    CompletionItemKind::Schema | CompletionItemKind::Role => {}
+                    CompletionItemKind::Schema
+                    | CompletionItemKind::Role
+                    | CompletionItemKind::Keyword => {}
                     _ => {
                         write!(writer, "{}.", item.description).unwrap();
                     }

--- a/crates/pgls_test_utils/src/bin/tree_print.rs
+++ b/crates/pgls_test_utils/src/bin/tree_print.rs
@@ -27,7 +27,7 @@ fn main() {
         .expect("Failed to parse query.");
 
     let mut result = String::new();
-    print_ts_tree(&tree.root_node(), &query, 0, &mut result);
+    print_ts_tree(&tree.root_node(), &query, &mut result);
 
     print!("{result}")
 }


### PR DESCRIPTION
## Summary
- Improves `print_ts_tree` function to show field names
- Updates `tree_print` binary to use new API
- Minor test helper improvements

## Part of stacked PRs
This is PR 5/7 splitting #629 into smaller reviewable chunks.
Base: stack/4-treesitter-helpers

## Test plan
- [x] Crates compile
- [x] `just tree-print test.sql` works