### PR TITLE
[6/7] feat(completions): add keyword completion in SELECT clauses

### DIFF
--- a/crates/pgls_completions/src/builder.rs
+++ b/crates/pgls_completions/src/builder.rs
@@ -32,10 +32,12 @@ impl<'a> CompletionBuilder<'a> {
     }
 
     pub fn finish(self) -> Vec<CompletionItem> {
+        let mut shared_tree = self.ctx.tree.clone();
+
         let mut items: Vec<PossibleCompletionItem> = self
             .items
             .into_iter()
-            .filter(|i| i.filter.is_relevant(self.ctx).is_some())
+            .filter(|i| i.filter.is_relevant(self.ctx, &mut shared_tree).is_some())
             .collect();
 
         for item in items.iter_mut() {

--- a/crates/pgls_completions/src/item.rs
+++ b/crates/pgls_completions/src/item.rs
@@ -13,6 +13,7 @@ pub enum CompletionItemKind {
     Schema,
     Policy,
     Role,
+    Keyword,
 }
 
 impl Display for CompletionItemKind {
@@ -24,6 +25,7 @@ impl Display for CompletionItemKind {
             CompletionItemKind::Schema => "Schema",
             CompletionItemKind::Policy => "Policy",
             CompletionItemKind::Role => "Role",
+            CompletionItemKind::Keyword => "Keyword",
         };
 
         write!(f, "{txt}")

--- a/crates/pgls_completions/src/providers/keywords.rs
+++ b/crates/pgls_completions/src/providers/keywords.rs
@@ -1,0 +1,836 @@
+use pgls_treesitter::TreesitterContext;
+
+use crate::{
+    CompletionItemKind, CompletionText,
+    builder::{CompletionBuilder, PossibleCompletionItem},
+    providers::helper::get_range_to_replace,
+    relevance::{CompletionRelevanceData, filtering::CompletionFilter, scoring::CompletionScore},
+};
+
+#[derive(Debug, Clone, Copy)]
+pub struct SqlKeyword {
+    pub name: &'static str,
+    pub require_prefix: bool,
+    pub starts_statement: bool,
+}
+
+impl SqlKeyword {
+    const fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            require_prefix: false,
+            starts_statement: false,
+        }
+    }
+
+    const fn require_prefix(mut self) -> Self {
+        self.require_prefix = true;
+        self
+    }
+
+    const fn starts_statement(mut self) -> Self {
+        self.starts_statement = true;
+        self
+    }
+}
+
+pub static ALL_KEYWORDS: &[SqlKeyword] = &[
+    SqlKeyword::new("action"),
+    SqlKeyword::new("add"),
+    SqlKeyword::new("admin"),
+    SqlKeyword::new("after"),
+    SqlKeyword::new("all"),
+    SqlKeyword::new("alter").starts_statement(),
+    SqlKeyword::new("always"),
+    SqlKeyword::new("analyze").starts_statement(),
+    SqlKeyword::new("and").require_prefix(),
+    SqlKeyword::new("any").require_prefix(),
+    SqlKeyword::new("array").require_prefix(),
+    SqlKeyword::new("as").require_prefix(),
+    SqlKeyword::new("asc"),
+    SqlKeyword::new("atomic"),
+    SqlKeyword::new("attribute"),
+    SqlKeyword::new("authorization"),
+    SqlKeyword::new("before"),
+    SqlKeyword::new("begin").starts_statement(),
+    SqlKeyword::new("between").require_prefix(),
+    SqlKeyword::new("bigint"),
+    SqlKeyword::new("bigserial"),
+    SqlKeyword::new("binary"),
+    SqlKeyword::new("bit"),
+    SqlKeyword::new("boolean"),
+    SqlKeyword::new("brin"),
+    SqlKeyword::new("btree"),
+    SqlKeyword::new("by"),
+    SqlKeyword::new("bytea"),
+    SqlKeyword::new("cache"),
+    SqlKeyword::new("called"),
+    SqlKeyword::new("cascade"),
+    SqlKeyword::new("cascaded"),
+    SqlKeyword::new("case"),
+    SqlKeyword::new("cast").require_prefix(),
+    SqlKeyword::new("char"),
+    SqlKeyword::new("character"),
+    SqlKeyword::new("characteristics"),
+    SqlKeyword::new("check"),
+    SqlKeyword::new("collate"),
+    SqlKeyword::new("column"),
+    SqlKeyword::new("columns"),
+    SqlKeyword::new("comment").starts_statement(),
+    SqlKeyword::new("commit").starts_statement(),
+    SqlKeyword::new("committed"),
+    SqlKeyword::new("compression"),
+    SqlKeyword::new("concurrently"),
+    SqlKeyword::new("conflict"),
+    SqlKeyword::new("connection"),
+    SqlKeyword::new("constraint"),
+    SqlKeyword::new("constraints"),
+    SqlKeyword::new("copy").starts_statement(),
+    SqlKeyword::new("cost"),
+    SqlKeyword::new("create").starts_statement(),
+    SqlKeyword::new("cross"),
+    SqlKeyword::new("csv"),
+    SqlKeyword::new("current"),
+    SqlKeyword::new("current_role"),
+    SqlKeyword::new("current_timestamp"),
+    SqlKeyword::new("current_user"),
+    SqlKeyword::new("cycle"),
+    SqlKeyword::new("data"),
+    SqlKeyword::new("database"),
+    SqlKeyword::new("date"),
+    SqlKeyword::new("decimal"),
+    SqlKeyword::new("declare").starts_statement(),
+    SqlKeyword::new("default"),
+    SqlKeyword::new("deferrable"),
+    SqlKeyword::new("deferred"),
+    SqlKeyword::new("definer"),
+    SqlKeyword::new("delete").starts_statement(),
+    SqlKeyword::new("delimiter"),
+    SqlKeyword::new("desc"),
+    SqlKeyword::new("disable_page_skipping"),
+    SqlKeyword::new("distinct"),
+    SqlKeyword::new("do").starts_statement(),
+    SqlKeyword::new("double"),
+    SqlKeyword::new("drop").starts_statement(),
+    SqlKeyword::new("each"),
+    SqlKeyword::new("else"),
+    SqlKeyword::new("encoding"),
+    SqlKeyword::new("encrypted"),
+    SqlKeyword::new("end"),
+    SqlKeyword::new("enum"),
+    SqlKeyword::new("escape"),
+    SqlKeyword::new("except"),
+    SqlKeyword::new("exclude"),
+    SqlKeyword::new("execute"),
+    SqlKeyword::new("exists").require_prefix(),
+    SqlKeyword::new("explain").starts_statement(),
+    SqlKeyword::new("extended"),
+    SqlKeyword::new("extension"),
+    SqlKeyword::new("external"),
+    SqlKeyword::new("false").require_prefix(),
+    SqlKeyword::new("filter"),
+    SqlKeyword::new("first"),
+    SqlKeyword::new("float"),
+    SqlKeyword::new("following"),
+    SqlKeyword::new("for"),
+    SqlKeyword::new("force"),
+    SqlKeyword::new("force_not_null"),
+    SqlKeyword::new("force_null"),
+    SqlKeyword::new("force_quote"),
+    SqlKeyword::new("foreign"),
+    SqlKeyword::new("format"),
+    SqlKeyword::new("freeze"),
+    SqlKeyword::new("from"),
+    SqlKeyword::new("full"),
+    SqlKeyword::new("function"),
+    SqlKeyword::new("functions"),
+    SqlKeyword::new("generated"),
+    SqlKeyword::new("gin"),
+    SqlKeyword::new("gist"),
+    SqlKeyword::new("grant").starts_statement(),
+    SqlKeyword::new("granted"),
+    SqlKeyword::new("group"),
+    SqlKeyword::new("groups"),
+    SqlKeyword::new("hash"),
+    SqlKeyword::new("having"),
+    SqlKeyword::new("header"),
+    SqlKeyword::new("if"),
+    SqlKeyword::new("immediate"),
+    SqlKeyword::new("immutable"),
+    SqlKeyword::new("in").require_prefix(),
+    SqlKeyword::new("increment"),
+    SqlKeyword::new("index"),
+    SqlKeyword::new("index_cleanup"),
+    SqlKeyword::new("inet"),
+    SqlKeyword::new("inherit"),
+    SqlKeyword::new("initially"),
+    SqlKeyword::new("inner"),
+    SqlKeyword::new("inout"),
+    SqlKeyword::new("input"),
+    SqlKeyword::new("insert").starts_statement(),
+    SqlKeyword::new("instead"),
+    SqlKeyword::new("int"),
+    SqlKeyword::new("intersect"),
+    SqlKeyword::new("interval").require_prefix(),
+    SqlKeyword::new("into"),
+    SqlKeyword::new("invoker"),
+    SqlKeyword::new("is"),
+    SqlKeyword::new("isolation"),
+    SqlKeyword::new("join"),
+    SqlKeyword::new("json"),
+    SqlKeyword::new("jsonb"),
+    SqlKeyword::new("key"),
+    SqlKeyword::new("language"),
+    SqlKeyword::new("last"),
+    SqlKeyword::new("lateral"),
+    SqlKeyword::new("leakproof"),
+    SqlKeyword::new("left"),
+    SqlKeyword::new("level"),
+    SqlKeyword::new("like").require_prefix(),
+    SqlKeyword::new("limit"),
+    SqlKeyword::new("list"),
+    SqlKeyword::new("local"),
+    SqlKeyword::new("location"),
+    SqlKeyword::new("logged"),
+    SqlKeyword::new("main"),
+    SqlKeyword::new("maintain"),
+    SqlKeyword::new("match"),
+    SqlKeyword::new("matched"),
+    SqlKeyword::new("materialized"),
+    SqlKeyword::new("maxvalue"),
+    SqlKeyword::new("merge").starts_statement(),
+    SqlKeyword::new("minvalue"),
+    SqlKeyword::new("money"),
+    SqlKeyword::new("name"),
+    SqlKeyword::new("names"),
+    SqlKeyword::new("natural"),
+    SqlKeyword::new("new"),
+    SqlKeyword::new("no"),
+    SqlKeyword::new("none"),
+    SqlKeyword::new("not").require_prefix(),
+    SqlKeyword::new("nothing"),
+    SqlKeyword::new("nowait"),
+    SqlKeyword::new("null").require_prefix(),
+    SqlKeyword::new("nulls"),
+    SqlKeyword::new("numeric"),
+    SqlKeyword::new("of"),
+    SqlKeyword::new("off"),
+    SqlKeyword::new("offset"),
+    SqlKeyword::new("oid"),
+    SqlKeyword::new("oids"),
+    SqlKeyword::new("old"),
+    SqlKeyword::new("on"),
+    SqlKeyword::new("only").require_prefix(),
+    SqlKeyword::new("option"),
+    SqlKeyword::new("or").require_prefix(),
+    SqlKeyword::new("order"),
+    SqlKeyword::new("ordinality"),
+    SqlKeyword::new("others"),
+    SqlKeyword::new("out"),
+    SqlKeyword::new("outer"),
+    SqlKeyword::new("over"),
+    SqlKeyword::new("overriding"),
+    SqlKeyword::new("owned"),
+    SqlKeyword::new("owner"),
+    SqlKeyword::new("parallel"),
+    SqlKeyword::new("partition"),
+    SqlKeyword::new("partitioned"),
+    SqlKeyword::new("password"),
+    SqlKeyword::new("permissive"),
+    SqlKeyword::new("plain"),
+    SqlKeyword::new("policy"),
+    SqlKeyword::new("precedes"),
+    SqlKeyword::new("preceding"),
+    SqlKeyword::new("precision"),
+    SqlKeyword::new("primary"),
+    SqlKeyword::new("privileges"),
+    SqlKeyword::new("procedure"),
+    SqlKeyword::new("procedures"),
+    SqlKeyword::new("process_toast"),
+    SqlKeyword::new("program"),
+    SqlKeyword::new("public"),
+    SqlKeyword::new("quote"),
+    SqlKeyword::new("range"),
+    SqlKeyword::new("read"),
+    SqlKeyword::new("real"),
+    SqlKeyword::new("recursive"),
+    SqlKeyword::new("references"),
+    SqlKeyword::new("referencing"),
+    SqlKeyword::new("regclass"),
+    SqlKeyword::new("regnamespace"),
+    SqlKeyword::new("regproc"),
+    SqlKeyword::new("regtype"),
+    SqlKeyword::new("rename"),
+    SqlKeyword::new("repeatable"),
+    SqlKeyword::new("replace"),
+    SqlKeyword::new("replication"),
+    SqlKeyword::new("reset").starts_statement(),
+    SqlKeyword::new("restart"),
+    SqlKeyword::new("restrict"),
+    SqlKeyword::new("restricted"),
+    SqlKeyword::new("restrictive"),
+    SqlKeyword::new("return"),
+    SqlKeyword::new("returning"),
+    SqlKeyword::new("returns"),
+    SqlKeyword::new("revoke").starts_statement(),
+    SqlKeyword::new("rewrite"),
+    SqlKeyword::new("right"),
+    SqlKeyword::new("role"),
+    SqlKeyword::new("rollback").starts_statement(),
+    SqlKeyword::new("routine"),
+    SqlKeyword::new("routines"),
+    SqlKeyword::new("row"),
+    SqlKeyword::new("rows"),
+    SqlKeyword::new("safe"),
+    SqlKeyword::new("schema"),
+    SqlKeyword::new("security"),
+    SqlKeyword::new("select").starts_statement(),
+    SqlKeyword::new("sequence"),
+    SqlKeyword::new("serial"),
+    SqlKeyword::new("serializable"),
+    SqlKeyword::new("session"),
+    SqlKeyword::new("session_user"),
+    SqlKeyword::new("set").starts_statement(),
+    SqlKeyword::new("setof"),
+    SqlKeyword::new("show").starts_statement(),
+    SqlKeyword::new("similar").require_prefix(),
+    SqlKeyword::new("skip_locked"),
+    SqlKeyword::new("smallint"),
+    SqlKeyword::new("smallserial"),
+    SqlKeyword::new("snapshot"),
+    SqlKeyword::new("some"),
+    SqlKeyword::new("spgist"),
+    SqlKeyword::new("stable"),
+    SqlKeyword::new("start"),
+    SqlKeyword::new("statement"),
+    SqlKeyword::new("statistics"),
+    SqlKeyword::new("stdin"),
+    SqlKeyword::new("storage"),
+    SqlKeyword::new("stored"),
+    SqlKeyword::new("strict"),
+    SqlKeyword::new("support"),
+    SqlKeyword::new("system"),
+    SqlKeyword::new("table"),
+    SqlKeyword::new("tables"),
+    SqlKeyword::new("tablespace"),
+    SqlKeyword::new("temp"),
+    SqlKeyword::new("temporary"),
+    SqlKeyword::new("text"),
+    SqlKeyword::new("then").require_prefix(),
+    SqlKeyword::new("ties"),
+    SqlKeyword::new("time"),
+    SqlKeyword::new("timestamp"),
+    SqlKeyword::new("timestamptz"),
+    SqlKeyword::new("to"),
+    SqlKeyword::new("transaction"),
+    SqlKeyword::new("trigger"),
+    SqlKeyword::new("true").require_prefix(),
+    SqlKeyword::new("truncate").starts_statement(),
+    SqlKeyword::new("type"),
+    SqlKeyword::new("unbounded"),
+    SqlKeyword::new("uncommitted"),
+    SqlKeyword::new("union"),
+    SqlKeyword::new("unique"),
+    SqlKeyword::new("unlogged"),
+    SqlKeyword::new("unsafe"),
+    SqlKeyword::new("until"),
+    SqlKeyword::new("update").starts_statement(),
+    SqlKeyword::new("user"),
+    SqlKeyword::new("using"),
+    SqlKeyword::new("uuid"),
+    SqlKeyword::new("vacuum").starts_statement(),
+    SqlKeyword::new("valid"),
+    SqlKeyword::new("value"),
+    SqlKeyword::new("values"),
+    SqlKeyword::new("varchar"),
+    SqlKeyword::new("variadic"),
+    SqlKeyword::new("varying"),
+    SqlKeyword::new("verbose"),
+    SqlKeyword::new("version"),
+    SqlKeyword::new("view"),
+    SqlKeyword::new("volatile"),
+    SqlKeyword::new("when"),
+    SqlKeyword::new("where"),
+    SqlKeyword::new("window"),
+    SqlKeyword::new("with").starts_statement(),
+    SqlKeyword::new("without"),
+    SqlKeyword::new("write"),
+    SqlKeyword::new("xml"),
+    SqlKeyword::new("zone"),
+];
+
+pub fn complete_keywords<'a>(
+    ctx: &TreesitterContext<'a>,
+    builder: &mut CompletionBuilder<'a>,
+    use_upper_case: bool,
+) {
+    // no keyword completions if we start with a quote
+    if ctx
+        .get_node_under_cursor_content()
+        .is_some_and(|n| n.starts_with('"'))
+    {
+        return;
+    }
+
+    let keywords_to_try = ALL_KEYWORDS.iter().filter(|kw| {
+        ctx.tree.root_node().has_error() || ctx.possible_keywords_at_position.contains(&kw.name)
+    });
+
+    for kw in keywords_to_try {
+        let relevance = CompletionRelevanceData::Keyword(kw);
+
+        let label = if use_upper_case {
+            kw.name.to_ascii_uppercase()
+        } else {
+            kw.name.to_string()
+        };
+
+        let item = PossibleCompletionItem {
+            label: label.clone(),
+            score: CompletionScore::from(relevance.clone()),
+            filter: CompletionFilter::from(relevance),
+            description: "".into(),
+            kind: CompletionItemKind::Keyword,
+            completion_text: Some(CompletionText {
+                text: label,
+                range: get_range_to_replace(ctx),
+                is_snippet: false,
+            }),
+            detail: None,
+        };
+
+        builder.add_item(item);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pgls_test_utils::QueryWithCursorPosition;
+    use sqlx::PgPool;
+
+    use crate::{
+        CompletionItemKind,
+        test_helper::{
+            CompletionAssertion, TestCompletionsCase, TestCompletionsSuite,
+            assert_complete_results, assert_no_complete_results,
+        },
+    };
+
+    #[sqlx::test]
+    async fn completes_stmt_start_keywords(pool: PgPool) {
+        let setup = r#"
+            create table public.users (
+                id serial primary key,
+                email varchar(255)
+            );
+        "#;
+
+        let query = format!("{}", QueryWithCursorPosition::cursor_marker());
+
+        assert_complete_results(
+            query.as_str(),
+            vec![
+                CompletionAssertion::LabelAndKind(
+                    "insert".into(),
+                    crate::CompletionItemKind::Keyword,
+                ),
+                CompletionAssertion::LabelAndKind(
+                    "reset".into(),
+                    crate::CompletionItemKind::Keyword,
+                ),
+                CompletionAssertion::LabelAndKind(
+                    "select".into(),
+                    crate::CompletionItemKind::Keyword,
+                ),
+                CompletionAssertion::LabelAndKind("set".into(), crate::CompletionItemKind::Keyword),
+                CompletionAssertion::LabelAndKind(
+                    "truncate".into(),
+                    crate::CompletionItemKind::Keyword,
+                ),
+                CompletionAssertion::LabelAndKind(
+                    "update".into(),
+                    crate::CompletionItemKind::Keyword,
+                ),
+            ],
+            Some(setup),
+            &pool,
+        )
+        .await;
+    }
+
+    #[sqlx::test]
+    async fn completes_keywords(pool: PgPool) {
+        let setup = r#"
+            create table public.users (
+                id serial primary key,
+                email varchar(255)
+            );
+        "#;
+
+        let query = format!("s{}", QueryWithCursorPosition::cursor_marker());
+
+        assert_complete_results(
+            query.as_str(),
+            vec![
+                CompletionAssertion::LabelAndKind(
+                    "select".into(),
+                    crate::CompletionItemKind::Keyword,
+                ),
+                CompletionAssertion::LabelAndKind("set".into(), crate::CompletionItemKind::Keyword),
+                CompletionAssertion::LabelAndKind(
+                    "insert".into(),
+                    crate::CompletionItemKind::Keyword,
+                ),
+                CompletionAssertion::LabelAndKind(
+                    "reset".into(),
+                    crate::CompletionItemKind::Keyword,
+                ),
+            ],
+            Some(setup),
+            &pool,
+        )
+        .await;
+    }
+
+    #[sqlx::test]
+    async fn does_not_complete_from_after_select(pool: PgPool) {
+        let setup = r#"
+            create table public.users (
+                id serial primary key,
+                email varchar(255)
+            );
+        "#;
+
+        let query = format!("select f{}", QueryWithCursorPosition::cursor_marker());
+
+        assert_complete_results(
+            query.as_str(),
+            vec![CompletionAssertion::LabelNotExists("from".into())], // keyword `false` is fine
+            Some(setup),
+            &pool,
+        )
+        .await;
+    }
+
+    #[sqlx::test]
+    async fn completes_columns_after_select(pool: PgPool) {
+        let setup = r#"
+            create table public.users (
+                id serial primary key,
+                email varchar(255)
+            );
+        "#;
+
+        let query = format!("select {}", QueryWithCursorPosition::cursor_marker());
+
+        assert_complete_results(
+            query.as_str(),
+            vec![CompletionAssertion::KindNotExists(
+                CompletionItemKind::Keyword,
+            )],
+            Some(setup),
+            &pool,
+        )
+        .await;
+    }
+
+    #[sqlx::test]
+    async fn completes_after_from_clause(pool: PgPool) {
+        let setup = r#"
+            create table public.users (
+                id serial primary key,
+                email varchar(255)
+            );
+        "#;
+
+        TestCompletionsSuite::new(&pool, Some(setup))
+            .with_case(
+                TestCompletionsCase::new()
+                    .inside_static_statement("select email from users <sql>")
+                    .type_sql("where id = 1;"),
+            )
+            .snapshot("after_from_clause")
+            .await;
+    }
+
+    #[sqlx::test]
+    async fn stays_within_order_clause(pool: PgPool) {
+        let setup = r#"
+            create table public.users (
+                id serial primary key,
+                email varchar(255)
+            );
+        "#;
+
+        let query = format!(
+            "select * from public.users order {}",
+            QueryWithCursorPosition::cursor_marker()
+        );
+
+        assert_complete_results(
+            query.as_str(),
+            vec![CompletionAssertion::LabelAndKind(
+                "by".into(),
+                crate::CompletionItemKind::Keyword,
+            )],
+            Some(setup),
+            &pool,
+        )
+        .await;
+    }
+
+    #[sqlx::test]
+    async fn only_allows_identifier_in_alias_clause(pool: PgPool) {
+        let setup = r#"
+            create table public.users (
+                id serial primary key,
+                email varchar(255)
+            );
+        "#;
+
+        let query = format!(
+            "select * from public.users as {}",
+            QueryWithCursorPosition::cursor_marker()
+        );
+
+        assert_no_complete_results(query.as_str(), Some(setup), &pool).await;
+    }
+
+    #[sqlx::test]
+    async fn completes_from_keyword(pool: PgPool) {
+        let setup = r#"
+            create table public.users (
+                id serial primary key,
+                email varchar(255)
+            );
+        "#;
+
+        let query = format!("select * f{}", QueryWithCursorPosition::cursor_marker());
+
+        assert_complete_results(
+            query.as_str(),
+            vec![CompletionAssertion::LabelAndKind(
+                "from".into(),
+                crate::CompletionItemKind::Keyword,
+            )],
+            Some(setup),
+            &pool,
+        )
+        .await;
+    }
+
+    #[sqlx::test]
+    async fn completes_from_keyword_after_aliases(pool: PgPool) {
+        let setup = r#"
+            create table public.users (
+                id serial primary key,
+                email varchar(255)
+            );
+        "#;
+
+        let query = format!(
+            "select email as em {}",
+            QueryWithCursorPosition::cursor_marker()
+        );
+
+        assert_complete_results(
+            query.as_str(),
+            vec![CompletionAssertion::LabelAndKind(
+                "from".into(),
+                crate::CompletionItemKind::Keyword,
+            )],
+            Some(setup),
+            &pool,
+        )
+        .await;
+    }
+
+    #[sqlx::test]
+    async fn adds_where_after_clause(pool: PgPool) {
+        let query = format!(
+            "select * from public.users us left join client_settings as cs on us.id = cs.client_id whe{}",
+            QueryWithCursorPosition::cursor_marker()
+        );
+
+        assert_complete_results(
+            query.as_str(),
+            vec![CompletionAssertion::LabelAndKind(
+                "where".into(),
+                crate::CompletionItemKind::Keyword,
+            )],
+            None,
+            &pool,
+        )
+        .await;
+    }
+
+    #[sqlx::test]
+    async fn completes_keywords_after_column_aliases(pool: PgPool) {
+        let setup = r#"
+            create table public.users (
+                id serial primary key,
+                email varchar(255)
+            );
+        "#;
+
+        let query = format!(
+            "select email from public.users als (id, email) {}",
+            QueryWithCursorPosition::cursor_marker()
+        );
+
+        assert_complete_results(
+            query.as_str(),
+            vec![
+                CompletionAssertion::LabelAndKind(
+                    "cross".into(),
+                    crate::CompletionItemKind::Keyword,
+                ),
+                CompletionAssertion::LabelAndKind(
+                    "full".into(),
+                    crate::CompletionItemKind::Keyword,
+                ),
+                CompletionAssertion::LabelAndKind(
+                    "group".into(),
+                    crate::CompletionItemKind::Keyword,
+                ),
+                CompletionAssertion::LabelAndKind(
+                    "inner".into(),
+                    crate::CompletionItemKind::Keyword,
+                ),
+                CompletionAssertion::LabelAndKind(
+                    "join".into(),
+                    crate::CompletionItemKind::Keyword,
+                ),
+                CompletionAssertion::LabelAndKind(
+                    "left".into(),
+                    crate::CompletionItemKind::Keyword,
+                ),
+                CompletionAssertion::LabelAndKind(
+                    "limit".into(),
+                    crate::CompletionItemKind::Keyword,
+                ),
+                CompletionAssertion::LabelAndKind(
+                    "natural".into(),
+                    crate::CompletionItemKind::Keyword,
+                ),
+                CompletionAssertion::LabelAndKind(
+                    "order".into(),
+                    crate::CompletionItemKind::Keyword,
+                ),
+            ],
+            Some(setup),
+            &pool,
+        )
+        .await;
+    }
+
+    #[sqlx::test]
+    async fn completes_join_kw(pool: PgPool) {
+        let setup = r#"
+            create table public.users (
+                id serial primary key,
+                email varchar(255)
+            );
+        "#;
+
+        let query = format!(
+            "select * from public.users left {}",
+            QueryWithCursorPosition::cursor_marker()
+        );
+
+        assert_complete_results(
+            query.as_str(),
+            vec![
+                CompletionAssertion::LabelAndKind(
+                    "join".into(),
+                    crate::CompletionItemKind::Keyword,
+                ),
+                CompletionAssertion::LabelAndKind(
+                    "outer".into(),
+                    crate::CompletionItemKind::Keyword,
+                ),
+            ],
+            Some(setup),
+            &pool,
+        )
+        .await;
+    }
+
+    #[sqlx::test]
+    async fn stays_in_joins(pool: PgPool) {
+        let setup = r#"
+            create table public.users (
+                id serial primary key,
+                email varchar(255)
+            );
+        "#;
+
+        let query = format!(
+            "select * from public.users u join public.something s {}",
+            QueryWithCursorPosition::cursor_marker()
+        );
+
+        assert_complete_results(
+            query.as_str(),
+            vec![CompletionAssertion::LabelNotExists("join".into())],
+            Some(setup),
+            &pool,
+        )
+        .await;
+    }
+
+    #[sqlx::test]
+    async fn completes_join_after_alias(pool: PgPool) {
+        let setup = r#"
+            create table public.users (
+                id serial primary key,
+                email varchar(255)
+            );
+        "#;
+
+        let query = format!(
+            "select * from public.users u {}",
+            QueryWithCursorPosition::cursor_marker()
+        );
+
+        assert_complete_results(
+            query.as_str(),
+            vec![
+                CompletionAssertion::LabelAndKind("cross".into(), CompletionItemKind::Keyword),
+                CompletionAssertion::LabelAndKind("full".into(), CompletionItemKind::Keyword),
+                CompletionAssertion::LabelAndKind("group".into(), CompletionItemKind::Keyword),
+                CompletionAssertion::LabelAndKind("inner".into(), CompletionItemKind::Keyword),
+                CompletionAssertion::LabelAndKind("join".into(), CompletionItemKind::Keyword),
+            ],
+            Some(setup),
+            &pool,
+        )
+        .await;
+    }
+
+    #[sqlx::test]
+    async fn allows_starting_new_select_stmt(pool: PgPool) {
+        let setup = r#"
+            create table public.users (
+                id serial primary key,
+                email varchar(255)
+            );
+        "#;
+
+        let query = format!(
+            "select * from public.users u; sel{}",
+            QueryWithCursorPosition::cursor_marker()
+        );
+
+        assert_complete_results(
+            query.as_str(),
+            vec![CompletionAssertion::LabelAndKind(
+                "select".into(),
+                CompletionItemKind::Keyword,
+            )],
+            Some(setup),
+            &pool,
+        )
+        .await;
+    }
+}

--- a/crates/pgls_completions/src/providers/mod.rs
+++ b/crates/pgls_completions/src/providers/mod.rs
@@ -1,6 +1,7 @@
 mod columns;
 mod functions;
 mod helper;
+mod keywords;
 mod policies;
 mod roles;
 mod schemas;
@@ -8,6 +9,7 @@ mod tables;
 
 pub use columns::*;
 pub use functions::*;
+pub use keywords::*;
 pub use policies::*;
 pub use roles::*;
 pub use schemas::*;

--- a/crates/pgls_completions/src/relevance.rs
+++ b/crates/pgls_completions/src/relevance.rs
@@ -1,6 +1,8 @@
 pub(crate) mod filtering;
 pub(crate) mod scoring;
 
+use crate::providers::SqlKeyword;
+
 #[derive(Debug, Clone)]
 pub(crate) enum CompletionRelevanceData<'a> {
     Table(&'a pgls_schema_cache::Table),
@@ -9,4 +11,5 @@ pub(crate) enum CompletionRelevanceData<'a> {
     Schema(&'a pgls_schema_cache::Schema),
     Policy(&'a pgls_schema_cache::Policy),
     Role(&'a pgls_schema_cache::Role),
+    Keyword(&'static SqlKeyword),
 }

--- a/crates/pgls_completions/src/sanitization.rs
+++ b/crates/pgls_completions/src/sanitization.rs
@@ -124,6 +124,7 @@ where
             tree: Cow::Owned(tree),
         }
     }
+
     fn unadjusted(params: CompletionParams<'larger>) -> Self {
         Self {
             position: params.position,
@@ -146,7 +147,7 @@ fn cursor_inbetween_nodes(sql: &str, position: TextSize) -> bool {
     let mut chars = sql.chars();
 
     let previous_whitespace = chars
-        .nth(position - 1)
+        .nth(position.saturating_sub(1))
         .is_some_and(|c| c.is_ascii_whitespace());
 
     let current_whitespace = chars.next().is_some_and(|c| c.is_ascii_whitespace());
@@ -169,7 +170,9 @@ fn cursor_prepared_to_write_token_after_last_node(sql: &str, position: TextSize)
 
 fn cursor_on_a_dot(sql: &str, position: TextSize) -> bool {
     let position: usize = position.into();
-    sql.chars().nth(position - 1).is_some_and(|c| c == '.')
+    sql.chars()
+        .nth(position.saturating_sub(1))
+        .is_some_and(|c| c == '.')
 }
 
 fn cursor_before_semicolon(tree: &tree_sitter::Tree, position: TextSize) -> bool {
@@ -244,7 +247,11 @@ fn cursor_between_parentheses(sql: &str, position: TextSize) -> bool {
     // early check: '(|)'
     // however, we want to check this after the level nesting.
     let mut chars = sql.chars();
-    if chars.nth(position - 1).is_some_and(|c| c == '(') && chars.next().is_some_and(|c| c == ')') {
+    if chars
+        .nth(position.saturating_sub(1))
+        .is_some_and(|c| c == '(')
+        && chars.next().is_some_and(|c| c == ')')
+    {
         return true;
     }
 

--- a/crates/pgls_lsp/src/handlers/completions.rs
+++ b/crates/pgls_lsp/src/handlers/completions.rs
@@ -79,5 +79,6 @@ fn to_lsp_types_completion_item_kind(
         pgls_completions::CompletionItemKind::Schema => lsp_types::CompletionItemKind::CLASS,
         pgls_completions::CompletionItemKind::Policy => lsp_types::CompletionItemKind::CONSTANT,
         pgls_completions::CompletionItemKind::Role => lsp_types::CompletionItemKind::CONSTANT,
+        pgls_completions::CompletionItemKind::Keyword => lsp_types::CompletionItemKind::KEYWORD,
     }
 }


### PR DESCRIPTION
## Summary
Core implementation of keyword completion for SQL statements.

### New features
- `keywords.rs`: Keyword provider with 300+ SQL keywords
- Keywords marked with `require_prefix` (like `and`, `as`, `like`) only appear after user starts typing
- Keywords marked with `starts_statement` (like `select`, `insert`) only appear at statement start
- Speculative parsing validates keywords produce valid SQL at cursor position

### Changes to existing code
- `filtering.rs`: Uses incremental parsing to validate keyword placement
- `scoring.rs`: Adds keyword scoring
- `complete.rs`: Integrates keyword provider into completion flow
- `completions.rs` (LSP handler): Passes mutable tree for incremental parsing

## Part of stacked PRs
This is PR 6/7 splitting #629 into smaller reviewable chunks.
Base: stack/5-test-infrastructure

## Test plan
- [x] Compiles
- [ ] Tests (to be updated in PR 7)