### PR TITLE
fix(formatter): add proper newlines for function bodies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ biome-main/
 .review/
 pglinter_repo/
 .review/
+.opencode-session-id

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "postgres_lsp",

--- a/crates/pgls_pretty_print/src/nodes/string.rs
+++ b/crates/pgls_pretty_print/src/nodes/string.rs
@@ -2,7 +2,7 @@ use pgls_query::protobuf::String as PgString;
 
 use crate::{
     TokenKind,
-    emitter::{EventEmitter, GroupKind},
+    emitter::{EventEmitter, GroupKind, LineType},
 };
 
 const RESERVED_KEYWORDS: &[&str] = &[
@@ -160,9 +160,15 @@ pub(super) fn emit_dollar_quoted_str_with_hint(
     hint: DollarQuoteHint,
 ) {
     let delimiter = pick_dollar_delimiter(value, hint);
-    e.token(TokenKind::DOLLAR_QUOTED_STRING(format!(
-        "{delimiter}{value}{delimiter}"
-    )));
+    // Trim leading/trailing whitespace from the body for cleaner formatting,
+    // then emit: delimiter, newline, body, newline, delimiter
+    // This puts the function body on its own lines for readability
+    let trimmed_body = value.trim();
+    e.token(TokenKind::DOLLAR_QUOTE_DELIMITER(delimiter.clone()));
+    e.line(LineType::Hard);
+    e.token(TokenKind::DOLLAR_QUOTE_BODY(trimmed_body.to_string()));
+    e.line(LineType::Hard);
+    e.token(TokenKind::DOLLAR_QUOTE_DELIMITER(delimiter));
 }
 
 fn needs_quoting(value: &str) -> bool {

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__aggregates_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__aggregates_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/aggregates.sql
-snapshot_kind: text
 ---
 set extra_float_digits = 0;
 
@@ -1978,7 +1977,8 @@ BEGIN
        RAISE 'erroneously called with NULL argument';
     END IF;
     RETURN NULL;
-END$function$;
+END
+$function$;
 
 create aggregate balk (
   int
@@ -2145,7 +2145,8 @@ BEGIN
        RAISE 'erroneously called with NULL argument';
     END IF;
     RETURN NULL;
-END$function$;
+END
+$function$;
 
 create aggregate balk (
   int

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__aggregates_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__aggregates_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/aggregates.sql
-snapshot_kind: text
 ---
 set extra_float_digits = 0;
 
@@ -2380,7 +2379,8 @@ BEGIN
        RAISE 'erroneously called with NULL argument';
     END IF;
     RETURN NULL;
-END$function$;
+END
+$function$;
 
 create aggregate balk (
   int
@@ -2567,7 +2567,8 @@ BEGIN
        RAISE 'erroneously called with NULL argument';
     END IF;
     RETURN NULL;
-END$function$;
+END
+$function$;
 
 create aggregate balk (
   int

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__alter_generic_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__alter_generic_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/alter_generic.sql
-snapshot_kind: text
 ---
 create function test_opclass_options_func(internal)
 returns void
@@ -37,12 +36,16 @@ set session authorization regress_alter_generic_user1;
 create function alt_func1(int)
 returns int
 language sql
-as $function$SELECT $1 + 1$function$;
+as $function$
+SELECT $1 + 1
+$function$;
 
 create function alt_func2(int)
 returns int
 language sql
-as $function$SELECT $1 - 1$function$;
+as $function$
+SELECT $1 - 1
+$function$;
 
 create aggregate alt_agg1 (sfunc1 = int4pl, basetype = int, stype1 = int, initcond = 0);
 
@@ -81,12 +84,16 @@ set session authorization regress_alter_generic_user2;
 create function alt_func1(int)
 returns int
 language sql
-as $function$SELECT $1 + 2$function$;
+as $function$
+SELECT $1 + 2
+$function$;
 
 create function alt_func2(int)
 returns int
 language sql
-as $function$SELECT $1 - 2$function$;
+as $function$
+SELECT $1 - 2
+$function$;
 
 create aggregate alt_agg1 (sfunc1 = int4pl, basetype = int, stype1 = int, initcond = 100);
 
@@ -519,7 +526,9 @@ create operator family alt_opf12 using btree;
 
 create function fn_opf12(int, smallint)
 returns bigint
-as $function$SELECT NULL::BIGINT;$function$
+as $function$
+SELECT NULL::BIGINT;
+$function$
 language sql;
 
 alter operator family alt_opf12 using btree add function 1 fn_opf12(int, smallint);
@@ -534,7 +543,9 @@ create operator family alt_opf13 using hash;
 
 create function fn_opf13(int)
 returns bigint
-as $function$SELECT NULL::BIGINT;$function$
+as $function$
+SELECT NULL::BIGINT;
+$function$
 language sql;
 
 alter operator family alt_opf13 using hash add function 1 fn_opf13(int);
@@ -549,7 +560,9 @@ create operator family alt_opf14 using btree;
 
 create function fn_opf14(int)
 returns bigint
-as $function$SELECT NULL::BIGINT;$function$
+as $function$
+SELECT NULL::BIGINT;
+$function$
 language sql;
 
 alter operator family alt_opf14 using btree add function 1 fn_opf14(int);
@@ -564,7 +577,9 @@ create operator family alt_opf15 using hash;
 
 create function fn_opf15(int, smallint)
 returns bigint
-as $function$SELECT NULL::BIGINT;$function$
+as $function$
+SELECT NULL::BIGINT;
+$function$
 language sql;
 
 alter operator family alt_opf15 using hash add function 1 fn_opf15(int, smallint);

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__alter_generic_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__alter_generic_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/alter_generic.sql
-snapshot_kind: text
 ---
 create function test_opclass_options_func(internal)
 returns void
@@ -37,12 +36,16 @@ set session authorization regress_alter_generic_user1;
 create function alt_func1(int)
 returns int
 language sql
-as $function$SELECT $1 + 1$function$;
+as $function$
+SELECT $1 + 1
+$function$;
 
 create function alt_func2(int)
 returns int
 language sql
-as $function$SELECT $1 - 1$function$;
+as $function$
+SELECT $1 - 1
+$function$;
 
 create aggregate alt_agg1 (
   sfunc1 = int4pl,
@@ -91,12 +94,16 @@ set session authorization regress_alter_generic_user2;
 create function alt_func1(int)
 returns int
 language sql
-as $function$SELECT $1 + 2$function$;
+as $function$
+SELECT $1 + 2
+$function$;
 
 create function alt_func2(int)
 returns int
 language sql
-as $function$SELECT $1 - 2$function$;
+as $function$
+SELECT $1 - 2
+$function$;
 
 create aggregate alt_agg1 (
   sfunc1 = int4pl,
@@ -548,7 +555,9 @@ create operator family alt_opf12 using btree;
 
 create function fn_opf12(int, smallint)
 returns bigint
-as $function$SELECT NULL::BIGINT;$function$
+as $function$
+SELECT NULL::BIGINT;
+$function$
 language sql;
 
 alter operator family alt_opf12 using btree
@@ -564,7 +573,9 @@ create operator family alt_opf13 using hash;
 
 create function fn_opf13(int)
 returns bigint
-as $function$SELECT NULL::BIGINT;$function$
+as $function$
+SELECT NULL::BIGINT;
+$function$
 language sql;
 
 alter operator family alt_opf13 using hash add function 1 fn_opf13(int);
@@ -579,7 +590,9 @@ create operator family alt_opf14 using btree;
 
 create function fn_opf14(int)
 returns bigint
-as $function$SELECT NULL::BIGINT;$function$
+as $function$
+SELECT NULL::BIGINT;
+$function$
 language sql;
 
 alter operator family alt_opf14 using btree add function 1 fn_opf14(int);
@@ -594,7 +607,9 @@ create operator family alt_opf15 using hash;
 
 create function fn_opf15(int, smallint)
 returns bigint
-as $function$SELECT NULL::BIGINT;$function$
+as $function$
+SELECT NULL::BIGINT;
+$function$
 language sql;
 
 alter operator family alt_opf15 using hash

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__alter_operator_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__alter_operator_100.snap
@@ -1,17 +1,20 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/alter_operator.sql
-snapshot_kind: text
 ---
 create function alter_op_test_fn(boolean, boolean)
 returns boolean
-as $function$ SELECT NULL::BOOLEAN; $function$
+as $function$
+SELECT NULL::BOOLEAN;
+$function$
 language sql
 immutable;
 
 create function customcontsel(internal, oid, internal, int)
 returns double precision
-as $function$contsel$function$
+as $function$
+contsel
+$function$
 language internal
 stable
 strict;
@@ -169,13 +172,17 @@ reset session_authorization;
 
 create function alter_op_test_fn_bool_real(boolean, real)
 returns boolean
-as $function$ SELECT NULL::BOOLEAN; $function$
+as $function$
+SELECT NULL::BOOLEAN;
+$function$
 language sql
 immutable;
 
 create function alter_op_test_fn_real_bool(real, boolean)
 returns boolean
-as $function$ SELECT NULL::BOOLEAN; $function$
+as $function$
+SELECT NULL::BOOLEAN;
+$function$
 language sql
 immutable;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__alter_operator_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__alter_operator_80.snap
@@ -1,17 +1,20 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/alter_operator.sql
-snapshot_kind: text
 ---
 create function alter_op_test_fn(boolean, boolean)
 returns boolean
-as $function$ SELECT NULL::BOOLEAN; $function$
+as $function$
+SELECT NULL::BOOLEAN;
+$function$
 language sql
 immutable;
 
 create function customcontsel(internal, oid, internal, int)
 returns double precision
-as $function$contsel$function$
+as $function$
+contsel
+$function$
 language internal
 stable
 strict;
@@ -185,13 +188,17 @@ reset session_authorization;
 
 create function alter_op_test_fn_bool_real(boolean, real)
 returns boolean
-as $function$ SELECT NULL::BOOLEAN; $function$
+as $function$
+SELECT NULL::BOOLEAN;
+$function$
 language sql
 immutable;
 
 create function alter_op_test_fn_real_bool(real, boolean)
 returns boolean
-as $function$ SELECT NULL::BOOLEAN; $function$
+as $function$
+SELECT NULL::BOOLEAN;
+$function$
 language sql
 immutable;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__alter_table_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__alter_table_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/alter_table.sql
-snapshot_kind: text
 ---
 set client_min_messages = warning;
 
@@ -687,7 +686,9 @@ returns int
 immutable
 strict
 language plpgsql
-as $function$ BEGIN RAISE NOTICE 'boo: %', $1; RETURN $1; END; $function$;
+as $function$
+BEGIN RAISE NOTICE 'boo: %', $1; RETURN $1; END;
+$function$;
 
 insert into attmp7 values (8, 18);
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__alter_table_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__alter_table_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/alter_table.sql
-snapshot_kind: text
 ---
 set client_min_messages = warning;
 
@@ -706,7 +705,9 @@ returns int
 immutable
 strict
 language plpgsql
-as $function$ BEGIN RAISE NOTICE 'boo: %', $1; RETURN $1; END; $function$;
+as $function$
+BEGIN RAISE NOTICE 'boo: %', $1; RETURN $1; END;
+$function$;
 
 insert into attmp7 values (8, 18);
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__arrays_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__arrays_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/arrays.sql
-snapshot_kind: text
 ---
 create table arrtest (
   a smallint[],
@@ -678,11 +677,13 @@ insert into arr_pk_tbl (pk, f1[0:2147483647]) values (2, '{}');
 insert into arr_pk_tbl (pk, f1[-2147483648:2147483647]) values (2, '{}');
 
 do
-$do$ declare a int[];
+$do$
+declare a int[];
 begin
   a := '[-2147483648:-2147483647]={1,2}'::int[];
   a[2147483647] := 42;
-end $do$;
+end
+$do$;
 
 select 'foo' ~~ any (array['%a', '%o']);
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__arrays_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__arrays_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/arrays.sql
-snapshot_kind: text
 ---
 create table arrtest (
   a smallint[],
@@ -834,11 +833,13 @@ insert into arr_pk_tbl (pk, f1[0:2147483647]) values (2, '{}');
 insert into arr_pk_tbl (pk, f1[-2147483648:2147483647]) values (2, '{}');
 
 do
-$do$ declare a int[];
+$do$
+declare a int[];
 begin
   a := '[-2147483648:-2147483647]={1,2}'::int[];
   a[2147483647] := 42;
-end $do$;
+end
+$do$;
 
 select 'foo' ~~ any (array['%a', '%o']);
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__btree_index_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__btree_index_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/btree_index.sql
-snapshot_kind: text
 ---
 create table bt_i4_heap (
   seqno int,
@@ -378,7 +377,8 @@ BEGIN
         DELETE FROM dedup_unique_test_table;
         INSERT INTO dedup_unique_test_table SELECT 1;
     END LOOP;
-END$do$;
+END
+$do$;
 
 drop index plain_unique;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__btree_index_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__btree_index_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/btree_index.sql
-snapshot_kind: text
 ---
 create table bt_i4_heap (
   seqno int,
@@ -463,7 +462,8 @@ BEGIN
         DELETE FROM dedup_unique_test_table;
         INSERT INTO dedup_unique_test_table SELECT 1;
     END LOOP;
-END$do$;
+END
+$do$;
 
 drop index plain_unique;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__case_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__case_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/case.sql
-snapshot_kind: text
 ---
 create table case_tbl (
   i int,
@@ -125,7 +124,9 @@ begin;
 
 create function vol(text)
 returns text
-as $function$begin return $1; end$function$
+as $function$
+begin return $1; end
+$function$
 language plpgsql
 volatile;
 
@@ -144,13 +145,17 @@ create domain foodomain as text;
 
 create function volfoo(text)
 returns foodomain
-as $function$begin return $1::foodomain; end$function$
+as $function$
+begin return $1::foodomain; end
+$function$
 language plpgsql
 volatile;
 
 create function inline_eq(foodomain, foodomain)
 returns boolean
-as $function$SELECT CASE $2::text WHEN $1::text THEN true ELSE false END$function$
+as $function$
+SELECT CASE $2::text WHEN $1::text THEN true ELSE false END
+$function$
 language sql;
 
 create operator = (PROCEDURE = inline_eq, LEFTARG = foodomain, RIGHTARG = foodomain);
@@ -165,17 +170,21 @@ create domain arrdomain as int[];
 
 create function make_ad(int, int)
 returns arrdomain
-as $function$declare x arrdomain;
+as $function$
+declare x arrdomain;
    begin
      x := array[$1,$2];
      return x;
-   end$function$
+   end
+$function$
 language plpgsql
 volatile;
 
 create function ad_eq(arrdomain, arrdomain)
 returns boolean
-as $function$begin return array_eq($1, $2); end$function$
+as $function$
+begin return array_eq($1, $2); end
+$function$
 language plpgsql;
 
 create operator = (PROCEDURE = ad_eq, LEFTARG = arrdomain, RIGHTARG = arrdomain);

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__case_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__case_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/case.sql
-snapshot_kind: text
 ---
 create table case_tbl (
   i int,
@@ -135,7 +134,9 @@ begin;
 
 create function vol(text)
 returns text
-as $function$begin return $1; end$function$
+as $function$
+begin return $1; end
+$function$
 language plpgsql
 volatile;
 
@@ -154,13 +155,17 @@ create domain foodomain as text;
 
 create function volfoo(text)
 returns foodomain
-as $function$begin return $1::foodomain; end$function$
+as $function$
+begin return $1::foodomain; end
+$function$
 language plpgsql
 volatile;
 
 create function inline_eq(foodomain, foodomain)
 returns boolean
-as $function$SELECT CASE $2::text WHEN $1::text THEN true ELSE false END$function$
+as $function$
+SELECT CASE $2::text WHEN $1::text THEN true ELSE false END
+$function$
 language sql;
 
 create operator = (PROCEDURE = inline_eq,
@@ -182,17 +187,21 @@ create domain arrdomain as int[];
 
 create function make_ad(int, int)
 returns arrdomain
-as $function$declare x arrdomain;
+as $function$
+declare x arrdomain;
    begin
      x := array[$1,$2];
      return x;
-   end$function$
+   end
+$function$
 language plpgsql
 volatile;
 
 create function ad_eq(arrdomain, arrdomain)
 returns boolean
-as $function$begin return array_eq($1, $2); end$function$
+as $function$
+begin return array_eq($1, $2); end
+$function$
 language plpgsql;
 
 create operator = (PROCEDURE = ad_eq,

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__collate.icu.utf8_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__collate.icu.utf8_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/collate.icu.utf8.sql
-snapshot_kind: text
 ---
 select
   getdatabaseencoding() <> 'UTF8' or
@@ -357,17 +356,23 @@ select a, cast(b as varchar) from collate_test3 order by 2;
 create function mylt(text, text)
 returns boolean
 language sql
-as $function$ select $1 < $2 $function$;
+as $function$
+select $1 < $2
+$function$;
 
 create function mylt_noninline(text, text)
 returns boolean
 language sql
-as $function$ select $1 < $2 limit 1 $function$;
+as $function$
+select $1 < $2 limit 1
+$function$;
 
 create function mylt_plpgsql(text, text)
 returns boolean
 language plpgsql
-as $function$ begin return $1 < $2; end $function$;
+as $function$
+begin return $1 < $2; end
+$function$;
 
 select
   a.b as a,
@@ -435,7 +440,9 @@ select * from unnest((select array_agg(b order by b) from collate_test3)) order 
 
 create function dup(anyelement)
 returns anyelement
-as $function$select $1$function$
+as $function$
+select $1
+$function$
 language sql;
 
 select a, dup(b) from collate_test1 order by 2;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__collate.icu.utf8_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__collate.icu.utf8_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/collate.icu.utf8.sql
-snapshot_kind: text
 ---
 select
   getdatabaseencoding() <> 'UTF8' or
@@ -445,17 +444,23 @@ select a, cast(b as varchar) from collate_test3 order by 2;
 create function mylt(text, text)
 returns boolean
 language sql
-as $function$ select $1 < $2 $function$;
+as $function$
+select $1 < $2
+$function$;
 
 create function mylt_noninline(text, text)
 returns boolean
 language sql
-as $function$ select $1 < $2 limit 1 $function$;
+as $function$
+select $1 < $2 limit 1
+$function$;
 
 create function mylt_plpgsql(text, text)
 returns boolean
 language plpgsql
-as $function$ begin return $1 < $2; end $function$;
+as $function$
+begin return $1 < $2; end
+$function$;
 
 select
   a.b as a,
@@ -558,7 +563,9 @@ order by 1;
 
 create function dup(anyelement)
 returns anyelement
-as $function$select $1$function$
+as $function$
+select $1
+$function$
 language sql;
 
 select a, dup(b) from collate_test1 order by 2;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__collate.linux.utf8_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__collate.linux.utf8_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/collate.linux.utf8.sql
-snapshot_kind: text
 ---
 select
   getdatabaseencoding() <> 'UTF8' or
@@ -367,17 +366,23 @@ select a, cast(b as varchar) from collate_test3 order by 2;
 create function mylt(text, text)
 returns boolean
 language sql
-as $function$ select $1 < $2 $function$;
+as $function$
+select $1 < $2
+$function$;
 
 create function mylt_noninline(text, text)
 returns boolean
 language sql
-as $function$ select $1 < $2 limit 1 $function$;
+as $function$
+select $1 < $2 limit 1
+$function$;
 
 create function mylt_plpgsql(text, text)
 returns boolean
 language plpgsql
-as $function$ begin return $1 < $2; end $function$;
+as $function$
+begin return $1 < $2; end
+$function$;
 
 select
   a.b as a,
@@ -445,7 +450,9 @@ select * from unnest((select array_agg(b order by b) from collate_test3)) order 
 
 create function dup(anyelement)
 returns anyelement
-as $function$select $1$function$
+as $function$
+select $1
+$function$
 language sql;
 
 select a, dup(b) from collate_test1 order by 2;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__collate.linux.utf8_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__collate.linux.utf8_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/collate.linux.utf8.sql
-snapshot_kind: text
 ---
 select
   getdatabaseencoding() <> 'UTF8' or
@@ -446,17 +445,23 @@ select a, cast(b as varchar) from collate_test3 order by 2;
 create function mylt(text, text)
 returns boolean
 language sql
-as $function$ select $1 < $2 $function$;
+as $function$
+select $1 < $2
+$function$;
 
 create function mylt_noninline(text, text)
 returns boolean
 language sql
-as $function$ select $1 < $2 limit 1 $function$;
+as $function$
+select $1 < $2 limit 1
+$function$;
 
 create function mylt_plpgsql(text, text)
 returns boolean
 language plpgsql
-as $function$ begin return $1 < $2; end $function$;
+as $function$
+begin return $1 < $2; end
+$function$;
 
 select
   a.b as a,
@@ -557,7 +562,9 @@ order by 1;
 
 create function dup(anyelement)
 returns anyelement
-as $function$select $1$function$
+as $function$
+select $1
+$function$
 language sql;
 
 select a, dup(b) from collate_test1 order by 2;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__collate_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__collate_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/collate.sql
-snapshot_kind: text
 ---
 create schema "collate_tests";
 
@@ -249,7 +248,9 @@ select a, cast(b as varchar) from collate_test2 order by 2;
 create function vc(text)
 returns text
 language sql
-as $function$select $1::varchar$function$;
+as $function$
+select $1::varchar
+$function$;
 
 select a, b from collate_test1 order by a, vc(b);
 
@@ -259,7 +260,9 @@ select * from unnest((select array_agg(b order by b) from collate_test2)) order 
 
 create function dup(anyelement)
 returns anyelement
-as $function$select $1$function$
+as $function$
+select $1
+$function$
 language sql;
 
 select a, dup(b) from collate_test1 order by 2;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__collate_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__collate_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/collate.sql
-snapshot_kind: text
 ---
 create schema "collate_tests";
 
@@ -338,7 +337,9 @@ select a, cast(b as varchar) from collate_test2 order by 2;
 create function vc(text)
 returns text
 language sql
-as $function$select $1::varchar$function$;
+as $function$
+select $1::varchar
+$function$;
 
 select a, b from collate_test1 order by a, vc(b);
 
@@ -370,7 +371,9 @@ order by 1;
 
 create function dup(anyelement)
 returns anyelement
-as $function$select $1$function$
+as $function$
+select $1
+$function$
 language sql;
 
 select a, dup(b) from collate_test1 order by 2;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__compression_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__compression_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/compression.sql
-snapshot_kind: text
 ---
 create schema "pglz";
 
@@ -28,7 +27,9 @@ create table cmdata2 (f1 int compression pglz);
 create or replace function large_val()
 returns text
 language sql
-as $function$select array_agg(fipshash(g::text))::text from generate_series(1, 256) g$function$;
+as $function$
+select array_agg(fipshash(g::text))::text from generate_series(1, 256) g
+$function$;
 
 create table cmdata2 (f1 text compression pglz);
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__compression_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__compression_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/compression.sql
-snapshot_kind: text
 ---
 create schema "pglz";
 
@@ -28,7 +27,9 @@ create table cmdata2 (f1 int compression pglz);
 create or replace function large_val()
 returns text
 language sql
-as $function$select array_agg(fipshash(g::text))::text from generate_series(1, 256) g$function$;
+as $function$
+select array_agg(fipshash(g::text))::text from generate_series(1, 256) g
+$function$;
 
 create table cmdata2 (f1 text compression pglz);
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__compression_lz4_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__compression_lz4_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/compression_lz4.sql
-snapshot_kind: text
 ---
 select
   not enumvals @> '{lz4}' as skip_test
@@ -61,7 +60,9 @@ select pg_column_compression(f1) from cmmove2;
 create or replace function large_val_lz4()
 returns text
 language sql
-as $function$select array_agg(fipshash(g::text))::text from generate_series(1, 256) g$function$;
+as $function$
+select array_agg(fipshash(g::text))::text from generate_series(1, 256) g
+$function$;
 
 create table cmdata2 (f1 text compression lz4);
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__compression_lz4_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__compression_lz4_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/compression_lz4.sql
-snapshot_kind: text
 ---
 select
   not enumvals @> '{lz4}' as skip_test
@@ -61,7 +60,9 @@ select pg_column_compression(f1) from cmmove2;
 create or replace function large_val_lz4()
 returns text
 language sql
-as $function$select array_agg(fipshash(g::text))::text from generate_series(1, 256) g$function$;
+as $function$
+select array_agg(fipshash(g::text))::text from generate_series(1, 256) g
+$function$;
 
 create table cmdata2 (f1 text compression lz4);
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__copy2_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__copy2_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/copy2.sql
-snapshot_kind: text
 ---
 create temporary table x (
   a serial,
@@ -14,7 +13,7 @@ create temporary table x (
 create function fn_x_before()
 returns trigger
 as $function$
-  BEGIN
+BEGIN
 		NEW.e := 'before trigger fired'::text;
 		return NEW;
 	END;
@@ -24,7 +23,7 @@ language plpgsql;
 create function fn_x_after()
 returns trigger
 as $function$
-  BEGIN
+BEGIN
 		UPDATE x set e='after trigger fired' where c='stuff';
 		return NULL;
 	END;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__copy2_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__copy2_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/copy2.sql
-snapshot_kind: text
 ---
 create temporary table x (
   a serial,
@@ -14,7 +13,7 @@ create temporary table x (
 create function fn_x_before()
 returns trigger
 as $function$
-  BEGIN
+BEGIN
 		NEW.e := 'before trigger fired'::text;
 		return NEW;
 	END;
@@ -24,7 +23,7 @@ language plpgsql;
 create function fn_x_after()
 returns trigger
 as $function$
-  BEGIN
+BEGIN
 		UPDATE x set e='after trigger fired' where c='stuff';
 		return NULL;
 	END;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_aggregate_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_aggregate_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/create_aggregate.sql
-snapshot_kind: text
 ---
 create aggregate newavg (
   sfunc = int4_avg_accum,
@@ -33,7 +32,9 @@ comment on aggregate newcnt("any") is 'an agg(any) comment';
 
 create function sum3(bigint, bigint, bigint)
 returns bigint
-as $function$select $1 + $2 + $3$function$
+as $function$
+select $1 + $2 + $3
+$function$
 language sql
 strict
 immutable;
@@ -44,14 +45,18 @@ create type aggtype as (a int, b int, c text);
 
 create function aggf_trans(aggtype[], int, int, text)
 returns aggtype[]
-as $function$select array_append($1,ROW($2,$3,$4)::aggtype)$function$
+as $function$
+select array_append($1,ROW($2,$3,$4)::aggtype)
+$function$
 language sql
 strict
 immutable;
 
 create function aggfns_trans(aggtype[], int, int, text)
 returns aggtype[]
-as $function$select array_append($1,ROW($2,$3,$4)::aggtype)$function$
+as $function$
+select array_append($1,ROW($2,$3,$4)::aggtype)
+$function$
 language sql
 immutable;
 
@@ -69,7 +74,9 @@ create aggregate aggfns (
 create function least_accum(bigint, bigint)
 returns bigint
 language sql
-as $function$select least($1, $2)$function$;
+as $function$
+select least($1, $2)
+$function$;
 
 create aggregate least_agg (int) (stype = bigint, sfunc = least_accum);
 
@@ -78,7 +85,9 @@ drop function least_accum(bigint, bigint);
 create function least_accum(anycompatible, anycompatible)
 returns anycompatible
 language sql
-as $function$select least($1, $2)$function$;
+as $function$
+select least($1, $2)
+$function$;
 
 create aggregate least_agg (int) (stype = bigint, sfunc = least_accum);
 
@@ -89,14 +98,18 @@ drop function least_accum(anycompatible, anycompatible) cascade;
 create function least_accum(anyelement, variadic anyarray)
 returns anyelement
 language sql
-as $function$select least($1, min($2[i])) from generate_subscripts($2,1) g(i)$function$;
+as $function$
+select least($1, min($2[i])) from generate_subscripts($2,1) g(i)
+$function$;
 
 create aggregate least_agg (variadic items anyarray) (stype = anyelement, sfunc = least_accum);
 
 create function cleast_accum(anycompatible, variadic anycompatiblearray)
 returns anycompatible
 language sql
-as $function$select least($1, min($2[i])) from generate_subscripts($2,1) g(i)$function$;
+as $function$
+select least($1, min($2[i])) from generate_subscripts($2,1) g(i)
+$function$;
 
 create aggregate cleast_agg (
   variadic items anycompatiblearray
@@ -262,7 +275,9 @@ create or replace aggregate myavg (numeric) (stype = numeric, sfunc = numeric_ad
 
 create function sum4(bigint, bigint, bigint, bigint)
 returns bigint
-as $function$select $1 + $2 + $3 + $4$function$
+as $function$
+select $1 + $2 + $3 + $4
+$function$
 language sql
 strict
 immutable;
@@ -277,7 +292,9 @@ create aggregate mysum (int) (stype = int, sfunc = int4pl, parallel = pear);
 
 create function float8mi_n(double precision, double precision)
 returns double precision
-as $function$ SELECT $1 - $2; $function$
+as $function$
+SELECT $1 - $2;
+$function$
 language sql;
 
 create aggregate invalidsumdouble (
@@ -292,7 +309,9 @@ create aggregate invalidsumdouble (
 
 create function float8mi_int(double precision, double precision)
 returns int
-as $function$ SELECT CAST($1 - $2 AS INT); $function$
+as $function$
+SELECT CAST($1 - $2 AS INT);
+$function$
 language sql;
 
 create aggregate wrongreturntype (

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_aggregate_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_aggregate_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/create_aggregate.sql
-snapshot_kind: text
 ---
 create aggregate newavg (
   sfunc = int4_avg_accum,
@@ -56,7 +55,9 @@ comment on aggregate newcnt("any") is 'an agg(any) comment';
 
 create function sum3(bigint, bigint, bigint)
 returns bigint
-as $function$select $1 + $2 + $3$function$
+as $function$
+select $1 + $2 + $3
+$function$
 language sql
 strict
 immutable;
@@ -73,14 +74,18 @@ create type aggtype as (a int, b int, c text);
 
 create function aggf_trans(aggtype[], int, int, text)
 returns aggtype[]
-as $function$select array_append($1,ROW($2,$3,$4)::aggtype)$function$
+as $function$
+select array_append($1,ROW($2,$3,$4)::aggtype)
+$function$
 language sql
 strict
 immutable;
 
 create function aggfns_trans(aggtype[], int, int, text)
 returns aggtype[]
-as $function$select array_append($1,ROW($2,$3,$4)::aggtype)$function$
+as $function$
+select array_append($1,ROW($2,$3,$4)::aggtype)
+$function$
 language sql
 immutable;
 
@@ -104,7 +109,9 @@ create aggregate aggfns (
 create function least_accum(bigint, bigint)
 returns bigint
 language sql
-as $function$select least($1, $2)$function$;
+as $function$
+select least($1, $2)
+$function$;
 
 create aggregate least_agg (int) (stype = bigint, sfunc = least_accum);
 
@@ -113,7 +120,9 @@ drop function least_accum(bigint, bigint);
 create function least_accum(anycompatible, anycompatible)
 returns anycompatible
 language sql
-as $function$select least($1, $2)$function$;
+as $function$
+select least($1, $2)
+$function$;
 
 create aggregate least_agg (int) (stype = bigint, sfunc = least_accum);
 
@@ -124,7 +133,9 @@ drop function least_accum(anycompatible, anycompatible) cascade;
 create function least_accum(anyelement, variadic anyarray)
 returns anyelement
 language sql
-as $function$select least($1, min($2[i])) from generate_subscripts($2,1) g(i)$function$;
+as $function$
+select least($1, min($2[i])) from generate_subscripts($2,1) g(i)
+$function$;
 
 create aggregate least_agg (
   variadic items anyarray
@@ -136,7 +147,9 @@ create aggregate least_agg (
 create function cleast_accum(anycompatible, variadic anycompatiblearray)
 returns anycompatible
 language sql
-as $function$select least($1, min($2[i])) from generate_subscripts($2,1) g(i)$function$;
+as $function$
+select least($1, min($2[i])) from generate_subscripts($2,1) g(i)
+$function$;
 
 create aggregate cleast_agg (
   variadic items anycompatiblearray
@@ -315,7 +328,9 @@ create or replace aggregate myavg (
 
 create function sum4(bigint, bigint, bigint, bigint)
 returns bigint
-as $function$select $1 + $2 + $3 + $4$function$
+as $function$
+select $1 + $2 + $3 + $4
+$function$
 language sql
 strict
 immutable;
@@ -335,7 +350,9 @@ create aggregate mysum (int) (stype = int, sfunc = int4pl, parallel = pear);
 
 create function float8mi_n(double precision, double precision)
 returns double precision
-as $function$ SELECT $1 - $2; $function$
+as $function$
+SELECT $1 - $2;
+$function$
 language sql;
 
 create aggregate invalidsumdouble (
@@ -350,7 +367,9 @@ create aggregate invalidsumdouble (
 
 create function float8mi_int(double precision, double precision)
 returns int
-as $function$ SELECT CAST($1 - $2 AS INT); $function$
+as $function$
+SELECT CAST($1 - $2 AS INT);
+$function$
 language sql;
 
 create aggregate wrongreturntype (

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_cast_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_cast_100.snap
@@ -1,20 +1,23 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/create_cast.sql
-snapshot_kind: text
 ---
 create type casttesttype;
 
 create function casttesttype_in(cstring)
 returns casttesttype
-as $function$textin$function$
+as $function$
+textin
+$function$
 language internal
 strict
 immutable;
 
 create function casttesttype_out(casttesttype)
 returns cstring
-as $function$textout$function$
+as $function$
+textout
+$function$
 language internal
 strict
 immutable;
@@ -29,7 +32,9 @@ create type casttesttype (
 create function casttestfunc(casttesttype)
 returns int
 language sql
-as $function$ SELECT 1; $function$;
+as $function$
+SELECT 1;
+$function$;
 
 select casttestfunc(cast('foo' as text));
 
@@ -56,7 +61,9 @@ drop cast (int as casttesttype);
 create function int4_casttesttype(int)
 returns casttesttype
 language sql
-as $function$ SELECT ('foo'::text || $1::text)::casttesttype; $function$;
+as $function$
+SELECT ('foo'::text || $1::text)::casttesttype;
+$function$;
 
 create cast (int as casttesttype) with function int4_casttesttype(int) as implicit;
 
@@ -67,7 +74,9 @@ drop function int4_casttesttype(int) cascade;
 create function bar_int4_text(int)
 returns text
 language sql
-as $function$ SELECT ('bar'::text || $1::text); $function$;
+as $function$
+SELECT ('bar'::text || $1::text);
+$function$;
 
 create cast (int as casttesttype) with function bar_int4_text(int) as implicit;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_cast_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_cast_80.snap
@@ -1,20 +1,23 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/create_cast.sql
-snapshot_kind: text
 ---
 create type casttesttype;
 
 create function casttesttype_in(cstring)
 returns casttesttype
-as $function$textin$function$
+as $function$
+textin
+$function$
 language internal
 strict
 immutable;
 
 create function casttesttype_out(casttesttype)
 returns cstring
-as $function$textout$function$
+as $function$
+textout
+$function$
 language internal
 strict
 immutable;
@@ -29,7 +32,9 @@ create type casttesttype (
 create function casttestfunc(casttesttype)
 returns int
 language sql
-as $function$ SELECT 1; $function$;
+as $function$
+SELECT 1;
+$function$;
 
 select casttestfunc(cast('foo' as text));
 
@@ -56,7 +61,9 @@ drop cast (int as casttesttype);
 create function int4_casttesttype(int)
 returns casttesttype
 language sql
-as $function$ SELECT ('foo'::text || $1::text)::casttesttype; $function$;
+as $function$
+SELECT ('foo'::text || $1::text)::casttesttype;
+$function$;
 
 create cast (int as casttesttype)
 with function int4_casttesttype(int)
@@ -69,7 +76,9 @@ drop function int4_casttesttype(int) cascade;
 create function bar_int4_text(int)
 returns text
 language sql
-as $function$ SELECT ('bar'::text || $1::text); $function$;
+as $function$
+SELECT ('bar'::text || $1::text);
+$function$;
 
 create cast (int as casttesttype) with function bar_int4_text(int) as implicit;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_function_c_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_function_c_100.snap
@@ -1,14 +1,15 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/create_function_c.sql
-snapshot_kind: text
 ---
 load 'regresslib';
 
 create function test1(int)
 returns int
 language c
-as $function$nosuchfile$function$;
+as $function$
+nosuchfile
+$function$;
 
 create function test1(int)
 returns int
@@ -20,4 +21,6 @@ select regexp_replace('LAST_ERROR_MESSAGE', 'file ".*"', 'file "..."');
 create function test1(int)
 returns int
 language internal
-as $function$nosuch$function$;
+as $function$
+nosuch
+$function$;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_function_c_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_function_c_80.snap
@@ -1,14 +1,15 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/create_function_c.sql
-snapshot_kind: text
 ---
 load 'regresslib';
 
 create function test1(int)
 returns int
 language c
-as $function$nosuchfile$function$;
+as $function$
+nosuchfile
+$function$;
 
 create function test1(int)
 returns int
@@ -20,4 +21,6 @@ select regexp_replace('LAST_ERROR_MESSAGE', 'file ".*"', 'file "..."');
 create function test1(int)
 returns int
 language internal
-as $function$nosuch$function$;
+as $function$
+nosuch
+$function$;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_function_sql_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_function_sql_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/create_function_sql.sql
-snapshot_kind: text
 ---
 create user regress_unpriv_user;
 
@@ -14,17 +13,23 @@ set search_path to temp_func_test, public;
 create function functest_a_1(text, date)
 returns boolean
 language sql
-as $function$SELECT $1 = 'abcd' AND $2 > '2001-01-01'$function$;
+as $function$
+SELECT $1 = 'abcd' AND $2 > '2001-01-01'
+$function$;
 
 create function functest_a_2(text[])
 returns int
 language sql
-as $function$SELECT $1[1]::int$function$;
+as $function$
+SELECT $1[1]::int
+$function$;
 
 create function functest_a_3()
 returns boolean
 language sql
-as $function$SELECT false$function$;
+as $function$
+SELECT false
+$function$;
 
 select
   proname,
@@ -50,25 +55,33 @@ select functest_a_3();
 create function functest_b_1(int)
 returns boolean
 language sql
-as $function$SELECT $1 > 0$function$;
+as $function$
+SELECT $1 > 0
+$function$;
 
 create function functest_b_2(int)
 returns boolean
 language sql
 immutable
-as $function$SELECT $1 > 0$function$;
+as $function$
+SELECT $1 > 0
+$function$;
 
 create function functest_b_3(int)
 returns boolean
 language sql
 stable
-as $function$SELECT $1 = 0$function$;
+as $function$
+SELECT $1 = 0
+$function$;
 
 create function functest_b_4(int)
 returns boolean
 language sql
 volatile
-as $function$SELECT $1 < 0$function$;
+as $function$
+SELECT $1 < 0
+$function$;
 
 select
   proname,
@@ -107,19 +120,25 @@ order by proname;
 create function functest_c_1(int)
 returns boolean
 language sql
-as $function$SELECT $1 > 0$function$;
+as $function$
+SELECT $1 > 0
+$function$;
 
 create function functest_c_2(int)
 returns boolean
 language sql
 security definer
-as $function$SELECT $1 = 0$function$;
+as $function$
+SELECT $1 = 0
+$function$;
 
 create function functest_c_3(int)
 returns boolean
 language sql
 security invoker
-as $function$SELECT $1 < 0$function$;
+as $function$
+SELECT $1 < 0
+$function$;
 
 select
   proname,
@@ -158,13 +177,17 @@ order by proname;
 create function functest_e_1(int)
 returns boolean
 language sql
-as $function$SELECT $1 > 100$function$;
+as $function$
+SELECT $1 > 100
+$function$;
 
 create function functest_e_2(int)
 returns boolean
 language sql
 leakproof
-as $function$SELECT $1 > 100$function$;
+as $function$
+SELECT $1 > 100
+$function$;
 
 select
   proname,
@@ -227,32 +250,42 @@ create function functest_e_3(int)
 returns boolean
 language sql
 leakproof
-as $function$SELECT $1 < 200$function$;
+as $function$
+SELECT $1 < 200
+$function$;
 
 reset session_authorization;
 
 create function functest_f_1(int)
 returns boolean
 language sql
-as $function$SELECT $1 > 50$function$;
+as $function$
+SELECT $1 > 50
+$function$;
 
 create function functest_f_2(int)
 returns boolean
 language sql
 called on null input
-as $function$SELECT $1 = 50$function$;
+as $function$
+SELECT $1 = 50
+$function$;
 
 create function functest_f_3(int)
 returns boolean
 language sql
 strict
-as $function$SELECT $1 < 50$function$;
+as $function$
+SELECT $1 < 50
+$function$;
 
 create function functest_f_4(int)
 returns boolean
 language sql
 strict
-as $function$SELECT $1 = 50$function$;
+as $function$
+SELECT $1 = 50
+$function$;
 
 select
   proname,
@@ -329,7 +362,9 @@ commit;
 create function functest_s_xxx(x int)
 returns int
 language sql
-as $function$ SELECT x * 2 $function$ return x * 3;;
+as $function$
+SELECT x * 2
+$function$ return x * 3;;
 
 create function functest_s_xx(x anyarray)
 returns anyelement
@@ -388,17 +423,23 @@ drop table functest3 cascade;
 create function functest_is_1(a int, b int default 1, c text default 'foo')
 returns int
 language sql
-as $function$SELECT $1 + $2$function$;
+as $function$
+SELECT $1 + $2
+$function$;
 
 create function functest_is_2(out a int, b int default 1)
 returns int
 language sql
-as $function$SELECT $1$function$;
+as $function$
+SELECT $1
+$function$;
 
 create function functest_is_3(a int default 1, out b int)
 returns int
 language sql
-as $function$SELECT $1$function$;
+as $function$
+SELECT $1
+$function$;
 
 select
   routine_name,
@@ -423,19 +464,25 @@ drop function functest_is_1(int, int, text), functest_is_2(int), functest_is_3(i
 create function functest_is_4a()
 returns int
 language sql
-as $function$SELECT 1$function$;
+as $function$
+SELECT 1
+$function$;
 
 create function functest_is_4b(x int default functest_is_4a())
 returns int
 language sql
-as $function$SELECT x$function$;
+as $function$
+SELECT x
+$function$;
 
 create sequence functest1;
 
 create function functest_is_5(x int default nextval('functest1'))
 returns int
 language sql
-as $function$SELECT x$function$;
+as $function$
+SELECT x
+$function$;
 
 create function functest_is_6()
 returns int
@@ -508,7 +555,9 @@ create function functest_b_2(bigint)
 returns boolean
 language sql
 immutable
-as $function$SELECT $1 > 0$function$;
+as $function$
+SELECT $1 > 0
+$function$;
 
 drop function functest_b_1;
 
@@ -519,24 +568,32 @@ drop function functest_b_2;
 create function functest1(a int)
 returns int
 language sql
-as $function$SELECT $1$function$;
+as $function$
+SELECT $1
+$function$;
 
 create or replace function functest1(a int)
 returns int
 language sql
 window
-as $function$SELECT $1$function$;
+as $function$
+SELECT $1
+$function$;
 
 create or replace procedure functest1(a int)
 language sql
-as $procedure$SELECT $1$procedure$;
+as $procedure$
+SELECT $1
+$procedure$;
 
 drop function functest1(int);
 
 create function functest_srf0()
 returns setof int
 language sql
-as $function$ SELECT i FROM generate_series(1, 100) i $function$;
+as $function$
+SELECT i FROM generate_series(1, 100) i
+$function$;
 
 select functest_srf0() limit 5;
 
@@ -549,7 +606,7 @@ returns setof int
 language sql
 stable
 as $function$
-    SELECT * FROM functest3;
+SELECT * FROM functest3;
 $function$;
 
 select * from functest_sri1();
@@ -569,14 +626,18 @@ drop table functest3 cascade;
 create function voidtest1(a int)
 returns void
 language sql
-as $function$ SELECT a + 1 $function$;
+as $function$
+SELECT a + 1
+$function$;
 
 select voidtest1(42);
 
 create function voidtest2(a int, b int)
 returns void
 language sql
-as $function$ SELECT voidtest1(a + b) $function$;
+as $function$
+SELECT voidtest1(a + b)
+$function$;
 
 select voidtest2(11, 22);
 
@@ -587,14 +648,18 @@ create temporary table sometable (f1 int);
 create function voidtest3(a int)
 returns void
 language sql
-as $function$ INSERT INTO sometable VALUES(a + 1) $function$;
+as $function$
+INSERT INTO sometable VALUES(a + 1)
+$function$;
 
 select voidtest3(17);
 
 create function voidtest4(a int)
 returns void
 language sql
-as $function$ INSERT INTO sometable VALUES(a - 1) RETURNING f1 $function$;
+as $function$
+INSERT INTO sometable VALUES(a - 1) RETURNING f1
+$function$;
 
 select voidtest4(39);
 
@@ -603,7 +668,9 @@ select * from sometable;
 create function voidtest5(a int)
 returns setof void
 language sql
-as $function$ SELECT generate_series(1, a) $function$
+as $function$
+SELECT generate_series(1, a)
+$function$
 stable;
 
 select * from voidtest5(3);
@@ -614,7 +681,7 @@ create function create_and_insert()
 returns void
 language sql
 as $function$
-  create table ddl_test (f1 int);
+create table ddl_test (f1 int);
   insert into ddl_test values (1.2);
 $function$;
 
@@ -626,7 +693,7 @@ create function alter_and_insert()
 returns void
 language sql
 as $function$
-  alter table ddl_test alter column f1 type numeric;
+alter table ddl_test alter column f1 type numeric;
   insert into ddl_test values (1.2);
 $function$;
 
@@ -640,7 +707,9 @@ create function double_append(anyarray, anyelement)
 returns setof anyarray
 language sql
 immutable
-as $function$ SELECT array_append($1, $2) || array_append($1, $2) $function$;
+as $function$
+SELECT array_append($1, $2) || array_append($1, $2)
+$function$;
 
 select
   double_append(array_append(array[q1], q2), q3)
@@ -653,7 +722,9 @@ language sql
 strict
 immutable
 parallel SAFE
-as $function$ SELECT value + seed + random()::int/0 $function$;
+as $function$
+SELECT value + seed + random()::int/0
+$function$;
 
 create operator class part_test_int4_ops_bad
   for type int
@@ -672,22 +743,30 @@ insert into pt values (1);
 create function test1(int)
 returns int
 language sql
-as $function$SELECT 'not an integer';$function$;
+as $function$
+SELECT 'not an integer';
+$function$;
 
 create function test1(int)
 returns int
 language sql
-as $function$not even SQL$function$;
+as $function$
+not even SQL
+$function$;
 
 create function test1(int)
 returns int
 language sql
-as $function$SELECT 1, 2, 3;$function$;
+as $function$
+SELECT 1, 2, 3;
+$function$;
 
 create function test1(int)
 returns int
 language sql
-as $function$SELECT $2;$function$;
+as $function$
+SELECT $2;
+$function$;
 
 create function test1(int)
 returns int
@@ -697,14 +776,18 @@ as 'a', 'b';
 create function test1(int)
 returns int
 language sql
-as $function$$function$;
+as $function$
+
+$function$;
 
 set check_function_bodies = off;
 
 create function test1(anyelement)
 returns anyarray
 language sql
-as $function$$function$;
+as $function$
+
+$function$;
 
 select test1(0);
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_function_sql_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_function_sql_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/create_function_sql.sql
-snapshot_kind: text
 ---
 create user regress_unpriv_user;
 
@@ -14,17 +13,23 @@ set search_path to temp_func_test, public;
 create function functest_a_1(text, date)
 returns boolean
 language sql
-as $function$SELECT $1 = 'abcd' AND $2 > '2001-01-01'$function$;
+as $function$
+SELECT $1 = 'abcd' AND $2 > '2001-01-01'
+$function$;
 
 create function functest_a_2(text[])
 returns int
 language sql
-as $function$SELECT $1[1]::int$function$;
+as $function$
+SELECT $1[1]::int
+$function$;
 
 create function functest_a_3()
 returns boolean
 language sql
-as $function$SELECT false$function$;
+as $function$
+SELECT false
+$function$;
 
 select
   proname,
@@ -50,25 +55,33 @@ select functest_a_3();
 create function functest_b_1(int)
 returns boolean
 language sql
-as $function$SELECT $1 > 0$function$;
+as $function$
+SELECT $1 > 0
+$function$;
 
 create function functest_b_2(int)
 returns boolean
 language sql
 immutable
-as $function$SELECT $1 > 0$function$;
+as $function$
+SELECT $1 > 0
+$function$;
 
 create function functest_b_3(int)
 returns boolean
 language sql
 stable
-as $function$SELECT $1 = 0$function$;
+as $function$
+SELECT $1 = 0
+$function$;
 
 create function functest_b_4(int)
 returns boolean
 language sql
 volatile
-as $function$SELECT $1 < 0$function$;
+as $function$
+SELECT $1 < 0
+$function$;
 
 select
   proname,
@@ -107,19 +120,25 @@ order by proname;
 create function functest_c_1(int)
 returns boolean
 language sql
-as $function$SELECT $1 > 0$function$;
+as $function$
+SELECT $1 > 0
+$function$;
 
 create function functest_c_2(int)
 returns boolean
 language sql
 security definer
-as $function$SELECT $1 = 0$function$;
+as $function$
+SELECT $1 = 0
+$function$;
 
 create function functest_c_3(int)
 returns boolean
 language sql
 security invoker
-as $function$SELECT $1 < 0$function$;
+as $function$
+SELECT $1 < 0
+$function$;
 
 select
   proname,
@@ -158,13 +177,17 @@ order by proname;
 create function functest_e_1(int)
 returns boolean
 language sql
-as $function$SELECT $1 > 100$function$;
+as $function$
+SELECT $1 > 100
+$function$;
 
 create function functest_e_2(int)
 returns boolean
 language sql
 leakproof
-as $function$SELECT $1 > 100$function$;
+as $function$
+SELECT $1 > 100
+$function$;
 
 select
   proname,
@@ -227,32 +250,42 @@ create function functest_e_3(int)
 returns boolean
 language sql
 leakproof
-as $function$SELECT $1 < 200$function$;
+as $function$
+SELECT $1 < 200
+$function$;
 
 reset session_authorization;
 
 create function functest_f_1(int)
 returns boolean
 language sql
-as $function$SELECT $1 > 50$function$;
+as $function$
+SELECT $1 > 50
+$function$;
 
 create function functest_f_2(int)
 returns boolean
 language sql
 called on null input
-as $function$SELECT $1 = 50$function$;
+as $function$
+SELECT $1 = 50
+$function$;
 
 create function functest_f_3(int)
 returns boolean
 language sql
 strict
-as $function$SELECT $1 < 50$function$;
+as $function$
+SELECT $1 < 50
+$function$;
 
 create function functest_f_4(int)
 returns boolean
 language sql
 strict
-as $function$SELECT $1 = 50$function$;
+as $function$
+SELECT $1 = 50
+$function$;
 
 select
   proname,
@@ -329,7 +362,9 @@ commit;
 create function functest_s_xxx(x int)
 returns int
 language sql
-as $function$ SELECT x * 2 $function$ return x * 3;;
+as $function$
+SELECT x * 2
+$function$ return x * 3;;
 
 create function functest_s_xx(x anyarray)
 returns anyelement
@@ -388,17 +423,23 @@ drop table functest3 cascade;
 create function functest_is_1(a int, b int default 1, c text default 'foo')
 returns int
 language sql
-as $function$SELECT $1 + $2$function$;
+as $function$
+SELECT $1 + $2
+$function$;
 
 create function functest_is_2(out a int, b int default 1)
 returns int
 language sql
-as $function$SELECT $1$function$;
+as $function$
+SELECT $1
+$function$;
 
 create function functest_is_3(a int default 1, out b int)
 returns int
 language sql
-as $function$SELECT $1$function$;
+as $function$
+SELECT $1
+$function$;
 
 select
   routine_name,
@@ -426,19 +467,25 @@ drop function
 create function functest_is_4a()
 returns int
 language sql
-as $function$SELECT 1$function$;
+as $function$
+SELECT 1
+$function$;
 
 create function functest_is_4b(x int default functest_is_4a())
 returns int
 language sql
-as $function$SELECT x$function$;
+as $function$
+SELECT x
+$function$;
 
 create sequence functest1;
 
 create function functest_is_5(x int default nextval('functest1'))
 returns int
 language sql
-as $function$SELECT x$function$;
+as $function$
+SELECT x
+$function$;
 
 create function functest_is_6()
 returns int
@@ -512,7 +559,9 @@ create function functest_b_2(bigint)
 returns boolean
 language sql
 immutable
-as $function$SELECT $1 > 0$function$;
+as $function$
+SELECT $1 > 0
+$function$;
 
 drop function functest_b_1;
 
@@ -523,24 +572,32 @@ drop function functest_b_2;
 create function functest1(a int)
 returns int
 language sql
-as $function$SELECT $1$function$;
+as $function$
+SELECT $1
+$function$;
 
 create or replace function functest1(a int)
 returns int
 language sql
 window
-as $function$SELECT $1$function$;
+as $function$
+SELECT $1
+$function$;
 
 create or replace procedure functest1(a int)
 language sql
-as $procedure$SELECT $1$procedure$;
+as $procedure$
+SELECT $1
+$procedure$;
 
 drop function functest1(int);
 
 create function functest_srf0()
 returns setof int
 language sql
-as $function$ SELECT i FROM generate_series(1, 100) i $function$;
+as $function$
+SELECT i FROM generate_series(1, 100) i
+$function$;
 
 select functest_srf0() limit 5;
 
@@ -553,7 +610,7 @@ returns setof int
 language sql
 stable
 as $function$
-    SELECT * FROM functest3;
+SELECT * FROM functest3;
 $function$;
 
 select * from functest_sri1();
@@ -573,14 +630,18 @@ drop table functest3 cascade;
 create function voidtest1(a int)
 returns void
 language sql
-as $function$ SELECT a + 1 $function$;
+as $function$
+SELECT a + 1
+$function$;
 
 select voidtest1(42);
 
 create function voidtest2(a int, b int)
 returns void
 language sql
-as $function$ SELECT voidtest1(a + b) $function$;
+as $function$
+SELECT voidtest1(a + b)
+$function$;
 
 select voidtest2(11, 22);
 
@@ -591,14 +652,18 @@ create temporary table sometable (f1 int);
 create function voidtest3(a int)
 returns void
 language sql
-as $function$ INSERT INTO sometable VALUES(a + 1) $function$;
+as $function$
+INSERT INTO sometable VALUES(a + 1)
+$function$;
 
 select voidtest3(17);
 
 create function voidtest4(a int)
 returns void
 language sql
-as $function$ INSERT INTO sometable VALUES(a - 1) RETURNING f1 $function$;
+as $function$
+INSERT INTO sometable VALUES(a - 1) RETURNING f1
+$function$;
 
 select voidtest4(39);
 
@@ -607,7 +672,9 @@ select * from sometable;
 create function voidtest5(a int)
 returns setof void
 language sql
-as $function$ SELECT generate_series(1, a) $function$
+as $function$
+SELECT generate_series(1, a)
+$function$
 stable;
 
 select * from voidtest5(3);
@@ -618,7 +685,7 @@ create function create_and_insert()
 returns void
 language sql
 as $function$
-  create table ddl_test (f1 int);
+create table ddl_test (f1 int);
   insert into ddl_test values (1.2);
 $function$;
 
@@ -630,7 +697,7 @@ create function alter_and_insert()
 returns void
 language sql
 as $function$
-  alter table ddl_test alter column f1 type numeric;
+alter table ddl_test alter column f1 type numeric;
   insert into ddl_test values (1.2);
 $function$;
 
@@ -644,7 +711,9 @@ create function double_append(anyarray, anyelement)
 returns setof anyarray
 language sql
 immutable
-as $function$ SELECT array_append($1, $2) || array_append($1, $2) $function$;
+as $function$
+SELECT array_append($1, $2) || array_append($1, $2)
+$function$;
 
 select
   double_append(
@@ -663,7 +732,9 @@ language sql
 strict
 immutable
 parallel SAFE
-as $function$ SELECT value + seed + random()::int/0 $function$;
+as $function$
+SELECT value + seed + random()::int/0
+$function$;
 
 create operator class part_test_int4_ops_bad
   for type int
@@ -682,22 +753,30 @@ insert into pt values (1);
 create function test1(int)
 returns int
 language sql
-as $function$SELECT 'not an integer';$function$;
+as $function$
+SELECT 'not an integer';
+$function$;
 
 create function test1(int)
 returns int
 language sql
-as $function$not even SQL$function$;
+as $function$
+not even SQL
+$function$;
 
 create function test1(int)
 returns int
 language sql
-as $function$SELECT 1, 2, 3;$function$;
+as $function$
+SELECT 1, 2, 3;
+$function$;
 
 create function test1(int)
 returns int
 language sql
-as $function$SELECT $2;$function$;
+as $function$
+SELECT $2;
+$function$;
 
 create function test1(int)
 returns int
@@ -707,14 +786,18 @@ as 'a', 'b';
 create function test1(int)
 returns int
 language sql
-as $function$$function$;
+as $function$
+
+$function$;
 
 set check_function_bodies = off;
 
 create function test1(anyelement)
 returns anyarray
 language sql
-as $function$$function$;
+as $function$
+
+$function$;
 
 select test1(0);
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_index_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_index_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/create_index.sql
-snapshot_kind: text
 ---
 create index "onek_unique1" on onek using btree (unique1 int4_ops);
 
@@ -648,7 +647,8 @@ as $function$
 BEGIN
   EXECUTE 'SELECT txid_current()';
   RETURN true;
-END; $function$;
+END;
+$function$;
 
 create index concurrently "concur_index8"
 on concur_heap
@@ -1811,7 +1811,7 @@ rollback;
 create or replace function create_relfilenode_part(relname text, indname text)
 returns void
 as $function$
-  BEGIN
+BEGIN
   EXECUTE format('
     CREATE TABLE %I AS
       SELECT oid, relname, relfilenode, relkind, reltoastrelid
@@ -1820,7 +1820,7 @@ as $function$
          (SELECT relid FROM pg_partition_tree(''%I''));',
 	 relname, indname);
   END
-  $function$
+$function$
 language plpgsql;
 
 create or replace function compare_relfilenode_part(tabname text)
@@ -1830,7 +1830,7 @@ returns table (
   state text
 )
 as $function$
-  BEGIN
+BEGIN
     RETURN QUERY EXECUTE
       format(
         'SELECT  b.relname,
@@ -1841,7 +1841,7 @@ as $function$
            FROM %I b JOIN pg_class a ON b.relname = a.relname
            ORDER BY 1;', tabname);
   END
-  $function$
+$function$
 language plpgsql;
 
 select create_relfilenode_part('reindex_index_status', 'concur_reindex_part_index');

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_index_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_index_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/create_index.sql
-snapshot_kind: text
 ---
 create index "onek_unique1" on onek using btree (unique1 int4_ops);
 
@@ -845,7 +844,8 @@ as $function$
 BEGIN
   EXECUTE 'SELECT txid_current()';
   RETURN true;
-END; $function$;
+END;
+$function$;
 
 create index
 concurrently "concur_index8"
@@ -2308,7 +2308,7 @@ rollback;
 create or replace function create_relfilenode_part(relname text, indname text)
 returns void
 as $function$
-  BEGIN
+BEGIN
   EXECUTE format('
     CREATE TABLE %I AS
       SELECT oid, relname, relfilenode, relkind, reltoastrelid
@@ -2317,7 +2317,7 @@ as $function$
          (SELECT relid FROM pg_partition_tree(''%I''));',
 	 relname, indname);
   END
-  $function$
+$function$
 language plpgsql;
 
 create or replace function compare_relfilenode_part(tabname text)
@@ -2327,7 +2327,7 @@ returns table (
   state text
 )
 as $function$
-  BEGIN
+BEGIN
     RETURN QUERY EXECUTE
       format(
         'SELECT  b.relname,
@@ -2338,7 +2338,7 @@ as $function$
            FROM %I b JOIN pg_class a ON b.relname = a.relname
            ORDER BY 1;', tabname);
   END
-  $function$
+$function$
 language plpgsql;
 
 select

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_operator_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_operator_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/create_operator.sql
-snapshot_kind: text
 ---
 create operator ## (LEFTARG = path, RIGHTARG = path, FUNCTION = path_inter, COMMUTATOR = ##);
 
@@ -42,7 +41,8 @@ select 2 <> 1, 2 <> 2;
 select 2 <> 1;
 
 do
-$do$ -- use DO to protect -- from psql
+$do$
+-- use DO to protect -- from psql
   declare r boolean;
   begin
     execute $e$ select 2 !=-- comment
@@ -96,7 +96,7 @@ begin;
 create or replace function fn_op2(boolean, boolean)
 returns boolean
 as $function$
-    SELECT NULL::BOOLEAN;
+SELECT NULL::BOOLEAN;
 $function$
 language sql
 immutable;
@@ -132,7 +132,7 @@ create type type_op3 as enum ('new', 'open', 'closed');
 create function fn_op3(type_op3, bigint)
 returns bigint
 as $function$
-    SELECT NULL::int8;
+SELECT NULL::int8;
 $function$
 language sql
 immutable;
@@ -156,7 +156,7 @@ create type type_op4 as enum ('new', 'open', 'closed');
 create function fn_op4(bigint, type_op4)
 returns bigint
 as $function$
-    SELECT NULL::int8;
+SELECT NULL::int8;
 $function$
 language sql
 immutable;
@@ -180,7 +180,7 @@ create type type_op5 as enum ('new', 'open', 'closed');
 create function fn_op5(bigint, bigint)
 returns bigint
 as $function$
-    SELECT NULL::int8;
+SELECT NULL::int8;
 $function$
 language sql
 immutable;
@@ -204,7 +204,7 @@ create type type_op6 as enum ('new', 'open', 'closed');
 create function fn_op6(bigint, bigint)
 returns type_op6
 as $function$
-    SELECT NULL::type_op6;
+SELECT NULL::type_op6;
 $function$
 language sql
 immutable;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_operator_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_operator_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/create_operator.sql
-snapshot_kind: text
 ---
 create operator ## (LEFTARG = path,
 RIGHTARG = path,
@@ -45,7 +44,8 @@ select 2 <> 1, 2 <> 2;
 select 2 <> 1;
 
 do
-$do$ -- use DO to protect -- from psql
+$do$
+-- use DO to protect -- from psql
   declare r boolean;
   begin
     execute $e$ select 2 !=-- comment
@@ -99,7 +99,7 @@ begin;
 create or replace function fn_op2(boolean, boolean)
 returns boolean
 as $function$
-    SELECT NULL::BOOLEAN;
+SELECT NULL::BOOLEAN;
 $function$
 language sql
 immutable;
@@ -137,7 +137,7 @@ create type type_op3 as enum ('new', 'open', 'closed');
 create function fn_op3(type_op3, bigint)
 returns bigint
 as $function$
-    SELECT NULL::int8;
+SELECT NULL::int8;
 $function$
 language sql
 immutable;
@@ -161,7 +161,7 @@ create type type_op4 as enum ('new', 'open', 'closed');
 create function fn_op4(bigint, type_op4)
 returns bigint
 as $function$
-    SELECT NULL::int8;
+SELECT NULL::int8;
 $function$
 language sql
 immutable;
@@ -185,7 +185,7 @@ create type type_op5 as enum ('new', 'open', 'closed');
 create function fn_op5(bigint, bigint)
 returns bigint
 as $function$
-    SELECT NULL::int8;
+SELECT NULL::int8;
 $function$
 language sql
 immutable;
@@ -209,7 +209,7 @@ create type type_op6 as enum ('new', 'open', 'closed');
 create function fn_op6(bigint, bigint)
 returns type_op6
 as $function$
-    SELECT NULL::type_op6;
+SELECT NULL::type_op6;
 $function$
 language sql
 immutable;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_procedure_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_procedure_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/create_procedure.sql
-snapshot_kind: text
 ---
 call nonexistent();
 
@@ -10,7 +9,9 @@ call random();
 create function cp_testfunc1(a int)
 returns int
 language sql
-as $function$ SELECT a $function$;
+as $function$
+SELECT a
+$function$;
 
 create table cp_test (
   a int,
@@ -182,7 +183,9 @@ call ptest9(1. / 0.);
 
 create procedure ptest10(out a int, in b int, in c int)
 language sql
-as $procedure$ SELECT b - c $procedure$;
+as $procedure$
+SELECT b - c
+$procedure$;
 
 call ptest10(null, 7, 4);
 
@@ -196,13 +199,17 @@ call ptest10("b" := 8, "c" := 2, "a" := 0);
 
 create procedure ptest11(out a int, variadic b int[])
 language sql
-as $procedure$ SELECT b[1] + b[2] $procedure$;
+as $procedure$
+SELECT b[1] + b[2]
+$procedure$;
 
 call ptest11(null, 11, 12, 13);
 
 create procedure ptest10(in a int, in b int, in c int)
 language sql
-as $procedure$ SELECT a + b - c $procedure$;
+as $procedure$
+SELECT a + b - c
+$procedure$;
 
 drop procedure ptest10;
 
@@ -231,20 +238,28 @@ call SUM(1);
 create procedure ptestx()
 language sql
 window
-as $procedure$ INSERT INTO cp_test VALUES (1, 'a') $procedure$;
+as $procedure$
+INSERT INTO cp_test VALUES (1, 'a')
+$procedure$;
 
 create procedure ptestx()
 language sql
 strict
-as $procedure$ INSERT INTO cp_test VALUES (1, 'a') $procedure$;
+as $procedure$
+INSERT INTO cp_test VALUES (1, 'a')
+$procedure$;
 
 create procedure ptestx(variadic a int[], out b int)
 language sql
-as $procedure$ SELECT a[1] $procedure$;
+as $procedure$
+SELECT a[1]
+$procedure$;
 
 create procedure ptestx(a int default 42, out b int)
 language sql
-as $procedure$ SELECT a $procedure$;
+as $procedure$
+SELECT a
+$procedure$;
 
 alter procedure ptest1(text) strict;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_procedure_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_procedure_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/create_procedure.sql
-snapshot_kind: text
 ---
 call nonexistent();
 
@@ -10,7 +9,9 @@ call random();
 create function cp_testfunc1(a int)
 returns int
 language sql
-as $function$ SELECT a $function$;
+as $function$
+SELECT a
+$function$;
 
 create table cp_test (
   a int,
@@ -187,7 +188,9 @@ call ptest9(1. / 0.);
 
 create procedure ptest10(out a int, in b int, in c int)
 language sql
-as $procedure$ SELECT b - c $procedure$;
+as $procedure$
+SELECT b - c
+$procedure$;
 
 call ptest10(null, 7, 4);
 
@@ -201,13 +204,17 @@ call ptest10("b" := 8, "c" := 2, "a" := 0);
 
 create procedure ptest11(out a int, variadic b int[])
 language sql
-as $procedure$ SELECT b[1] + b[2] $procedure$;
+as $procedure$
+SELECT b[1] + b[2]
+$procedure$;
 
 call ptest11(null, 11, 12, 13);
 
 create procedure ptest10(in a int, in b int, in c int)
 language sql
-as $procedure$ SELECT a + b - c $procedure$;
+as $procedure$
+SELECT a + b - c
+$procedure$;
 
 drop procedure ptest10;
 
@@ -236,20 +243,28 @@ call SUM(1);
 create procedure ptestx()
 language sql
 window
-as $procedure$ INSERT INTO cp_test VALUES (1, 'a') $procedure$;
+as $procedure$
+INSERT INTO cp_test VALUES (1, 'a')
+$procedure$;
 
 create procedure ptestx()
 language sql
 strict
-as $procedure$ INSERT INTO cp_test VALUES (1, 'a') $procedure$;
+as $procedure$
+INSERT INTO cp_test VALUES (1, 'a')
+$procedure$;
 
 create procedure ptestx(variadic a int[], out b int)
 language sql
-as $procedure$ SELECT a[1] $procedure$;
+as $procedure$
+SELECT a[1]
+$procedure$;
 
 create procedure ptestx(a int default 42, out b int)
 language sql
-as $procedure$ SELECT a $procedure$;
+as $procedure$
+SELECT a
+$procedure$;
 
 alter procedure ptest1(text) strict;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_table_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_table_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/create_table.sql
-snapshot_kind: text
 ---
 create table unknowntab (u unknown);
 
@@ -189,7 +188,9 @@ partition by LIST(a1, a2);
 
 create function retset(a int)
 returns setof int
-as $function$ SELECT 1; $function$
+as $function$
+SELECT 1;
+$function$
 language sql
 immutable;
 
@@ -215,7 +216,9 @@ partition by range((42));
 
 create function const_func()
 returns int
-as $function$ SELECT 1; $function$
+as $function$
+SELECT 1;
+$function$
 language sql
 immutable;
 
@@ -244,7 +247,9 @@ partition by range(a, ('unknown'));
 
 create function immut_func(a int)
 returns int
-as $function$ SELECT a + random()::int; $function$
+as $function$
+SELECT a + random()::int;
+$function$
 language sql;
 
 create table partitioned (a int)
@@ -272,7 +277,9 @@ partition by range(a);
 
 create function plusone(a int)
 returns int
-as $function$ SELECT a+1; $function$
+as $function$
+SELECT a+1;
+$function$
 language sql;
 
 create table partitioned (
@@ -815,7 +822,9 @@ drop table range_parted4;
 create function my_int4_sort(int, int)
 returns int
 language sql
-as $function$ SELECT CASE WHEN $1 = $2 THEN 0 WHEN $1 > $2 THEN 1 ELSE -1 END; $function$;
+as $function$
+SELECT CASE WHEN $1 = $2 THEN 0 WHEN $1 > $2 THEN 1 ELSE -1 END;
+$function$;
 
 create operator class test_int4_ops
   for type int
@@ -904,10 +913,11 @@ create or replace function func_part_create()
 returns trigger
 language plpgsql
 as $function$
-  begin
+begin
     execute 'create table tab_part_create_1 partition of tab_part_create for values in (1)';
     return null;
-  end $function$;
+  end
+$function$;
 
 create trigger trig_part_create
 before insert

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_table_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_table_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/create_table.sql
-snapshot_kind: text
 ---
 create table unknowntab (u unknown);
 
@@ -196,7 +195,9 @@ partition by LIST(a1, a2);
 
 create function retset(a int)
 returns setof int
-as $function$ SELECT 1; $function$
+as $function$
+SELECT 1;
+$function$
 language sql
 immutable;
 
@@ -222,7 +223,9 @@ partition by range((42));
 
 create function const_func()
 returns int
-as $function$ SELECT 1; $function$
+as $function$
+SELECT 1;
+$function$
 language sql
 immutable;
 
@@ -251,7 +254,9 @@ partition by range(a, ('unknown'));
 
 create function immut_func(a int)
 returns int
-as $function$ SELECT a + random()::int; $function$
+as $function$
+SELECT a + random()::int;
+$function$
 language sql;
 
 create table partitioned (a int)
@@ -279,7 +284,9 @@ partition by range(a);
 
 create function plusone(a int)
 returns int
-as $function$ SELECT a+1; $function$
+as $function$
+SELECT a+1;
+$function$
 language sql;
 
 create table partitioned (
@@ -938,7 +945,9 @@ drop table range_parted4;
 create function my_int4_sort(int, int)
 returns int
 language sql
-as $function$ SELECT CASE WHEN $1 = $2 THEN 0 WHEN $1 > $2 THEN 1 ELSE -1 END; $function$;
+as $function$
+SELECT CASE WHEN $1 = $2 THEN 0 WHEN $1 > $2 THEN 1 ELSE -1 END;
+$function$;
 
 create operator class test_int4_ops
   for type int
@@ -1033,10 +1042,11 @@ create or replace function func_part_create()
 returns trigger
 language plpgsql
 as $function$
-  begin
+begin
     execute 'create table tab_part_create_1 partition of tab_part_create for values in (1)';
     return null;
-  end $function$;
+  end
+$function$;
 
 create trigger trig_part_create
 before insert

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_type_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_type_100.snap
@@ -1,32 +1,39 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/create_type.sql
-snapshot_kind: text
 ---
 create function widget_in(cstring)
 returns widget
-as $function$regresslib$function$
+as $function$
+regresslib
+$function$
 language c
 strict
 immutable;
 
 create function widget_out(widget)
 returns cstring
-as $function$regresslib$function$
+as $function$
+regresslib
+$function$
 language c
 strict
 immutable;
 
 create function int44in(cstring)
 returns city_budget
-as $function$regresslib$function$
+as $function$
+regresslib
+$function$
 language c
 strict
 immutable;
 
 create function int44out(city_budget)
 returns cstring
-as $function$regresslib$function$
+as $function$
+regresslib
+$function$
 language c
 strict
 immutable;
@@ -65,28 +72,36 @@ create type text_w_default;
 
 create function int42_in(cstring)
 returns int42
-as $function$int4in$function$
+as $function$
+int4in
+$function$
 language internal
 strict
 immutable;
 
 create function int42_out(int42)
 returns cstring
-as $function$int4out$function$
+as $function$
+int4out
+$function$
 language internal
 strict
 immutable;
 
 create function text_w_default_in(cstring)
 returns text_w_default
-as $function$textin$function$
+as $function$
+textin
+$function$
 language internal
 strict
 immutable;
 
 create function text_w_default_out(text_w_default)
 returns cstring
-as $function$textout$function$
+as $function$
+textout
+$function$
 language internal
 strict
 immutable;
@@ -139,7 +154,7 @@ create type default_test_row as (f1 text_w_default, f2 int42);
 create function get_default_test()
 returns setof default_test_row
 as $function$
-  SELECT * FROM default_test;
+SELECT * FROM default_test;
 $function$
 language sql;
 
@@ -167,14 +182,18 @@ create type base_type;
 
 create function base_fn_in(cstring)
 returns base_type
-as $function$boolin$function$
+as $function$
+boolin
+$function$
 language internal
 immutable
 strict;
 
 create function base_fn_out(base_type)
 returns cstring
-as $function$boolout$function$
+as $function$
+boolout
+$function$
 language internal
 immutable
 strict;
@@ -225,7 +244,9 @@ select pg_input_is_valid('("(1,2)")', 'mytab');
 
 create function pt_in_widget(point, widget)
 returns boolean
-as $function$regresslib$function$
+as $function$
+regresslib
+$function$
 language c
 strict;
 
@@ -268,7 +289,9 @@ language internal
 immutable
 parallel SAFE
 strict
-as $function$varcharin$function$;
+as $function$
+varcharin
+$function$;
 
 create function myvarcharout(myvarchar)
 returns cstring
@@ -276,7 +299,9 @@ language internal
 immutable
 parallel SAFE
 strict
-as $function$varcharout$function$;
+as $function$
+varcharout
+$function$;
 
 create function myvarcharsend(myvarchar)
 returns bytea
@@ -284,7 +309,9 @@ language internal
 stable
 parallel SAFE
 strict
-as $function$varcharsend$function$;
+as $function$
+varcharsend
+$function$;
 
 create function myvarcharrecv(internal, oid, int)
 returns myvarchar
@@ -292,7 +319,9 @@ language internal
 stable
 parallel SAFE
 strict
-as $function$varcharrecv$function$;
+as $function$
+varcharrecv
+$function$;
 
 alter type myvarchar set (storage = extended);
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_type_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_type_80.snap
@@ -1,32 +1,39 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/create_type.sql
-snapshot_kind: text
 ---
 create function widget_in(cstring)
 returns widget
-as $function$regresslib$function$
+as $function$
+regresslib
+$function$
 language c
 strict
 immutable;
 
 create function widget_out(widget)
 returns cstring
-as $function$regresslib$function$
+as $function$
+regresslib
+$function$
 language c
 strict
 immutable;
 
 create function int44in(cstring)
 returns city_budget
-as $function$regresslib$function$
+as $function$
+regresslib
+$function$
 language c
 strict
 immutable;
 
 create function int44out(city_budget)
 returns cstring
-as $function$regresslib$function$
+as $function$
+regresslib
+$function$
 language c
 strict
 immutable;
@@ -65,28 +72,36 @@ create type text_w_default;
 
 create function int42_in(cstring)
 returns int42
-as $function$int4in$function$
+as $function$
+int4in
+$function$
 language internal
 strict
 immutable;
 
 create function int42_out(int42)
 returns cstring
-as $function$int4out$function$
+as $function$
+int4out
+$function$
 language internal
 strict
 immutable;
 
 create function text_w_default_in(cstring)
 returns text_w_default
-as $function$textin$function$
+as $function$
+textin
+$function$
 language internal
 strict
 immutable;
 
 create function text_w_default_out(text_w_default)
 returns cstring
-as $function$textout$function$
+as $function$
+textout
+$function$
 language internal
 strict
 immutable;
@@ -149,7 +164,7 @@ create type default_test_row as (f1 text_w_default, f2 int42);
 create function get_default_test()
 returns setof default_test_row
 as $function$
-  SELECT * FROM default_test;
+SELECT * FROM default_test;
 $function$
 language sql;
 
@@ -177,14 +192,18 @@ create type base_type;
 
 create function base_fn_in(cstring)
 returns base_type
-as $function$boolin$function$
+as $function$
+boolin
+$function$
 language internal
 immutable
 strict;
 
 create function base_fn_out(base_type)
 returns cstring
-as $function$boolout$function$
+as $function$
+boolout
+$function$
 language internal
 immutable
 strict;
@@ -235,7 +254,9 @@ select pg_input_is_valid('("(1,2)")', 'mytab');
 
 create function pt_in_widget(point, widget)
 returns boolean
-as $function$regresslib$function$
+as $function$
+regresslib
+$function$
 language c
 strict;
 
@@ -280,7 +301,9 @@ language internal
 immutable
 parallel SAFE
 strict
-as $function$varcharin$function$;
+as $function$
+varcharin
+$function$;
 
 create function myvarcharout(myvarchar)
 returns cstring
@@ -288,7 +311,9 @@ language internal
 immutable
 parallel SAFE
 strict
-as $function$varcharout$function$;
+as $function$
+varcharout
+$function$;
 
 create function myvarcharsend(myvarchar)
 returns bytea
@@ -296,7 +321,9 @@ language internal
 stable
 parallel SAFE
 strict
-as $function$varcharsend$function$;
+as $function$
+varcharsend
+$function$;
 
 create function myvarcharrecv(internal, oid, int)
 returns myvarchar
@@ -304,7 +331,9 @@ language internal
 stable
 parallel SAFE
 strict
-as $function$varcharrecv$function$;
+as $function$
+varcharrecv
+$function$;
 
 alter type myvarchar set (storage = extended);
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_view_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_view_100.snap
@@ -1,11 +1,12 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/create_view.sql
-snapshot_kind: text
 ---
 create function interpt_pp(path, path)
 returns point
-as $function$regresslib$function$
+as $function$
+regresslib
+$function$
 language c
 strict;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_view_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__create_view_80.snap
@@ -1,11 +1,12 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/create_view.sql
-snapshot_kind: text
 ---
 create function interpt_pp(path, path)
 returns point
-as $function$regresslib$function$
+as $function$
+regresslib
+$function$
 language c
 strict;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__dependency_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__dependency_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/dependency.sql
-snapshot_kind: text
 ---
 create user regress_dep_user;
 
@@ -113,7 +112,9 @@ grant all on tables to regress_dep_user2;
 create function deptest_func()
 returns void
 language plpgsql
-as $function$ BEGIN END; $function$;
+as $function$
+BEGIN END;
+$function$;
 
 create type deptest_enum as enum ('red');
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__dependency_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__dependency_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/dependency.sql
-snapshot_kind: text
 ---
 create user regress_dep_user;
 
@@ -115,7 +114,9 @@ to regress_dep_user2;
 create function deptest_func()
 returns void
 language plpgsql
-as $function$ BEGIN END; $function$;
+as $function$
+BEGIN END;
+$function$;
 
 create type deptest_enum as enum ('red');
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__domain_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__domain_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/domain.sql
-snapshot_kind: text
 ---
 create domain domaindroptest as int;
 
@@ -220,7 +219,9 @@ do instead
 
 create function makedcomp(r double precision, i double precision)
 returns dcomptype
-as $function$select row(r, i)$function$
+as $function$
+select row(r, i)
+$function$
 language sql;
 
 select makedcomp(1, 2);
@@ -780,7 +781,8 @@ as $function$
 declare v pos_int;
 begin
     return p1;
-end$function$
+end
+$function$
 language plpgsql;
 
 select doubledecrement(3);
@@ -791,7 +793,8 @@ as $function$
 declare v pos_int := 0;
 begin
     return p1;
-end$function$
+end
+$function$
 language plpgsql;
 
 select doubledecrement(3);
@@ -803,7 +806,8 @@ declare v pos_int := 1;
 begin
     v := p1 - 1;
     return v - 1;
-end$function$
+end
+$function$
 language plpgsql;
 
 select doubledecrement(null);
@@ -902,7 +906,8 @@ declare
 begin
   x[1] := $1;
   return x[1];
-end$function$
+end
+$function$
 language plpgsql;
 
 select array_elem_check(121.00);
@@ -919,7 +924,8 @@ declare
 begin
   x[1] := $1;
   return x[1];
-end$function$
+end
+$function$
 language plpgsql;
 
 select array_elem_check(121.00);
@@ -936,7 +942,8 @@ declare
 begin
   x[1] := $1;
   return x[1];
-end$function$
+end
+$function$
 language plpgsql;
 
 select array_elem_check(121.00);
@@ -971,7 +978,8 @@ declare
 begin
   x[2] := $1;
   return x[2];
-end$function$
+end
+$function$
 language plpgsql;
 
 select array_elem_check(3);
@@ -1033,7 +1041,9 @@ drop domain di;
 create function sql_is_distinct_from(anyelement, anyelement)
 returns boolean
 language sql
-as $function$select $1 is distinct from $2 limit 1$function$;
+as $function$
+select $1 is distinct from $2 limit 1
+$function$;
 
 create domain inotnull as int check (sql_is_distinct_from(value, null));
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__domain_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__domain_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/domain.sql
-snapshot_kind: text
 ---
 create domain domaindroptest as int;
 
@@ -226,7 +225,9 @@ do instead
 
 create function makedcomp(r double precision, i double precision)
 returns dcomptype
-as $function$select row(r, i)$function$
+as $function$
+select row(r, i)
+$function$
 language sql;
 
 select makedcomp(1, 2);
@@ -818,7 +819,8 @@ as $function$
 declare v pos_int;
 begin
     return p1;
-end$function$
+end
+$function$
 language plpgsql;
 
 select doubledecrement(3);
@@ -829,7 +831,8 @@ as $function$
 declare v pos_int := 0;
 begin
     return p1;
-end$function$
+end
+$function$
 language plpgsql;
 
 select doubledecrement(3);
@@ -841,7 +844,8 @@ declare v pos_int := 1;
 begin
     v := p1 - 1;
     return v - 1;
-end$function$
+end
+$function$
 language plpgsql;
 
 select doubledecrement(null);
@@ -940,7 +944,8 @@ declare
 begin
   x[1] := $1;
   return x[1];
-end$function$
+end
+$function$
 language plpgsql;
 
 select array_elem_check(121.00);
@@ -957,7 +962,8 @@ declare
 begin
   x[1] := $1;
   return x[1];
-end$function$
+end
+$function$
 language plpgsql;
 
 select array_elem_check(121.00);
@@ -974,7 +980,8 @@ declare
 begin
   x[1] := $1;
   return x[1];
-end$function$
+end
+$function$
 language plpgsql;
 
 select array_elem_check(121.00);
@@ -1009,7 +1016,8 @@ declare
 begin
   x[2] := $1;
   return x[2];
-end$function$
+end
+$function$
 language plpgsql;
 
 select array_elem_check(3);
@@ -1071,7 +1079,9 @@ drop domain di;
 create function sql_is_distinct_from(anyelement, anyelement)
 returns boolean
 language sql
-as $function$select $1 is distinct from $2 limit 1$function$;
+as $function$
+select $1 is distinct from $2 limit 1
+$function$;
 
 create domain inotnull as int check (sql_is_distinct_from(value, null));
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__drop_if_exists_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__drop_if_exists_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/drop_if_exists.sql
-snapshot_kind: text
 ---
 drop table test_exists;
 
@@ -309,12 +308,16 @@ drop view if exists no_such_schema.foo;
 
 create function test_ambiguous_funcname(int)
 returns int
-as $function$ select $1; $function$
+as $function$
+select $1;
+$function$
 language sql;
 
 create function test_ambiguous_funcname(text)
 returns text
-as $function$ select $1; $function$
+as $function$
+select $1;
+$function$
 language sql;
 
 drop function test_ambiguous_funcname;
@@ -326,11 +329,15 @@ drop function test_ambiguous_funcname(int);
 drop function test_ambiguous_funcname(text);
 
 create procedure test_ambiguous_procname(int)
-as $procedure$ begin end; $procedure$
+as $procedure$
+begin end;
+$procedure$
 language plpgsql;
 
 create procedure test_ambiguous_procname(text)
-as $procedure$ begin end; $procedure$
+as $procedure$
+begin end;
+$procedure$
 language plpgsql;
 
 drop procedure test_ambiguous_procname;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__drop_if_exists_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__drop_if_exists_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/drop_if_exists.sql
-snapshot_kind: text
 ---
 drop table test_exists;
 
@@ -315,12 +314,16 @@ drop view if exists no_such_schema.foo;
 
 create function test_ambiguous_funcname(int)
 returns int
-as $function$ select $1; $function$
+as $function$
+select $1;
+$function$
 language sql;
 
 create function test_ambiguous_funcname(text)
 returns text
-as $function$ select $1; $function$
+as $function$
+select $1;
+$function$
 language sql;
 
 drop function test_ambiguous_funcname;
@@ -332,11 +335,15 @@ drop function test_ambiguous_funcname(int);
 drop function test_ambiguous_funcname(text);
 
 create procedure test_ambiguous_procname(int)
-as $procedure$ begin end; $procedure$
+as $procedure$
+begin end;
+$procedure$
 language plpgsql;
 
 create procedure test_ambiguous_procname(text)
-as $procedure$ begin end; $procedure$
+as $procedure$
+begin end;
+$procedure$
 language plpgsql;
 
 drop procedure test_ambiguous_procname;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__equivclass_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__equivclass_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/equivclass.sql
-snapshot_kind: text
 ---
 create type int8alias1;
 
@@ -10,14 +9,18 @@ returns int8alias1
 strict
 immutable
 language internal
-as $function$int8in$function$;
+as $function$
+int8in
+$function$;
 
 create function int8alias1out(int8alias1)
 returns cstring
 strict
 immutable
 language internal
-as $function$int8out$function$;
+as $function$
+int8out
+$function$;
 
 create type int8alias1 (input = int8alias1in, output = int8alias1out, like = bigint);
 
@@ -28,14 +31,18 @@ returns int8alias2
 strict
 immutable
 language internal
-as $function$int8in$function$;
+as $function$
+int8in
+$function$;
 
 create function int8alias2out(int8alias2)
 returns cstring
 strict
 immutable
 language internal
-as $function$int8out$function$;
+as $function$
+int8out
+$function$;
 
 create type int8alias2 (input = int8alias2in, output = int8alias2out, like = bigint);
 
@@ -52,7 +59,9 @@ returns boolean
 strict
 immutable
 language internal
-as $function$int8eq$function$;
+as $function$
+int8eq
+$function$;
 
 create operator = (PROCEDURE = int8alias1eq,
 LEFTARG = int8alias1,
@@ -69,7 +78,9 @@ returns boolean
 strict
 immutable
 language internal
-as $function$int8eq$function$;
+as $function$
+int8eq
+$function$;
 
 create operator = (PROCEDURE = int8alias2eq,
 LEFTARG = int8alias2,
@@ -86,7 +97,9 @@ returns boolean
 strict
 immutable
 language internal
-as $function$int8eq$function$;
+as $function$
+int8eq
+$function$;
 
 create operator = (PROCEDURE = int8alias1eq,
 LEFTARG = bigint,
@@ -102,7 +115,9 @@ returns boolean
 strict
 immutable
 language internal
-as $function$int8eq$function$;
+as $function$
+int8eq
+$function$;
 
 create operator = (PROCEDURE = int8alias1eq,
 LEFTARG = int8alias1,
@@ -118,7 +133,9 @@ returns boolean
 strict
 immutable
 language internal
-as $function$int8lt$function$;
+as $function$
+int8lt
+$function$;
 
 create operator < (PROCEDURE = int8alias1lt, LEFTARG = int8alias1, RIGHTARG = int8alias1);
 
@@ -129,7 +146,9 @@ returns int
 strict
 immutable
 language internal
-as $function$btint8cmp$function$;
+as $function$
+btint8cmp
+$function$;
 
 alter operator family integer_ops using btree add function 1 int8alias1cmp(bigint, int8alias1);
 
@@ -454,7 +473,9 @@ returns int
 strict
 immutable
 language internal
-as $function$hashint8$function$;
+as $function$
+hashint8
+$function$;
 
 alter operator family integer_ops using hash add function 1 hashint8alias1(int8alias1);
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__equivclass_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__equivclass_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/equivclass.sql
-snapshot_kind: text
 ---
 create type int8alias1;
 
@@ -10,14 +9,18 @@ returns int8alias1
 strict
 immutable
 language internal
-as $function$int8in$function$;
+as $function$
+int8in
+$function$;
 
 create function int8alias1out(int8alias1)
 returns cstring
 strict
 immutable
 language internal
-as $function$int8out$function$;
+as $function$
+int8out
+$function$;
 
 create type int8alias1 (
   input = int8alias1in,
@@ -32,14 +35,18 @@ returns int8alias2
 strict
 immutable
 language internal
-as $function$int8in$function$;
+as $function$
+int8in
+$function$;
 
 create function int8alias2out(int8alias2)
 returns cstring
 strict
 immutable
 language internal
-as $function$int8out$function$;
+as $function$
+int8out
+$function$;
 
 create type int8alias2 (
   input = int8alias2in,
@@ -60,7 +67,9 @@ returns boolean
 strict
 immutable
 language internal
-as $function$int8eq$function$;
+as $function$
+int8eq
+$function$;
 
 create operator = (PROCEDURE = int8alias1eq,
 LEFTARG = int8alias1,
@@ -78,7 +87,9 @@ returns boolean
 strict
 immutable
 language internal
-as $function$int8eq$function$;
+as $function$
+int8eq
+$function$;
 
 create operator = (PROCEDURE = int8alias2eq,
 LEFTARG = int8alias2,
@@ -96,7 +107,9 @@ returns boolean
 strict
 immutable
 language internal
-as $function$int8eq$function$;
+as $function$
+int8eq
+$function$;
 
 create operator = (PROCEDURE = int8alias1eq,
 LEFTARG = bigint,
@@ -113,7 +126,9 @@ returns boolean
 strict
 immutable
 language internal
-as $function$int8eq$function$;
+as $function$
+int8eq
+$function$;
 
 create operator = (PROCEDURE = int8alias1eq,
 LEFTARG = int8alias1,
@@ -130,7 +145,9 @@ returns boolean
 strict
 immutable
 language internal
-as $function$int8lt$function$;
+as $function$
+int8lt
+$function$;
 
 create operator < (PROCEDURE = int8alias1lt,
 LEFTARG = int8alias1,
@@ -144,7 +161,9 @@ returns int
 strict
 immutable
 language internal
-as $function$btint8cmp$function$;
+as $function$
+btint8cmp
+$function$;
 
 alter operator family integer_ops using btree
   add function 1 int8alias1cmp(bigint, int8alias1);
@@ -494,7 +513,9 @@ returns int
 strict
 immutable
 language internal
-as $function$hashint8$function$;
+as $function$
+hashint8
+$function$;
 
 alter operator family integer_ops using hash
   add function 1 hashint8alias1(int8alias1);

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__event_trigger_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__event_trigger_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/event_trigger.sql
-snapshot_kind: text
 ---
 create event trigger "regress_event_trigger" on ddl_command_start execute function pg_backend_pid();
 
@@ -18,13 +17,16 @@ select test_event_trigger();
 
 create function test_event_trigger_arg(name text)
 returns event_trigger
-as $function$ BEGIN RETURN 1; END $function$
+as $function$
+BEGIN RETURN 1; END
+$function$
 language plpgsql;
 
 create function test_event_trigger_sql()
 returns event_trigger
 as $function$
-SELECT 1 $function$
+SELECT 1
+$function$
 language sql;
 
 create event trigger "regress_event_trigger"
@@ -125,7 +127,8 @@ as $function$
 begin
   create table event_trigger_fire6 (a int);
   return 0;
-end $function$;
+end
+$function$;
 
 select f1();
 
@@ -134,7 +137,8 @@ language plpgsql
 as $procedure$
 begin
   create table event_trigger_fire7 (a int);
-end $procedure$;
+end
+$procedure$;
 
 call p1();
 
@@ -219,7 +223,9 @@ create or replace function schema_two.add(int, int)
 returns int
 language plpgsql
 called on null input
-as $function$ BEGIN RETURN coalesce($1,0) + coalesce($2,0); END; $function$;
+as $function$
+BEGIN RETURN coalesce($1,0) + coalesce($2,0); END;
+$function$;
 
 create aggregate schema_two.newton (basetype = int, sfunc = schema_two.add, stype = int);
 
@@ -342,7 +348,8 @@ BEGIN
         r.object_identity, r.schema_name, r.object_name,
         r.address_names, r.address_args;
     END LOOP;
-END; $function$;
+END;
+$function$;
 
 create event trigger "regress_event_trigger_report_dropped"
 on sql_drop
@@ -359,7 +366,8 @@ BEGIN
         RAISE NOTICE 'END: command_tag=% type=% identity=%',
             r.command_tag, r.object_type, r.object_identity;
     END LOOP;
-END; $function$;
+END;
+$function$;
 
 create event trigger "regress_event_trigger_report_end"
 on ddl_command_end
@@ -434,7 +442,8 @@ BEGIN
         r.object_identity, r.schema_name, r.object_name,
         r.address_names, r.address_args;
     END LOOP;
-END; $function$;
+END;
+$function$;
 
 create function event_trigger_dummy_trigger()
 returns trigger
@@ -442,7 +451,8 @@ language plpgsql
 as $function$
 BEGIN
     RETURN new;
-END; $function$;
+END;
+$function$;
 
 create table evtrg_nontemp_table (
   f1 int primary key,
@@ -627,7 +637,9 @@ execute function reindex_end_command();
 
 create function reindex_end_command_snap()
 returns event_trigger
-as $function$ BEGIN PERFORM 1; END $function$
+as $function$
+BEGIN PERFORM 1; END
+$function$
 language plpgsql;
 
 create event trigger "regress_reindex_end_snap"

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__event_trigger_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__event_trigger_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/event_trigger.sql
-snapshot_kind: text
 ---
 create event trigger "regress_event_trigger"
 on ddl_command_start
@@ -20,13 +19,16 @@ select test_event_trigger();
 
 create function test_event_trigger_arg(name text)
 returns event_trigger
-as $function$ BEGIN RETURN 1; END $function$
+as $function$
+BEGIN RETURN 1; END
+$function$
 language plpgsql;
 
 create function test_event_trigger_sql()
 returns event_trigger
 as $function$
-SELECT 1 $function$
+SELECT 1
+$function$
 language sql;
 
 create event trigger "regress_event_trigger"
@@ -127,7 +129,8 @@ as $function$
 begin
   create table event_trigger_fire6 (a int);
   return 0;
-end $function$;
+end
+$function$;
 
 select f1();
 
@@ -136,7 +139,8 @@ language plpgsql
 as $procedure$
 begin
   create table event_trigger_fire7 (a int);
-end $procedure$;
+end
+$procedure$;
 
 call p1();
 
@@ -225,7 +229,9 @@ create or replace function schema_two.add(int, int)
 returns int
 language plpgsql
 called on null input
-as $function$ BEGIN RETURN coalesce($1,0) + coalesce($2,0); END; $function$;
+as $function$
+BEGIN RETURN coalesce($1,0) + coalesce($2,0); END;
+$function$;
 
 create aggregate schema_two.newton (
   basetype = int,
@@ -364,7 +370,8 @@ BEGIN
         r.object_identity, r.schema_name, r.object_name,
         r.address_names, r.address_args;
     END LOOP;
-END; $function$;
+END;
+$function$;
 
 create event trigger "regress_event_trigger_report_dropped"
 on sql_drop
@@ -381,7 +388,8 @@ BEGIN
         RAISE NOTICE 'END: command_tag=% type=% identity=%',
             r.command_tag, r.object_type, r.object_identity;
     END LOOP;
-END; $function$;
+END;
+$function$;
 
 create event trigger "regress_event_trigger_report_end"
 on ddl_command_end
@@ -471,7 +479,8 @@ BEGIN
         r.object_identity, r.schema_name, r.object_name,
         r.address_names, r.address_args;
     END LOOP;
-END; $function$;
+END;
+$function$;
 
 create function event_trigger_dummy_trigger()
 returns trigger
@@ -479,7 +488,8 @@ language plpgsql
 as $function$
 BEGIN
     RETURN new;
-END; $function$;
+END;
+$function$;
 
 create table evtrg_nontemp_table (
   f1 int primary key,
@@ -669,7 +679,9 @@ execute function reindex_end_command();
 
 create function reindex_end_command_snap()
 returns event_trigger
-as $function$ BEGIN PERFORM 1; END $function$
+as $function$
+BEGIN PERFORM 1; END
+$function$
 language plpgsql;
 
 create event trigger "regress_reindex_end_snap"

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__explain_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__explain_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/explain.sql
-snapshot_kind: text
 ---
 create function explain_filter(text)
 returns setof text
@@ -176,7 +175,9 @@ create temporary table t1 (f1 double precision);
 create function pg_temp.mysin(double precision)
 returns double precision
 language plpgsql
-as $function$begin return sin($1); end$function$;
+as $function$
+begin return sin($1); end
+$function$;
 
 select explain_filter('explain (verbose) select * from t1 where pg_temp.mysin(f1) < 0.5');
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__explain_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__explain_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/explain.sql
-snapshot_kind: text
 ---
 create function explain_filter(text)
 returns setof text
@@ -212,7 +211,9 @@ create temporary table t1 (f1 double precision);
 create function pg_temp.mysin(double precision)
 returns double precision
 language plpgsql
-as $function$begin return sin($1); end$function$;
+as $function$
+begin return sin($1); end
+$function$;
 
 select
   explain_filter(

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__expressions_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__expressions_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/expressions.sql
-snapshot_kind: text
 ---
 select cast(date(NOW()) as text) = cast(current_date as text);
 
@@ -164,21 +163,27 @@ returns myint
 strict
 immutable
 language internal
-as $function$int4in$function$;
+as $function$
+int4in
+$function$;
 
 create function myintout(myint)
 returns cstring
 strict
 immutable
 language internal
-as $function$int4out$function$;
+as $function$
+int4out
+$function$;
 
 create function myinthash(myint)
 returns int
 strict
 immutable
 language internal
-as $function$hashint4$function$;
+as $function$
+hashint4
+$function$;
 
 create type myint (input = myintin, output = myintout, like = int);
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__expressions_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__expressions_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/expressions.sql
-snapshot_kind: text
 ---
 select cast(date(NOW()) as text) = cast(current_date as text);
 
@@ -226,21 +225,27 @@ returns myint
 strict
 immutable
 language internal
-as $function$int4in$function$;
+as $function$
+int4in
+$function$;
 
 create function myintout(myint)
 returns cstring
 strict
 immutable
 language internal
-as $function$int4out$function$;
+as $function$
+int4out
+$function$;
 
 create function myinthash(myint)
 returns int
 strict
 immutable
 language internal
-as $function$hashint4$function$;
+as $function$
+hashint4
+$function$;
 
 create type myint (input = myintin, output = myintout, like = int);
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__fast_default_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__fast_default_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/fast_default.sql
-snapshot_kind: text
 ---
 set search_path to fast_default;
 
@@ -45,7 +44,6 @@ create function log_rewrite()
 returns event_trigger
 language plpgsql
 as $function$
-
 declare
    this_schema text;
 begin
@@ -230,7 +228,8 @@ BEGIN
     i := i + 1;
   END LOOP;
   RETURN res;
-END; $function$
+END;
+$function$
 language plpgsql
 stable;
 
@@ -396,7 +395,9 @@ select comp();
 create function foolme(timestamp with time zone default clock_timestamp())
 returns timestamp with time zone
 immutable
-as $function$select $1$function$
+as $function$
+select $1
+$function$
 language sql;
 
 alter table t
@@ -521,7 +522,6 @@ create function test_trigger()
 returns trigger
 language plpgsql
 as $function$
-
 begin
     raise notice 'old tuple: %', to_json(OLD)::text;
     if TG_OP = 'DELETE'
@@ -531,7 +531,6 @@ begin
        return NEW;
     end if;
 end;
-
 $function$;
 
 create table t (

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__fast_default_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__fast_default_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/fast_default.sql
-snapshot_kind: text
 ---
 set search_path to fast_default;
 
@@ -45,7 +44,6 @@ create function log_rewrite()
 returns event_trigger
 language plpgsql
 as $function$
-
 declare
    this_schema text;
 begin
@@ -234,7 +232,8 @@ BEGIN
     i := i + 1;
   END LOOP;
   RETURN res;
-END; $function$
+END;
+$function$
 language plpgsql
 stable;
 
@@ -409,7 +408,9 @@ select comp();
 create function foolme(timestamp with time zone default clock_timestamp())
 returns timestamp with time zone
 immutable
-as $function$select $1$function$
+as $function$
+select $1
+$function$
 language sql;
 
 alter table t
@@ -559,7 +560,6 @@ create function test_trigger()
 returns trigger
 language plpgsql
 as $function$
-
 begin
     raise notice 'old tuple: %', to_json(OLD)::text;
     if TG_OP = 'DELETE'
@@ -569,7 +569,6 @@ begin
        return NEW;
     end if;
 end;
-
 $function$;
 
 create table t (

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__float4_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__float4_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/float4.sql
-snapshot_kind: text
 ---
 create table float4_tbl (f1 real);
 
@@ -188,14 +187,18 @@ returns xfloat4
 immutable
 strict
 language internal
-as $function$int4in$function$;
+as $function$
+int4in
+$function$;
 
 create function xfloat4out(xfloat4)
 returns cstring
 immutable
 strict
 language internal
-as $function$int4out$function$;
+as $function$
+int4out
+$function$;
 
 create type xfloat4 (input = xfloat4in, output = xfloat4out, like = real);
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__float4_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__float4_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/float4.sql
-snapshot_kind: text
 ---
 create table float4_tbl (f1 real);
 
@@ -188,14 +187,18 @@ returns xfloat4
 immutable
 strict
 language internal
-as $function$int4in$function$;
+as $function$
+int4in
+$function$;
 
 create function xfloat4out(xfloat4)
 returns cstring
 immutable
 strict
 language internal
-as $function$int4out$function$;
+as $function$
+int4out
+$function$;
 
 create type xfloat4 (input = xfloat4in, output = xfloat4out, like = real);
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__float8_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__float8_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/float8.sql
-snapshot_kind: text
 ---
 create temporary table float8_tbl (f1 double precision);
 
@@ -505,14 +504,18 @@ returns xfloat8
 immutable
 strict
 language internal
-as $function$int8in$function$;
+as $function$
+int8in
+$function$;
 
 create function xfloat8out(xfloat8)
 returns cstring
 immutable
 strict
 language internal
-as $function$int8out$function$;
+as $function$
+int8out
+$function$;
 
 create type xfloat8 (input = xfloat8in, output = xfloat8out, like = no_such_type);
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__float8_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__float8_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/float8.sql
-snapshot_kind: text
 ---
 create temporary table float8_tbl (f1 double precision);
 
@@ -533,14 +532,18 @@ returns xfloat8
 immutable
 strict
 language internal
-as $function$int8in$function$;
+as $function$
+int8in
+$function$;
 
 create function xfloat8out(xfloat8)
 returns cstring
 immutable
 strict
 language internal
-as $function$int8out$function$;
+as $function$
+int8out
+$function$;
 
 create type xfloat8 (
   input = xfloat8in,

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__foreign_data_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__foreign_data_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/foreign_data.sql
-snapshot_kind: text
 ---
 create function test_fdw_handler()
 returns fdw_handler
@@ -84,7 +83,9 @@ create foreign data wrapper foo validator postgresql_fdw_validator ;
 create function invalid_fdw_handler()
 returns int
 language sql
-as $function$SELECT 1;$function$;
+as $function$
+SELECT 1;
+$function$;
 
 create foreign data wrapper test_fdw handler invalid_fdw_handler ;
 
@@ -1098,7 +1099,7 @@ drop server s10 cascade;
 create function dummy_trigger()
 returns trigger
 as $function$
-  BEGIN
+BEGIN
     RETURN NULL;
   END
 $function$

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__foreign_data_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__foreign_data_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/foreign_data.sql
-snapshot_kind: text
 ---
 create function test_fdw_handler()
 returns fdw_handler
@@ -84,7 +83,9 @@ create foreign data wrapper foo validator postgresql_fdw_validator ;
 create function invalid_fdw_handler()
 returns int
 language sql
-as $function$SELECT 1;$function$;
+as $function$
+SELECT 1;
+$function$;
 
 create foreign data wrapper test_fdw handler invalid_fdw_handler ;
 
@@ -1172,7 +1173,7 @@ drop server s10 cascade;
 create function dummy_trigger()
 returns trigger
 as $function$
-  BEGIN
+BEGIN
     RETURN NULL;
   END
 $function$

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__foreign_key_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__foreign_key_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/foreign_key.sql
-snapshot_kind: text
 ---
 create table pktable (
   ptest1 int primary key,
@@ -3954,7 +3953,7 @@ create function fkpart11.print_row()
 returns trigger
 language plpgsql
 as $function$
-  BEGIN
+BEGIN
     RAISE NOTICE 'TABLE: %, OP: %, OLD: %, NEW: %', TG_RELNAME, TG_OP, OLD, NEW;
     RETURN NULL;
   END;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__foreign_key_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__foreign_key_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/foreign_key.sql
-snapshot_kind: text
 ---
 create table pktable (
   ptest1 int primary key,
@@ -4155,7 +4154,7 @@ create function fkpart11.print_row()
 returns trigger
 language plpgsql
 as $function$
-  BEGIN
+BEGIN
     RAISE NOTICE 'TABLE: %, OP: %, OLD: %, NEW: %', TG_RELNAME, TG_OP, OLD, NEW;
     RETURN NULL;
   END;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__generated_stored_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__generated_stored_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/generated_stored.sql
-snapshot_kind: text
 ---
 create schema "generated_stored_tests";
 
@@ -503,7 +502,9 @@ grant SELECT (a, c) on table gtest11 to regress_user11;
 
 create function gf1(a int)
 returns int
-as $function$ SELECT a * 3 $function$
+as $function$
+SELECT a * 3
+$function$
 immutable
 language sql;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__generated_stored_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__generated_stored_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/generated_stored.sql
-snapshot_kind: text
 ---
 create schema "generated_stored_tests";
 
@@ -516,7 +515,9 @@ grant SELECT (a, c) on table gtest11 to regress_user11;
 
 create function gf1(a int)
 returns int
-as $function$ SELECT a * 3 $function$
+as $function$
+SELECT a * 3
+$function$
 immutable
 language sql;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__generated_virtual_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__generated_virtual_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/generated_virtual.sql
-snapshot_kind: text
 ---
 create schema "generated_virtual_tests";
 
@@ -310,7 +309,9 @@ grant SELECT (a, c) on table gtest11 to regress_user11;
 
 create function gf1(a int)
 returns int
-as $function$ SELECT a * 3 $function$
+as $function$
+SELECT a * 3
+$function$
 immutable
 language sql;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__generated_virtual_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__generated_virtual_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/generated_virtual.sql
-snapshot_kind: text
 ---
 create schema "generated_virtual_tests";
 
@@ -311,7 +310,9 @@ grant SELECT (a, c) on table gtest11 to regress_user11;
 
 create function gf1(a int)
 returns int
-as $function$ SELECT a * 3 $function$
+as $function$
+SELECT a * 3
+$function$
 immutable
 language sql;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__groupingsets_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__groupingsets_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/groupingsets.sql
-snapshot_kind: text
 ---
 create temporary view gstest1
 (
@@ -73,10 +72,10 @@ create temporary table gstest_empty (
 create function gstest_data(v int, out a int, out b int)
 returns setof record
 as $function$
-    begin
+begin
       return query select v, i from generate_series(1,3) i;
     end;
-  $function$
+$function$
 language plpgsql;
 
 set enable_hashagg = 'false';

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__groupingsets_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__groupingsets_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/groupingsets.sql
-snapshot_kind: text
 ---
 create temporary view gstest1
 (
@@ -73,10 +72,10 @@ create temporary table gstest_empty (
 create function gstest_data(v int, out a int, out b int)
 returns setof record
 as $function$
-    begin
+begin
       return query select v, i from generate_series(1,3) i;
     end;
-  $function$
+$function$
 language plpgsql;
 
 set enable_hashagg = 'false';

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__indexing_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__indexing_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/indexing.sql
-snapshot_kind: text
 ---
 create table idxpart (
   a int,
@@ -2224,7 +2223,9 @@ create table test_pg_index_toast_table (a int);
 
 create or replace function test_pg_index_toast_func(a int, b int[])
 returns boolean
-as $function$ select true $function$
+as $function$
+select true
+$function$
 language sql
 immutable;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__indexing_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__indexing_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/indexing.sql
-snapshot_kind: text
 ---
 create table idxpart (
   a int,
@@ -2443,7 +2442,9 @@ create table test_pg_index_toast_table (a int);
 
 create or replace function test_pg_index_toast_func(a int, b int[])
 returns boolean
-as $function$ select true $function$
+as $function$
+select true
+$function$
 language sql
 immutable;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__indirect_toast_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__indirect_toast_100.snap
@@ -1,11 +1,12 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/indirect_toast.sql
-snapshot_kind: text
 ---
 create function make_tuple_indirect(record)
 returns record
-as $function$regresslib$function$
+as $function$
+regresslib
+$function$
 language c
 strict;
 
@@ -98,7 +99,8 @@ as $function$
 BEGIN
     NEW := make_tuple_indirect(NEW);
     RETURN NEW;
-END$function$;
+END
+$function$;
 
 create trigger indtoasttest_update_indirect
 before insert or update

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__indirect_toast_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__indirect_toast_80.snap
@@ -1,11 +1,12 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/indirect_toast.sql
-snapshot_kind: text
 ---
 create function make_tuple_indirect(record)
 returns record
-as $function$regresslib$function$
+as $function$
+regresslib
+$function$
 language c
 strict;
 
@@ -99,7 +100,8 @@ as $function$
 BEGIN
     NEW := make_tuple_indirect(NEW);
     RETURN NEW;
-END$function$;
+END
+$function$;
 
 create trigger indtoasttest_update_indirect
 before insert or update

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__infinite_recurse_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__infinite_recurse_100.snap
@@ -1,11 +1,12 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/infinite_recurse.sql
-snapshot_kind: text
 ---
 create function infinite_recurse()
 returns int
-as $function$select infinite_recurse()$function$
+as $function$
+select infinite_recurse()
+$function$
 language sql;
 
 select version() ~ 'powerpc64[^,]*-linux-gnu' as skip_test;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__infinite_recurse_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__infinite_recurse_80.snap
@@ -1,11 +1,12 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/infinite_recurse.sql
-snapshot_kind: text
 ---
 create function infinite_recurse()
 returns int
-as $function$select infinite_recurse()$function$
+as $function$
+select infinite_recurse()
+$function$
 language sql;
 
 select version() ~ 'powerpc64[^,]*-linux-gnu' as skip_test;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__inherit_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__inherit_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/inherit.sql
-snapshot_kind: text
 ---
 create table a (aa text);
 
@@ -194,7 +193,9 @@ create index on some_tab_child using btree (f1, f2);
 
 create function some_tab_stmt_trig_func()
 returns trigger
-as $function$begin raise notice 'updating some_tab'; return NULL; end;$function$
+as $function$
+begin raise notice 'updating some_tab'; return NULL; end;
+$function$
 language plpgsql;
 
 create trigger some_tab_stmt_trig
@@ -517,7 +518,9 @@ create table p2 (f1 text);
 
 create function p2text(p2)
 returns text
-as $function$select $1.f1$function$
+as $function$
+select $1.f1
+$function$
 language sql;
 
 create table c1 (f3 int)

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__inherit_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__inherit_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/inherit.sql
-snapshot_kind: text
 ---
 create table a (aa text);
 
@@ -200,7 +199,9 @@ create index on some_tab_child using btree (f1, f2);
 
 create function some_tab_stmt_trig_func()
 returns trigger
-as $function$begin raise notice 'updating some_tab'; return NULL; end;$function$
+as $function$
+begin raise notice 'updating some_tab'; return NULL; end;
+$function$
 language plpgsql;
 
 create trigger some_tab_stmt_trig
@@ -550,7 +551,9 @@ create table p2 (f1 text);
 
 create function p2text(p2)
 returns text
-as $function$select $1.f1$function$
+as $function$
+select $1.f1
+$function$
 language sql;
 
 create table c1 (f3 int)

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__insert_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__insert_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/insert.sql
-snapshot_kind: text
 ---
 create table inserttest (
   col1 int,
@@ -658,7 +657,9 @@ insert into mlparted values (1, 45, 'a');
 
 create function mlparted5abrtrig_func()
 returns trigger
-as $function$ begin new.c = 'b'; return new; end; $function$
+as $function$
+begin new.c = 'b'; return new; end;
+$function$
 language plpgsql;
 
 create trigger mlparted5abrtrig
@@ -931,7 +932,9 @@ create table brtrigpartcon1 partition of brtrigpartcon for values in (1);
 
 create or replace function brtrigpartcon1trigf()
 returns trigger
-as $function$begin new.a := 2; return new; end$function$
+as $function$
+begin new.a := 2; return new; end
+$function$
 language plpgsql;
 
 create trigger brtrigpartcon1trig
@@ -1006,7 +1009,9 @@ alter table donothingbrtrig_test2
 
 create or replace function donothingbrtrig_func()
 returns trigger
-as $function$begin raise notice 'b: %', new.b; return NULL; end$function$
+as $function$
+begin raise notice 'b: %', new.b; return NULL; end
+$function$
 language plpgsql;
 
 create trigger donothingbrtrig1

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__insert_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__insert_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/insert.sql
-snapshot_kind: text
 ---
 create table inserttest (
   col1 int,
@@ -726,7 +725,9 @@ insert into mlparted values (1, 45, 'a');
 
 create function mlparted5abrtrig_func()
 returns trigger
-as $function$ begin new.c = 'b'; return new; end; $function$
+as $function$
+begin new.c = 'b'; return new; end;
+$function$
 language plpgsql;
 
 create trigger mlparted5abrtrig
@@ -1018,7 +1019,9 @@ create table brtrigpartcon1 partition of brtrigpartcon for values in (1);
 
 create or replace function brtrigpartcon1trigf()
 returns trigger
-as $function$begin new.a := 2; return new; end$function$
+as $function$
+begin new.a := 2; return new; end
+$function$
 language plpgsql;
 
 create trigger brtrigpartcon1trig
@@ -1093,7 +1096,9 @@ alter table donothingbrtrig_test2
 
 create or replace function donothingbrtrig_func()
 returns trigger
-as $function$begin raise notice 'b: %', new.b; return NULL; end$function$
+as $function$
+begin raise notice 'b: %', new.b; return NULL; end
+$function$
 language plpgsql;
 
 create trigger donothingbrtrig1

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__largeobject_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__largeobject_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/largeobject.sql
-snapshot_kind: text
 ---
 set bytea_output = escape;
 
@@ -102,7 +101,10 @@ select lo_open(loid, cast(X'40000' as int)) from lotest_stash_values;
 
 rollback;
 
-do $do$dobody$do$;
+do
+$do$
+dobody
+$do$;
 
 begin;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__largeobject_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__largeobject_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/largeobject.sql
-snapshot_kind: text
 ---
 set bytea_output = escape;
 
@@ -110,7 +109,10 @@ select lo_open(loid, cast(X'40000' as int)) from lotest_stash_values;
 
 rollback;
 
-do $do$dobody$do$;
+do
+$do$
+dobody
+$do$;
 
 begin;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__lock_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__lock_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/lock.sql
-snapshot_kind: text
 ---
 create schema "lock_schema1";
 
@@ -355,7 +354,9 @@ reset search_path;
 
 create function test_atomic_ops()
 returns boolean
-as $function$regresslib$function$
+as $function$
+regresslib
+$function$
 language c;
 
 select test_atomic_ops();

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__lock_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__lock_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/lock.sql
-snapshot_kind: text
 ---
 create schema "lock_schema1";
 
@@ -358,7 +357,9 @@ reset search_path;
 
 create function test_atomic_ops()
 returns boolean
-as $function$regresslib$function$
+as $function$
+regresslib
+$function$
 language c;
 
 select test_atomic_ops();

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__merge_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__merge_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/merge.sql
-snapshot_kind: text
 ---
 create user regress_merge_privs;
 
@@ -740,7 +739,7 @@ merge_into_sq_target(
 )
 language sql
 as $function$
-    MERGE INTO sq_target t
+MERGE INTO sq_target t
     USING (VALUES ($1, $2, $3)) AS v(sid, balance, delta)
     ON tid = v.sid
     WHEN MATCHED AND tid >= 2 THEN
@@ -781,7 +780,7 @@ returns table (
 )
 language sql
 as $function$
-    MERGE INTO sq_target t
+MERGE INTO sq_target t
     USING sq_source s
     ON tid = sid
     WHEN MATCHED AND tid >= 2 THEN
@@ -1193,7 +1192,9 @@ begin;
 create function trig_fn()
 returns trigger
 language plpgsql
-as $function$ BEGIN RETURN NULL; END; $function$;
+as $function$
+BEGIN RETURN NULL; END;
+$function$;
 
 create trigger del_trig before delete on pa_target for each row execute function trig_fn();
 
@@ -1225,7 +1226,9 @@ begin;
 create function trig_fn()
 returns trigger
 language plpgsql
-as $function$ BEGIN RETURN NULL; END; $function$;
+as $function$
+BEGIN RETURN NULL; END;
+$function$;
 
 create trigger ins_trig before insert on pa_target for each row execute function trig_fn();
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__merge_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__merge_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/merge.sql
-snapshot_kind: text
 ---
 create user regress_merge_privs;
 
@@ -787,7 +786,7 @@ merge_into_sq_target(
 )
 language sql
 as $function$
-    MERGE INTO sq_target t
+MERGE INTO sq_target t
     USING (VALUES ($1, $2, $3)) AS v(sid, balance, delta)
     ON tid = v.sid
     WHEN MATCHED AND tid >= 2 THEN
@@ -835,7 +834,7 @@ returns table (
 )
 language sql
 as $function$
-    MERGE INTO sq_target t
+MERGE INTO sq_target t
     USING sq_source s
     ON tid = sid
     WHEN MATCHED AND tid >= 2 THEN
@@ -1278,7 +1277,9 @@ begin;
 create function trig_fn()
 returns trigger
 language plpgsql
-as $function$ BEGIN RETURN NULL; END; $function$;
+as $function$
+BEGIN RETURN NULL; END;
+$function$;
 
 create trigger del_trig
 before delete
@@ -1314,7 +1315,9 @@ begin;
 create function trig_fn()
 returns trigger
 language plpgsql
-as $function$ BEGIN RETURN NULL; END; $function$;
+as $function$
+BEGIN RETURN NULL; END;
+$function$;
 
 create trigger ins_trig
 before insert

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__misc_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__misc_100.snap
@@ -1,17 +1,20 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/misc.sql
-snapshot_kind: text
 ---
 create function overpaid(emp)
 returns boolean
-as $function$regresslib$function$
+as $function$
+regresslib
+$function$
 language c
 strict;
 
 create function reverse_name(name)
 returns name
-as $function$regresslib$function$
+as $function$
+regresslib
+$function$
 language c
 strict;
 
@@ -95,57 +98,79 @@ insert into equipment_r (name, hobby) values ('guts', 'skywalking');
 
 create function hobbies(person)
 returns setof hobbies_r
-as $function$select * from hobbies_r where person = $1.name$function$
+as $function$
+select * from hobbies_r where person = $1.name
+$function$
 language sql;
 
 create function hobby_construct(text, text)
 returns hobbies_r
-as $function$select $1 as name, $2 as hobby$function$
+as $function$
+select $1 as name, $2 as hobby
+$function$
 language sql;
 
 create function hobby_construct_named(name text, hobby text)
 returns hobbies_r
-as $function$select name, hobby$function$
+as $function$
+select name, hobby
+$function$
 language sql;
 
 create function hobbies_by_name(hobbies_r.name%type)
 returns hobbies_r.person%type
-as $function$select person from hobbies_r where name = $1$function$
+as $function$
+select person from hobbies_r where name = $1
+$function$
 language sql;
 
 create function equipment(hobbies_r)
 returns setof equipment_r
-as $function$select * from equipment_r where hobby = $1.name$function$
+as $function$
+select * from equipment_r where hobby = $1.name
+$function$
 language sql;
 
 create function equipment_named(hobby hobbies_r)
 returns setof equipment_r
-as $function$select * from equipment_r where equipment_r.hobby = equipment_named.hobby.name$function$
+as $function$
+select * from equipment_r where equipment_r.hobby = equipment_named.hobby.name
+$function$
 language sql;
 
 create function equipment_named_ambiguous_1a(hobby hobbies_r)
 returns setof equipment_r
-as $function$select * from equipment_r where hobby = equipment_named_ambiguous_1a.hobby.name$function$
+as $function$
+select * from equipment_r where hobby = equipment_named_ambiguous_1a.hobby.name
+$function$
 language sql;
 
 create function equipment_named_ambiguous_1b(hobby hobbies_r)
 returns setof equipment_r
-as $function$select * from equipment_r where equipment_r.hobby = hobby.name$function$
+as $function$
+select * from equipment_r where equipment_r.hobby = hobby.name
+$function$
 language sql;
 
 create function equipment_named_ambiguous_1c(hobby hobbies_r)
 returns setof equipment_r
-as $function$select * from equipment_r where hobby = hobby.name$function$
+as $function$
+select * from equipment_r where hobby = hobby.name
+$function$
 language sql;
 
 create function equipment_named_ambiguous_2a(hobby text)
 returns setof equipment_r
-as $function$select * from equipment_r where hobby = equipment_named_ambiguous_2a.hobby$function$
+as $function$
+select * from equipment_r where hobby = equipment_named_ambiguous_2a.hobby
+$function$
 language sql;
 
 create function equipment_named_ambiguous_2b(hobby text)
 returns setof equipment_r
-as $function$select * from equipment_r where equipment_r.hobby = hobby$function$
+as $function$
+select * from equipment_r where equipment_r.hobby = hobby
+$function$
 language sql;
 
 select p.name, name(p.hobbies) from only person as p;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__misc_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__misc_80.snap
@@ -1,17 +1,20 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/misc.sql
-snapshot_kind: text
 ---
 create function overpaid(emp)
 returns boolean
-as $function$regresslib$function$
+as $function$
+regresslib
+$function$
 language c
 strict;
 
 create function reverse_name(name)
 returns name
-as $function$regresslib$function$
+as $function$
+regresslib
+$function$
 language c
 strict;
 
@@ -95,57 +98,79 @@ insert into equipment_r (name, hobby) values ('guts', 'skywalking');
 
 create function hobbies(person)
 returns setof hobbies_r
-as $function$select * from hobbies_r where person = $1.name$function$
+as $function$
+select * from hobbies_r where person = $1.name
+$function$
 language sql;
 
 create function hobby_construct(text, text)
 returns hobbies_r
-as $function$select $1 as name, $2 as hobby$function$
+as $function$
+select $1 as name, $2 as hobby
+$function$
 language sql;
 
 create function hobby_construct_named(name text, hobby text)
 returns hobbies_r
-as $function$select name, hobby$function$
+as $function$
+select name, hobby
+$function$
 language sql;
 
 create function hobbies_by_name(hobbies_r.name%type)
 returns hobbies_r.person%type
-as $function$select person from hobbies_r where name = $1$function$
+as $function$
+select person from hobbies_r where name = $1
+$function$
 language sql;
 
 create function equipment(hobbies_r)
 returns setof equipment_r
-as $function$select * from equipment_r where hobby = $1.name$function$
+as $function$
+select * from equipment_r where hobby = $1.name
+$function$
 language sql;
 
 create function equipment_named(hobby hobbies_r)
 returns setof equipment_r
-as $function$select * from equipment_r where equipment_r.hobby = equipment_named.hobby.name$function$
+as $function$
+select * from equipment_r where equipment_r.hobby = equipment_named.hobby.name
+$function$
 language sql;
 
 create function equipment_named_ambiguous_1a(hobby hobbies_r)
 returns setof equipment_r
-as $function$select * from equipment_r where hobby = equipment_named_ambiguous_1a.hobby.name$function$
+as $function$
+select * from equipment_r where hobby = equipment_named_ambiguous_1a.hobby.name
+$function$
 language sql;
 
 create function equipment_named_ambiguous_1b(hobby hobbies_r)
 returns setof equipment_r
-as $function$select * from equipment_r where equipment_r.hobby = hobby.name$function$
+as $function$
+select * from equipment_r where equipment_r.hobby = hobby.name
+$function$
 language sql;
 
 create function equipment_named_ambiguous_1c(hobby hobbies_r)
 returns setof equipment_r
-as $function$select * from equipment_r where hobby = hobby.name$function$
+as $function$
+select * from equipment_r where hobby = hobby.name
+$function$
 language sql;
 
 create function equipment_named_ambiguous_2a(hobby text)
 returns setof equipment_r
-as $function$select * from equipment_r where hobby = equipment_named_ambiguous_2a.hobby$function$
+as $function$
+select * from equipment_r where hobby = equipment_named_ambiguous_2a.hobby
+$function$
 language sql;
 
 create function equipment_named_ambiguous_2b(hobby text)
 returns setof equipment_r
-as $function$select * from equipment_r where equipment_r.hobby = hobby$function$
+as $function$
+select * from equipment_r where equipment_r.hobby = hobby
+$function$
 language sql;
 
 select p.name, name(p.hobbies) from only person as p;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__misc_functions_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__misc_functions_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/misc_functions.sql
-snapshot_kind: text
 ---
 create function
 explain_mask_costs(
@@ -129,7 +128,9 @@ select num_nulls();
 
 create function test_canonicalize_path(text)
 returns text
-as $function$regresslib$function$
+as $function$
+regresslib
+$function$
 language c
 strict
 immutable;
@@ -315,7 +316,9 @@ language internal
 strict
 immutable
 parallel SAFE
-as $function$int4eq$function$;
+as $function$
+int4eq
+$function$;
 
 select
   *
@@ -351,7 +354,9 @@ language internal
 strict
 immutable
 parallel SAFE
-as $function$generate_series_int4$function$
+as $function$
+generate_series_int4
+$function$
 support test_support_func;
 
 select * from tenk1 as a inner join my_gen_series(1, 1000) as g on a.unique1 = g;
@@ -598,7 +603,9 @@ select gist_translate_cmptype_common(3);
 
 create function test_relpath()
 returns void
-as $function$regresslib$function$
+as $function$
+regresslib
+$function$
 language c;
 
 select test_relpath();

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__misc_functions_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__misc_functions_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/misc_functions.sql
-snapshot_kind: text
 ---
 create function
 explain_mask_costs(
@@ -129,7 +128,9 @@ select num_nulls();
 
 create function test_canonicalize_path(text)
 returns text
-as $function$regresslib$function$
+as $function$
+regresslib
+$function$
 language c
 strict
 immutable;
@@ -368,7 +369,9 @@ language internal
 strict
 immutable
 parallel SAFE
-as $function$int4eq$function$;
+as $function$
+int4eq
+$function$;
 
 select
   *
@@ -404,7 +407,9 @@ language internal
 strict
 immutable
 parallel SAFE
-as $function$generate_series_int4$function$
+as $function$
+generate_series_int4
+$function$
 support test_support_func;
 
 select
@@ -680,7 +685,9 @@ select gist_translate_cmptype_common(3);
 
 create function test_relpath()
 returns void
-as $function$regresslib$function$
+as $function$
+regresslib
+$function$
 language c;
 
 select test_relpath();

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__multirangetypes_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__multirangetypes_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/multirangetypes.sql
-snapshot_kind: text
 ---
 select cast('' as textmultirange);
 
@@ -1437,7 +1436,9 @@ drop role regress_multirange_owner;
 
 create function anyarray_anymultirange_func(a anyarray, r anymultirange)
 returns anyelement
-as $function$select $1[1] + lower($2);$function$
+as $function$
+select $1[1] + lower($2);
+$function$
 language sql;
 
 select anyarray_anymultirange_func(array[1, 2], int4multirange(int4range(10, 20)));
@@ -1448,17 +1449,23 @@ drop function anyarray_anymultirange_func(anyarray, anymultirange);
 
 create function bogus_func(anyelement)
 returns anymultirange
-as $function$select int4multirange(int4range(1,10))$function$
+as $function$
+select int4multirange(int4range(1,10))
+$function$
 language sql;
 
 create function bogus_func(int)
 returns anymultirange
-as $function$select int4multirange(int4range(1,10))$function$
+as $function$
+select int4multirange(int4range(1,10))
+$function$
 language sql;
 
 create function range_add_bounds(anymultirange)
 returns anyelement
-as $function$select lower($1) + upper($1)$function$
+as $function$
+select lower($1) + upper($1)
+$function$
 language sql;
 
 select range_add_bounds(int4multirange(int4range(1, 17)));
@@ -1466,7 +1473,9 @@ select range_add_bounds(int4multirange(int4range(1, 17)));
 select range_add_bounds(nummultirange(numrange(1.0001, 123.123)));
 
 create function multirangetypes_sql(q anymultirange, b anyarray, out c anyelement)
-as $function$ select upper($1) + $2[1] $function$
+as $function$
+select upper($1) + $2[1]
+$function$
 language sql;
 
 select multirangetypes_sql(int4multirange(int4range(1, 10)), array[2, 20]);
@@ -1479,7 +1488,9 @@ anycompatiblearray_anycompatiblemultirange_func(
   mr anycompatiblemultirange
 )
 returns anycompatible
-as $function$select $1[1] + lower($2);$function$
+as $function$
+select $1[1] + lower($2);
+$function$
 language sql;
 
 select anycompatiblearray_anycompatiblemultirange_func(array[1, 2], multirange(int4range(10, 20)));
@@ -1503,7 +1514,9 @@ anycompatiblerange_anycompatiblemultirange_func(
   mr anycompatiblemultirange
 )
 returns anycompatible
-as $function$select lower($1) + lower($2);$function$
+as $function$
+select lower($1) + lower($2);
+$function$
 language sql;
 
 select
@@ -1525,7 +1538,9 @@ drop function
 
 create function bogus_func(anycompatible)
 returns anycompatiblerange
-as $function$select int4range(1,10)$function$
+as $function$
+select int4range(1,10)
+$function$
 language sql;
 
 select array[nummultirange(numrange(1.1, 1.2)), nummultirange(numrange(12.3, 155.5))];
@@ -1587,31 +1602,41 @@ select cast('{(01,10)}' as varbitmultirange) except select cast('{(10,11)}' as v
 reset enable_sort;
 
 create function mr_outparam_succeed(i anymultirange, out r anymultirange, out t text)
-as $function$ select $1, 'foo'::text $function$
+as $function$
+select $1, 'foo'::text
+$function$
 language sql;
 
 select * from mr_outparam_succeed(int4multirange(int4range(1, 2)));
 
 create function mr_outparam_succeed2(i anymultirange, out r anyarray, out t text)
-as $function$ select ARRAY[upper($1)], 'foo'::text $function$
+as $function$
+select ARRAY[upper($1)], 'foo'::text
+$function$
 language sql;
 
 select * from mr_outparam_succeed2(int4multirange(int4range(1, 2)));
 
 create function mr_outparam_succeed3(i anymultirange, out r anyrange, out t text)
-as $function$ select range_merge($1), 'foo'::text $function$
+as $function$
+select range_merge($1), 'foo'::text
+$function$
 language sql;
 
 select * from mr_outparam_succeed3(int4multirange(int4range(1, 2)));
 
 create function mr_outparam_succeed4(i anyrange, out r anymultirange, out t text)
-as $function$ select multirange($1), 'foo'::text $function$
+as $function$
+select multirange($1), 'foo'::text
+$function$
 language sql;
 
 select * from mr_outparam_succeed4(int4range(1, 2));
 
 create function mr_inoutparam_succeed(out i anyelement, inout r anymultirange)
-as $function$ select upper($1), $1 $function$
+as $function$
+select upper($1), $1
+$function$
 language sql;
 
 select * from mr_inoutparam_succeed(int4multirange(int4range(1, 2)));
@@ -1621,24 +1646,32 @@ returns table (
   i anyelement,
   r anymultirange
 )
-as $function$ select $1, $2 $function$
+as $function$
+select $1, $2
+$function$
 language sql;
 
 select * from mr_table_succeed(123, int4multirange(int4range(1, 11)));
 
 create function mr_polymorphic(i anyrange)
 returns anymultirange
-as $function$ begin return multirange($1); end; $function$
+as $function$
+begin return multirange($1); end;
+$function$
 language plpgsql;
 
 select mr_polymorphic(int4range(1, 4));
 
 create function mr_outparam_fail(i anyelement, out r anymultirange, out t text)
-as $function$ select '[1,10]', 'foo' $function$
+as $function$
+select '[1,10]', 'foo'
+$function$
 language sql;
 
 create function mr_inoutparam_fail(inout i anyelement, out r anymultirange)
-as $function$ select $1, '[1,10]' $function$
+as $function$
+select $1, '[1,10]'
+$function$
 language sql;
 
 create function mr_table_fail(i anyelement)
@@ -1646,5 +1679,7 @@ returns table (
   i anyelement,
   r anymultirange
 )
-as $function$ select $1, '[1,10]' $function$
+as $function$
+select $1, '[1,10]'
+$function$
 language sql;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__multirangetypes_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__multirangetypes_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/multirangetypes.sql
-snapshot_kind: text
 ---
 select cast('' as textmultirange);
 
@@ -1958,7 +1957,9 @@ drop role regress_multirange_owner;
 
 create function anyarray_anymultirange_func(a anyarray, r anymultirange)
 returns anyelement
-as $function$select $1[1] + lower($2);$function$
+as $function$
+select $1[1] + lower($2);
+$function$
 language sql;
 
 select
@@ -1977,17 +1978,23 @@ drop function anyarray_anymultirange_func(anyarray, anymultirange);
 
 create function bogus_func(anyelement)
 returns anymultirange
-as $function$select int4multirange(int4range(1,10))$function$
+as $function$
+select int4multirange(int4range(1,10))
+$function$
 language sql;
 
 create function bogus_func(int)
 returns anymultirange
-as $function$select int4multirange(int4range(1,10))$function$
+as $function$
+select int4multirange(int4range(1,10))
+$function$
 language sql;
 
 create function range_add_bounds(anymultirange)
 returns anyelement
-as $function$select lower($1) + upper($1)$function$
+as $function$
+select lower($1) + upper($1)
+$function$
 language sql;
 
 select range_add_bounds(int4multirange(int4range(1, 17)));
@@ -2000,7 +2007,9 @@ multirangetypes_sql(
   b anyarray,
   out c anyelement
 )
-as $function$ select upper($1) + $2[1] $function$
+as $function$
+select upper($1) + $2[1]
+$function$
 language sql;
 
 select multirangetypes_sql(int4multirange(int4range(1, 10)), array[2, 20]);
@@ -2013,7 +2022,9 @@ anycompatiblearray_anycompatiblemultirange_func(
   mr anycompatiblemultirange
 )
 returns anycompatible
-as $function$select $1[1] + lower($2);$function$
+as $function$
+select $1[1] + lower($2);
+$function$
 language sql;
 
 select
@@ -2045,7 +2056,9 @@ anycompatiblerange_anycompatiblemultirange_func(
   mr anycompatiblemultirange
 )
 returns anycompatible
-as $function$select lower($1) + lower($2);$function$
+as $function$
+select lower($1) + lower($2);
+$function$
 language sql;
 
 select
@@ -2067,7 +2080,9 @@ drop function
 
 create function bogus_func(anycompatible)
 returns anycompatiblerange
-as $function$select int4range(1,10)$function$
+as $function$
+select int4range(1,10)
+$function$
 language sql;
 
 select
@@ -2140,7 +2155,9 @@ mr_outparam_succeed(
   out r anymultirange,
   out t text
 )
-as $function$ select $1, 'foo'::text $function$
+as $function$
+select $1, 'foo'::text
+$function$
 language sql;
 
 select * from mr_outparam_succeed(int4multirange(int4range(1, 2)));
@@ -2151,7 +2168,9 @@ mr_outparam_succeed2(
   out r anyarray,
   out t text
 )
-as $function$ select ARRAY[upper($1)], 'foo'::text $function$
+as $function$
+select ARRAY[upper($1)], 'foo'::text
+$function$
 language sql;
 
 select * from mr_outparam_succeed2(int4multirange(int4range(1, 2)));
@@ -2162,7 +2181,9 @@ mr_outparam_succeed3(
   out r anyrange,
   out t text
 )
-as $function$ select range_merge($1), 'foo'::text $function$
+as $function$
+select range_merge($1), 'foo'::text
+$function$
 language sql;
 
 select * from mr_outparam_succeed3(int4multirange(int4range(1, 2)));
@@ -2173,13 +2194,17 @@ mr_outparam_succeed4(
   out r anymultirange,
   out t text
 )
-as $function$ select multirange($1), 'foo'::text $function$
+as $function$
+select multirange($1), 'foo'::text
+$function$
 language sql;
 
 select * from mr_outparam_succeed4(int4range(1, 2));
 
 create function mr_inoutparam_succeed(out i anyelement, inout r anymultirange)
-as $function$ select upper($1), $1 $function$
+as $function$
+select upper($1), $1
+$function$
 language sql;
 
 select * from mr_inoutparam_succeed(int4multirange(int4range(1, 2)));
@@ -2189,24 +2214,32 @@ returns table (
   i anyelement,
   r anymultirange
 )
-as $function$ select $1, $2 $function$
+as $function$
+select $1, $2
+$function$
 language sql;
 
 select * from mr_table_succeed(123, int4multirange(int4range(1, 11)));
 
 create function mr_polymorphic(i anyrange)
 returns anymultirange
-as $function$ begin return multirange($1); end; $function$
+as $function$
+begin return multirange($1); end;
+$function$
 language plpgsql;
 
 select mr_polymorphic(int4range(1, 4));
 
 create function mr_outparam_fail(i anyelement, out r anymultirange, out t text)
-as $function$ select '[1,10]', 'foo' $function$
+as $function$
+select '[1,10]', 'foo'
+$function$
 language sql;
 
 create function mr_inoutparam_fail(inout i anyelement, out r anymultirange)
-as $function$ select $1, '[1,10]' $function$
+as $function$
+select $1, '[1,10]'
+$function$
 language sql;
 
 create function mr_table_fail(i anyelement)
@@ -2214,5 +2247,7 @@ returns table (
   i anyelement,
   r anymultirange
 )
-as $function$ select $1, '[1,10]' $function$
+as $function$
+select $1, '[1,10]'
+$function$
 language sql;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__mvcc_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__mvcc_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/mvcc.sql
-snapshot_kind: text
 ---
 begin;
 
@@ -37,7 +36,8 @@ BEGIN
 	    RAISE reading_sql_data_not_permitted USING MESSAGE = 'round and round again';
 	EXCEPTION WHEN reading_sql_data_not_permitted THEN END;
     END LOOP;
-END;$do$;
+END;
+$do$;
 
 select
   'clean_aborted_self_key_before' as size_before,

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__mvcc_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__mvcc_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/mvcc.sql
-snapshot_kind: text
 ---
 begin;
 
@@ -42,7 +41,8 @@ BEGIN
 	    RAISE reading_sql_data_not_permitted USING MESSAGE = 'round and round again';
 	EXCEPTION WHEN reading_sql_data_not_permitted THEN END;
     END LOOP;
-END;$do$;
+END;
+$do$;
 
 select
   'clean_aborted_self_key_before'

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__namespace_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__namespace_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/namespace.sql
-snapshot_kind: text
 ---
 select set_config('search_path', ' ', false);
 
@@ -128,7 +127,7 @@ returns int
 immutable
 language plpgsql
 as $function$
-  BEGIN
+BEGIN
     RAISE NOTICE 'current search_path: %', current_setting('search_path');
     RETURN $1;
   END;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__namespace_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__namespace_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/namespace.sql
-snapshot_kind: text
 ---
 select set_config('search_path', ' ', false);
 
@@ -128,7 +127,7 @@ returns int
 immutable
 language plpgsql
 as $function$
-  BEGIN
+BEGIN
     RAISE NOTICE 'current search_path: %', current_setting('search_path');
     RETURN $1;
   END;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__numerology_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__numerology_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/numerology.sql
-snapshot_kind: text
 ---
 select 37;
 
@@ -87,7 +86,8 @@ BEGIN
   FOR i IN 1_001..1_003 LOOP
     RAISE NOTICE 'i = %', i;
   END LOOP;
-END $do$;
+END
+$do$;
 
 select _100;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__numerology_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__numerology_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/numerology.sql
-snapshot_kind: text
 ---
 select 37;
 
@@ -87,7 +86,8 @@ BEGIN
   FOR i IN 1_001..1_003 LOOP
     RAISE NOTICE 'i = %', i;
   END LOOP;
-END $do$;
+END
+$do$;
 
 select _100;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__object_address_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__object_address_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/object_address.sql
-snapshot_kind: text
 ---
 set client_min_messages = warning;
 
@@ -60,7 +59,9 @@ create domain addr_nsp.gendomain as int constraint "domconstr" check (value > 0)
 create function addr_nsp.trig()
 returns trigger
 language plpgsql
-as $function$ BEGIN END; $function$;
+as $function$
+BEGIN END;
+$function$;
 
 create trigger t before insert on addr_nsp.gentable for each row execute function addr_nsp.trig();
 
@@ -68,7 +69,9 @@ create policy genpol on addr_nsp.gentable as permissive for all to public;
 
 create procedure addr_nsp.proc(int)
 language sql
-as $procedure$ $procedure$;
+as $procedure$
+
+$procedure$;
 
 create server integer foreign data wrapper addr_fdw;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__object_address_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__object_address_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/object_address.sql
-snapshot_kind: text
 ---
 set client_min_messages = warning;
 
@@ -61,7 +60,9 @@ create domain addr_nsp.gendomain as int
 create function addr_nsp.trig()
 returns trigger
 language plpgsql
-as $function$ BEGIN END; $function$;
+as $function$
+BEGIN END;
+$function$;
 
 create trigger t
 before insert
@@ -73,7 +74,9 @@ create policy genpol on addr_nsp.gentable as permissive for all to public;
 
 create procedure addr_nsp.proc(int)
 language sql
-as $procedure$ $procedure$;
+as $procedure$
+
+$procedure$;
 
 create server integer foreign data wrapper addr_fdw;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__partition_prune_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__partition_prune_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/partition_prune.sql
-snapshot_kind: text
 ---
 create function explain_analyze(query text)
 returns setof text
@@ -904,7 +903,9 @@ begin;
 
 create function list_part_fn(int)
 returns int
-as $function$ begin return $1; end;$function$
+as $function$
+begin return $1; end;
+$function$
 language plpgsql
 stable;
 
@@ -2039,7 +2040,9 @@ deallocate update_part_abc_view;
 
 create function stable_one()
 returns int
-as $function$ begin return 1; end; $function$
+as $function$
+begin return 1; end;
+$function$
 language plpgsql
 stable;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__partition_prune_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__partition_prune_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/partition_prune.sql
-snapshot_kind: text
 ---
 create function explain_analyze(query text)
 returns setof text
@@ -1040,7 +1039,9 @@ begin;
 
 create function list_part_fn(int)
 returns int
-as $function$ begin return $1; end;$function$
+as $function$
+begin return $1; end;
+$function$
 language plpgsql
 stable;
 
@@ -2389,7 +2390,9 @@ deallocate update_part_abc_view;
 
 create function stable_one()
 returns int
-as $function$ begin return 1; end; $function$
+as $function$
+begin return 1; end;
+$function$
 language plpgsql
 stable;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__plancache_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__plancache_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/plancache.sql
-snapshot_kind: text
 ---
 create temporary table pcachetest as select * from int8_tbl;
 
@@ -82,7 +81,8 @@ returns int
 as $function$
 begin
 	return f1 from v1;
-end$function$
+end
+$function$
 language plpgsql;
 
 select cache_test_2();
@@ -156,7 +156,8 @@ begin
   for r in select * from vv loop
     raise notice '%', r;
   end loop;
-end$function$
+end
+$function$
 language plpgsql;
 
 select cachebug();

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__plancache_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__plancache_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/plancache.sql
-snapshot_kind: text
 ---
 create temporary table pcachetest as select * from int8_tbl;
 
@@ -82,7 +81,8 @@ returns int
 as $function$
 begin
 	return f1 from v1;
-end$function$
+end
+$function$
 language plpgsql;
 
 select cache_test_2();
@@ -158,7 +158,8 @@ begin
   for r in select * from vv loop
     raise notice '%', r;
   end loop;
-end$function$
+end
+$function$
 language plpgsql;
 
 select cachebug();

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__plpgsql_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__plpgsql_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/plpgsql.sql
-snapshot_kind: text
 ---
 create table room (
   roomno char(8),
@@ -1495,7 +1494,8 @@ BEGIN
         rslt = CAST($1 AS TEXT) || ',' || recursion_test($1 - 1, $2);
     END IF;
     RETURN rslt;
-END;$function$
+END;
+$function$
 language plpgsql;
 
 select recursion_test(4, 3);
@@ -1505,7 +1505,7 @@ create table found_test_tbl (a int);
 create function test_found()
 returns boolean
 as $function$
-  declare
+declare
   begin
   insert into found_test_tbl values (1);
   if FOUND then
@@ -1537,7 +1537,8 @@ as $function$
     insert into found_test_tbl values (6);
   end if;
   return true;
-  end;$function$
+  end;
+$function$
 language plpgsql;
 
 select test_found();
@@ -1554,7 +1555,8 @@ BEGIN
 		RETURN NEXT rec;
 	END LOOP;
 	RETURN;
-END;$function$
+END;
+$function$
 language plpgsql;
 
 select * from test_table_func_rec();
@@ -1569,7 +1571,8 @@ BEGIN
 		RETURN NEXT row;
 	END LOOP;
 	RETURN;
-END;$function$
+END;
+$function$
 language plpgsql;
 
 select * from test_table_func_row();
@@ -1584,7 +1587,8 @@ BEGIN
 		RETURN NEXT i + 1;
 	END LOOP;
 	RETURN;
-END;$function$
+END;
+$function$
 language plpgsql;
 
 select * from test_ret_set_scalar(1, 10);
@@ -1605,7 +1609,8 @@ BEGIN
 		RETURN NEXT retval;
 	END IF;
 	RETURN;
-END;$function$
+END;
+$function$
 language plpgsql;
 
 select * from test_ret_set_rec_dyn(1500) as (a int, b int, c int);
@@ -1625,7 +1630,8 @@ BEGIN
 		SELECT INTO retval 50, 5::numeric, 'xxx'::text;
 		RETURN retval;
 	END IF;
-END;$function$
+END;
+$function$
 language plpgsql;
 
 select * from test_ret_rec_dyn(1500) as (a int, b int, c int);
@@ -1637,7 +1643,8 @@ returns anyelement
 as $function$
 begin
   return x + 1;
-end$function$
+end
+$function$
 language plpgsql;
 
 select f1(42) as int, f1(4.5) as num;
@@ -1651,7 +1658,8 @@ returns anyarray
 as $function$
 begin
   return array[x + 1, x + 2];
-end$function$
+end
+$function$
 language plpgsql;
 
 select f1(42) as int, f1(4.5) as num;
@@ -1663,7 +1671,8 @@ returns anyelement
 as $function$
 begin
   return x[1];
-end$function$
+end
+$function$
 language plpgsql;
 
 select f1(array[2, 4]) as int, f1(array[4.5, 7.7]) as num;
@@ -1677,7 +1686,8 @@ returns anyarray
 as $function$
 begin
   return x;
-end$function$
+end
+$function$
 language plpgsql;
 
 select f1(array[2, 4]) as int, f1(array[4.5, 7.7]) as num;
@@ -1691,7 +1701,8 @@ returns anyrange
 as $function$
 begin
   return array[x + 1, x + 2];
-end$function$
+end
+$function$
 language plpgsql;
 
 create function f1(x anyrange)
@@ -1699,7 +1710,8 @@ returns anyarray
 as $function$
 begin
   return array[lower(x), upper(x)];
-end$function$
+end
+$function$
 language plpgsql;
 
 select f1(int4range(42, 49)) as int, f1(float8range(4.5, 7.8)) as num;
@@ -1711,7 +1723,8 @@ returns anycompatiblearray
 as $function$
 begin
   return array[x, y];
-end$function$
+end
+$function$
 language plpgsql;
 
 select f1(2, 4) as int, f1(2, 4.5) as num;
@@ -1723,7 +1736,8 @@ returns anycompatiblearray
 as $function$
 begin
   return array[lower(x), upper(x), y, z];
-end$function$
+end
+$function$
 language plpgsql;
 
 select
@@ -1741,7 +1755,8 @@ returns anycompatiblerange
 as $function$
 begin
   return array[x + 1, x + 2];
-end$function$
+end
+$function$
 language plpgsql;
 
 create function f1(x anycompatiblerange, y anycompatiblearray)
@@ -1749,7 +1764,8 @@ returns anycompatiblerange
 as $function$
 begin
   return x;
-end$function$
+end
+$function$
 language plpgsql;
 
 select f1(int4range(42, 49), array[11]) as int, f1(float8range(4.5, 7.8), array[7]) as num;
@@ -1769,7 +1785,8 @@ as $function$
 begin
   x := a || b;
   y := array[c, d];
-end$function$
+end
+$function$
 language plpgsql;
 
 select x, pg_typeof(x), y, pg_typeof(y) from f1(11, array[1, 2], 42, 34.5);
@@ -1787,7 +1804,8 @@ returns int
 as $function$
 begin
   return i+1;
-end$function$
+end
+$function$
 language plpgsql;
 
 create function f1(in i int, out j int)
@@ -1795,7 +1813,8 @@ as $function$
 begin
   j := i+1;
   return;
-end$function$
+end
+$function$
 language plpgsql;
 
 select f1(42);
@@ -1806,7 +1825,8 @@ create or replace function f1(inout i int)
 as $function$
 begin
   i := i+1;
-end$function$
+end
+$function$
 language plpgsql;
 
 select f1(42);
@@ -1824,7 +1844,8 @@ begin
   j := i+2;
   return next;
   return;
-end$function$
+end
+$function$
 language plpgsql;
 
 select * from f1(42);
@@ -1837,7 +1858,8 @@ begin
   j := i;
   j := j+1;
   k := 'foo';
-end$function$
+end
+$function$
 language plpgsql;
 
 select f1(42);
@@ -1856,7 +1878,8 @@ begin
   j := j+1;
   k := 'foot';
   return next;
-end$function$
+end
+$function$
 language plpgsql;
 
 select * from f1(42);
@@ -1869,7 +1892,8 @@ begin
   j := i;
   k := array[j,j];
   return;
-end$function$
+end
+$function$
 language plpgsql;
 
 select * from duplic(42);
@@ -1884,7 +1908,8 @@ begin
   j := lower(i);
   k := array[lower(i),upper(i)];
   return;
-end$function$
+end
+$function$
 language plpgsql;
 
 select * from duplic(int4range(42, 49));
@@ -1908,7 +1933,8 @@ BEGIN
 	ELSE
 		RETURN FALSE;
 	END IF;
-END;$function$
+END;
+$function$
 language plpgsql;
 
 create function perform_test_func()
@@ -1932,7 +1958,8 @@ BEGIN
 	END IF;
 
 	RETURN;
-END;$function$
+END;
+$function$
 language plpgsql;
 
 select perform_test_func();
@@ -1954,7 +1981,8 @@ begin
   select into x id from users where login = a_login;
   if found then return x; end if;
   return 0;
-end$function$
+end
+$function$
 language plpgsql
 stable;
 
@@ -1979,7 +2007,8 @@ begin
     RETURN -2;  -- error code for insertion failure
   END IF;
   RETURN my_id_user;
-end$function$
+end
+$function$
 language plpgsql;
 
 select sp_add_user('user1');
@@ -2215,7 +2244,8 @@ declare
     select * from tenk1 where thousand = p1 and tenthous = p2;
 begin
   open c1 (p2 := 77, p1 := 42/0);
-end $function$
+end
+$function$
 language plpgsql;
 
 select namedparmcursor_test7();
@@ -2232,7 +2262,8 @@ begin
   , 42);
   fetch c1 into n;
   return n;
-end $function$
+end
+$function$
 language plpgsql;
 
 select namedparmcursor_test8();
@@ -2251,7 +2282,8 @@ begin
   open c1 (p1 := p1, p2 => p2, debug => 2);
   fetch c1 into n;
   return n;
-end $function$
+end
+$function$
 language plpgsql;
 
 select namedparmcursor_test9(6);
@@ -2322,7 +2354,8 @@ begin
     Johnny Yuma;
     a := 10;
     return a;
-end$function$
+end
+$function$
 language plpgsql;
 
 create function bad_sql2()
@@ -2334,7 +2367,8 @@ begin
         raise notice 'in loop';
     end loop;
     return 5;
-end;$function$
+end;
+$function$
 language plpgsql;
 
 create function missing_return_expr()
@@ -2342,7 +2376,8 @@ returns int
 as $function$
 begin
     return ;
-end;$function$
+end;
+$function$
 language plpgsql;
 
 create function void_return_expr()
@@ -2350,7 +2385,8 @@ returns void
 as $function$
 begin
     return 5;
-end;$function$
+end;
+$function$
 language plpgsql;
 
 create function void_return_expr()
@@ -2358,7 +2394,8 @@ returns void
 as $function$
 begin
     perform 2+2;
-end;$function$
+end;
+$function$
 language plpgsql;
 
 select void_return_expr();
@@ -2368,7 +2405,8 @@ returns int
 as $function$
 begin
     perform 2+2;
-end;$function$
+end;
+$function$
 language plpgsql;
 
 select missing_return_expr();
@@ -2404,7 +2442,8 @@ begin
     raise notice '% % %', i, j, k;
     execute 'select 1,2' into _v;
     return _v;
-end; $function$
+end;
+$function$
 language plpgsql;
 
 select execute_into_test('eifoo');
@@ -2418,7 +2457,8 @@ returns void
 as $function$
 begin
     raise notice '% %', sqlstate, sqlerrm;
-end; $function$
+end;
+$function$
 language plpgsql;
 
 select excpt_test1();
@@ -2432,7 +2472,8 @@ begin
             raise notice '% %', sqlstate, sqlerrm;
         end;
     end;
-end; $function$
+end;
+$function$
 language plpgsql;
 
 select excpt_test2();
@@ -2457,7 +2498,8 @@ begin
 	    end;
 	    raise notice '% %', sqlstate, sqlerrm;
     end;
-end; $function$
+end;
+$function$
 language plpgsql;
 
 select excpt_test3();
@@ -2468,7 +2510,8 @@ as $function$
 begin
 	begin perform 1/0;
 	exception when others then return sqlerrm; end;
-end; $function$
+end;
+$function$
 language plpgsql;
 
 select excpt_test4();
@@ -2491,7 +2534,8 @@ declare
 begin
     i := 2;
     raise notice '%; %; %; %; %; %', a, a[i], c, (select c || 'abc'), row(10,'aaa',NULL,30), NULL;
-end;$function$
+end;
+$function$
 language plpgsql;
 
 select raise_exprs();
@@ -2507,7 +2551,8 @@ declare
 begin
   select into x,y unique1/p1, unique1/$1 from tenk1 group by unique1/p1;
   return x = y;
-end$function$
+end
+$function$
 language plpgsql;
 
 select multi_datum_use(42);
@@ -2527,7 +2572,8 @@ begin
   -- should work
   insert into foo values(5,6) returning * into x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2540,7 +2586,8 @@ begin
   -- should fail due to implicit strict
   insert into foo values(7,8),(9,10) returning * into x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2553,7 +2600,8 @@ begin
   -- should work
   execute 'insert into foo values(5,6) returning *' into x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2566,7 +2614,8 @@ begin
   -- this should work since EXECUTE isn't as picky
   execute 'insert into foo values(7,8),(9,10) returning *' into x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2581,7 +2630,8 @@ begin
   -- should work
   select * from foo where f1 = 3 into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2594,7 +2644,8 @@ begin
   -- should fail, no rows
   select * from foo where f1 = 0 into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2607,7 +2658,8 @@ begin
   -- should fail, too many rows
   select * from foo where f1 > 3 into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2620,7 +2672,8 @@ begin
   -- should work
   execute 'select * from foo where f1 = 3' into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2633,7 +2686,8 @@ begin
   -- should fail, no rows
   execute 'select * from foo where f1 = 0' into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2646,7 +2700,8 @@ begin
   -- should fail, too many rows
   execute 'select * from foo where f1 > 3' into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2666,7 +2721,8 @@ begin
   -- no rows
   select * from foo where f1 = p1 and f1::text = p3 into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2682,7 +2738,8 @@ begin
   -- no rows
   select * from foo where f1 = p1 and f1::text = p3 into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2698,7 +2755,8 @@ begin
   -- too many rows
   select * from foo where f1 > p1 or f1::text = p3  into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2711,7 +2769,8 @@ begin
   -- too many rows, no params
   select * from foo where f1 > 3 into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2724,7 +2783,8 @@ begin
   -- no rows
   execute 'select * from foo where f1 = $1 or f1::text = $2' using 0, 'foo' into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2737,7 +2797,8 @@ begin
   -- too many rows
   execute 'select * from foo where f1 > $1' using 1 into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2750,7 +2811,8 @@ begin
   -- too many rows, no parameters
   execute 'select * from foo where f1 > 3' into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2768,7 +2830,8 @@ begin
   -- too many rows
   select * from foo where f1 > p1 or f1::text = p3  into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2788,7 +2851,8 @@ begin
   -- too many rows
   select * from foo where f1 > p1 or f1::text = p3  into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2849,7 +2913,8 @@ begin
 	f1 int;
 	begin
 	end;
-end$function$
+end
+$function$
 language plpgsql;
 
 drop function shadowtest();
@@ -2864,7 +2929,8 @@ begin
 	in1 int;
 	begin
 	end;
-end$function$
+end
+$function$
 language plpgsql;
 
 drop function shadowtest(int);
@@ -2876,7 +2942,8 @@ declare
 f1 int;
 c1 cursor (f1 int) for select 1;
 begin
-end$function$
+end
+$function$
 language plpgsql;
 
 drop function shadowtest();
@@ -2886,7 +2953,8 @@ set plpgsql.extra_errors = shadowed_variables;
 create or replace function shadowtest(f1 int)
 returns boolean
 as $function$
-declare f1 int; begin return 1; end $function$
+declare f1 int; begin return 1; end
+$function$
 language plpgsql;
 
 select shadowtest(1);
@@ -2898,14 +2966,16 @@ reset plpgsql.extra_warnings;
 create or replace function shadowtest(f1 int)
 returns boolean
 as $function$
-declare f1 int; begin return 1; end $function$
+declare f1 int; begin return 1; end
+$function$
 language plpgsql;
 
 select shadowtest(1);
 
 set plpgsql.extra_warnings = too_many_rows;
 
-do $do$
+do
+$do$
 declare x int;
 begin
   select v from generate_series(1,2) g(v) into x;
@@ -2914,7 +2984,8 @@ $do$;
 
 set plpgsql.extra_errors = too_many_rows;
 
-do $do$
+do
+$do$
 declare x int;
 begin
   select v from generate_series(1,2) g(v) into x;
@@ -2987,7 +3058,8 @@ begin
 end;
 $do$;
 
-do $do$
+do
+$do$
 declare
   t test_01;
 begin
@@ -3346,7 +3418,8 @@ begin
     end;
   end loop;
   raise notice 'cnt = %', cnt;
-end $do$;
+end
+$do$;
 
 create or replace function forc_bad()
 returns void
@@ -4131,7 +4204,9 @@ language plpgsql;
 
 create function sql_recurse(double precision)
 returns double precision
-as $function$ select recurse($1) limit 1; $function$
+as $function$
+select recurse($1) limit 1;
+$function$
 language sql;
 
 select recurse(10);
@@ -4139,7 +4214,9 @@ select recurse(10);
 create function error1(text)
 returns text
 language sql
-as $function$ SELECT relname::text FROM pg_class c WHERE c.oid = $1::regclass $function$;
+as $function$
+SELECT relname::text FROM pg_class c WHERE c.oid = $1::regclass
+$function$;
 
 create function error2(p_name_table text)
 returns text
@@ -4147,7 +4224,8 @@ language plpgsql
 as $function$
 begin
   return error1(p_name_table);
-end$function$;
+end
+$function$;
 
 begin;
 
@@ -4183,7 +4261,8 @@ returns date
 as $function$
 begin
   return $1;
-end$function$
+end
+$function$
 language plpgsql;
 
 select cast_invoker(20150717);
@@ -4216,9 +4295,15 @@ drop function sql_to_date(int) cascade;
 
 begin;
 
-do $do$ declare x text[]; begin x := '{1.23, 4.56}'::numeric[]; end $do$;
+do
+$do$
+declare x text[]; begin x := '{1.23, 4.56}'::numeric[]; end
+$do$;
 
-do $do$ declare x text[]; begin x := '{1.23, 4.56}'::numeric[]; end $do$;
+do
+$do$
+declare x text[]; begin x := '{1.23, 4.56}'::numeric[]; end
+$do$;
 
 commit;
 
@@ -4299,9 +4384,14 @@ BEGIN
     LOOP
         RAISE NOTICE '%, %', r.roomno, r.comment;
     END LOOP;
-END$do$;
+END
+$do$;
 
-do language plpgsql $do$begin return 1; end$do$;
+do
+language plpgsql
+$do$
+begin return 1; end
+$do$;
 
 do
 $do$
@@ -4311,7 +4401,8 @@ BEGIN
     LOOP
         RAISE NOTICE '%, %', r.roomno, r.comment;
     END LOOP;
-END$do$;
+END
+$do$;
 
 do
 $do$
@@ -4333,7 +4424,8 @@ begin
 end;
 $do$;
 
-do $do$
+do
+$do$
 declare x int := x + 1;  -- error
 begin
   raise notice 'x = %', x;
@@ -4626,7 +4718,8 @@ begin
   r := row(12, '{foo,bar,baz}')::rtype;
   r.ar[2] := 'replace';
   return r.ar;
-end$function$;
+end
+$function$;
 
 select arrayassign1();
 
@@ -4647,7 +4740,8 @@ begin
   res := array[x1, x2];
   res[2] := x3;
   return res;
-end$function$;
+end
+$function$;
 
 select testoa(1, 2, 3);
 
@@ -4665,7 +4759,7 @@ create function returns_rw_array(int)
 returns int[]
 language plpgsql
 as $function$
-  declare r int[];
+declare r int[];
   begin r := array[$1, $1]; return r; end;
 $function$
 stable;
@@ -4674,7 +4768,7 @@ create function consumes_rw_array(int[])
 returns int
 language plpgsql
 as $function$
-  begin return $1[1]; end;
+begin return $1[1]; end;
 $function$
 stable;
 
@@ -4702,12 +4796,14 @@ select consumes_rw_array(a), a from (values (returns_rw_array(1)), (returns_rw_a
 
 select consumes_rw_array(a), a from (values (returns_rw_array(1)), (returns_rw_array(2))) as v (a);
 
-do $do$
+do
+$do$
 declare a int[] := array[1,2];
 begin
   a := a || 3;
   raise notice 'a = %', a;
-end$do$;
+end
+$do$;
 
 create function inner_func(int)
 returns int
@@ -4851,19 +4947,22 @@ begin
 end;
 $do$;
 
-do $do$
+do
+$do$
 begin
   assert 1=1;  -- should succeed
 end;
 $do$;
 
-do $do$
+do
+$do$
 begin
   assert 1=0;  -- should fail
 end;
 $do$;
 
-do $do$
+do
+$do$
 begin
   assert NULL;  -- should fail
 end;
@@ -4871,7 +4970,8 @@ $do$;
 
 set plpgsql.check_asserts = off;
 
-do $do$
+do
+$do$
 begin
   assert 1=0;  -- won't be tested
 end;
@@ -4906,14 +5006,16 @@ immutable;
 
 create domain plpgsql_domain as int check (plpgsql_domain_check(value));
 
-do $do$
+do
+$do$
 declare v_test plpgsql_domain;
 begin
   v_test := 1;
 end;
 $do$;
 
-do $do$
+do
+$do$
 declare v_test plpgsql_domain := 1;
 begin
   v_test := 0;  -- fail
@@ -5049,7 +5151,7 @@ create function transition_table_level1_ri_parent_del_func()
 returns trigger
 language plpgsql
 as $function$
-  DECLARE n bigint;
+DECLARE n bigint;
   BEGIN
     PERFORM FROM p JOIN transition_table_level2 c ON c.parent_no = p.level1_no;
     IF FOUND THEN
@@ -5070,7 +5172,7 @@ create function transition_table_level1_ri_parent_upd_func()
 returns trigger
 language plpgsql
 as $function$
-  DECLARE
+DECLARE
     x int;
   BEGIN
     WITH p AS (SELECT level1_no, sum(delta) cnt
@@ -5101,7 +5203,7 @@ create function transition_table_level2_ri_child_insupd_func()
 returns trigger
 language plpgsql
 as $function$
-  BEGIN
+BEGIN
     PERFORM FROM i
       LEFT JOIN transition_table_level1 p
         ON p.level1_no IS NOT NULL AND p.level1_no = i.parent_no
@@ -5166,7 +5268,7 @@ create function transition_table_level2_bad_usage_func()
 returns trigger
 language plpgsql
 as $function$
-  BEGIN
+BEGIN
     INSERT INTO dx VALUES (1000000, 1000000, 'x');
     RETURN NULL;
   END;
@@ -5265,7 +5367,8 @@ BEGIN
       (SELECT COUNT(*)
        FROM (SELECT * FROM new_test UNION ALL SELECT * FROM new_test) ss);
     RETURN NULL;
-END$function$;
+END
+$function$;
 
 create trigger my_trigger
 after update
@@ -5305,7 +5408,8 @@ BEGIN
     a_val := $1;
     SELECT * INTO result FROM partitioned_table WHERE a = a_val;
     RETURN result;
-END; $function$
+END;
+$function$
 language plpgsql;
 
 select * from get_from_partitioned_table(1) as t;
@@ -5322,7 +5426,8 @@ BEGIN
         RETURN NEXT a_val;
     END LOOP;
     RETURN;
-END; $function$
+END;
+$function$
 language plpgsql;
 
 select * from list_partitioned_table() as t;
@@ -5333,5 +5438,6 @@ as $function$
 BEGIN
   GET DIAGNOSTICS x = ROW_COUNT;
   RETURN;
-END; $function$
+END;
+$function$
 language plpgsql;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__plpgsql_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__plpgsql_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/plpgsql.sql
-snapshot_kind: text
 ---
 create table room (
   roomno char(8),
@@ -1552,7 +1551,8 @@ BEGIN
         rslt = CAST($1 AS TEXT) || ',' || recursion_test($1 - 1, $2);
     END IF;
     RETURN rslt;
-END;$function$
+END;
+$function$
 language plpgsql;
 
 select recursion_test(4, 3);
@@ -1562,7 +1562,7 @@ create table found_test_tbl (a int);
 create function test_found()
 returns boolean
 as $function$
-  declare
+declare
   begin
   insert into found_test_tbl values (1);
   if FOUND then
@@ -1594,7 +1594,8 @@ as $function$
     insert into found_test_tbl values (6);
   end if;
   return true;
-  end;$function$
+  end;
+$function$
 language plpgsql;
 
 select test_found();
@@ -1611,7 +1612,8 @@ BEGIN
 		RETURN NEXT rec;
 	END LOOP;
 	RETURN;
-END;$function$
+END;
+$function$
 language plpgsql;
 
 select * from test_table_func_rec();
@@ -1626,7 +1628,8 @@ BEGIN
 		RETURN NEXT row;
 	END LOOP;
 	RETURN;
-END;$function$
+END;
+$function$
 language plpgsql;
 
 select * from test_table_func_row();
@@ -1641,7 +1644,8 @@ BEGIN
 		RETURN NEXT i + 1;
 	END LOOP;
 	RETURN;
-END;$function$
+END;
+$function$
 language plpgsql;
 
 select * from test_ret_set_scalar(1, 10);
@@ -1662,7 +1666,8 @@ BEGIN
 		RETURN NEXT retval;
 	END IF;
 	RETURN;
-END;$function$
+END;
+$function$
 language plpgsql;
 
 select * from test_ret_set_rec_dyn(1500) as (a int, b int, c int);
@@ -1682,7 +1687,8 @@ BEGIN
 		SELECT INTO retval 50, 5::numeric, 'xxx'::text;
 		RETURN retval;
 	END IF;
-END;$function$
+END;
+$function$
 language plpgsql;
 
 select * from test_ret_rec_dyn(1500) as (a int, b int, c int);
@@ -1694,7 +1700,8 @@ returns anyelement
 as $function$
 begin
   return x + 1;
-end$function$
+end
+$function$
 language plpgsql;
 
 select f1(42) as int, f1(4.5) as num;
@@ -1708,7 +1715,8 @@ returns anyarray
 as $function$
 begin
   return array[x + 1, x + 2];
-end$function$
+end
+$function$
 language plpgsql;
 
 select f1(42) as int, f1(4.5) as num;
@@ -1720,7 +1728,8 @@ returns anyelement
 as $function$
 begin
   return x[1];
-end$function$
+end
+$function$
 language plpgsql;
 
 select f1(array[2, 4]) as int, f1(array[4.5, 7.7]) as num;
@@ -1734,7 +1743,8 @@ returns anyarray
 as $function$
 begin
   return x;
-end$function$
+end
+$function$
 language plpgsql;
 
 select f1(array[2, 4]) as int, f1(array[4.5, 7.7]) as num;
@@ -1748,7 +1758,8 @@ returns anyrange
 as $function$
 begin
   return array[x + 1, x + 2];
-end$function$
+end
+$function$
 language plpgsql;
 
 create function f1(x anyrange)
@@ -1756,7 +1767,8 @@ returns anyarray
 as $function$
 begin
   return array[lower(x), upper(x)];
-end$function$
+end
+$function$
 language plpgsql;
 
 select f1(int4range(42, 49)) as int, f1(float8range(4.5, 7.8)) as num;
@@ -1768,7 +1780,8 @@ returns anycompatiblearray
 as $function$
 begin
   return array[x, y];
-end$function$
+end
+$function$
 language plpgsql;
 
 select f1(2, 4) as int, f1(2, 4.5) as num;
@@ -1780,7 +1793,8 @@ returns anycompatiblearray
 as $function$
 begin
   return array[lower(x), upper(x), y, z];
-end$function$
+end
+$function$
 language plpgsql;
 
 select
@@ -1806,7 +1820,8 @@ returns anycompatiblerange
 as $function$
 begin
   return array[x + 1, x + 2];
-end$function$
+end
+$function$
 language plpgsql;
 
 create function f1(x anycompatiblerange, y anycompatiblearray)
@@ -1814,7 +1829,8 @@ returns anycompatiblerange
 as $function$
 begin
   return x;
-end$function$
+end
+$function$
 language plpgsql;
 
 select
@@ -1837,7 +1853,8 @@ as $function$
 begin
   x := a || b;
   y := array[c, d];
-end$function$
+end
+$function$
 language plpgsql;
 
 select x, pg_typeof(x), y, pg_typeof(y) from f1(11, array[1, 2], 42, 34.5);
@@ -1872,7 +1889,8 @@ returns int
 as $function$
 begin
   return i+1;
-end$function$
+end
+$function$
 language plpgsql;
 
 create function f1(in i int, out j int)
@@ -1880,7 +1898,8 @@ as $function$
 begin
   j := i+1;
   return;
-end$function$
+end
+$function$
 language plpgsql;
 
 select f1(42);
@@ -1891,7 +1910,8 @@ create or replace function f1(inout i int)
 as $function$
 begin
   i := i+1;
-end$function$
+end
+$function$
 language plpgsql;
 
 select f1(42);
@@ -1909,7 +1929,8 @@ begin
   j := i+2;
   return next;
   return;
-end$function$
+end
+$function$
 language plpgsql;
 
 select * from f1(42);
@@ -1922,7 +1943,8 @@ begin
   j := i;
   j := j+1;
   k := 'foo';
-end$function$
+end
+$function$
 language plpgsql;
 
 select f1(42);
@@ -1941,7 +1963,8 @@ begin
   j := j+1;
   k := 'foot';
   return next;
-end$function$
+end
+$function$
 language plpgsql;
 
 select * from f1(42);
@@ -1954,7 +1977,8 @@ begin
   j := i;
   k := array[j,j];
   return;
-end$function$
+end
+$function$
 language plpgsql;
 
 select * from duplic(42);
@@ -1974,7 +1998,8 @@ begin
   j := lower(i);
   k := array[lower(i),upper(i)];
   return;
-end$function$
+end
+$function$
 language plpgsql;
 
 select * from duplic(int4range(42, 49));
@@ -1998,7 +2023,8 @@ BEGIN
 	ELSE
 		RETURN FALSE;
 	END IF;
-END;$function$
+END;
+$function$
 language plpgsql;
 
 create function perform_test_func()
@@ -2022,7 +2048,8 @@ BEGIN
 	END IF;
 
 	RETURN;
-END;$function$
+END;
+$function$
 language plpgsql;
 
 select perform_test_func();
@@ -2044,7 +2071,8 @@ begin
   select into x id from users where login = a_login;
   if found then return x; end if;
   return 0;
-end$function$
+end
+$function$
 language plpgsql
 stable;
 
@@ -2069,7 +2097,8 @@ begin
     RETURN -2;  -- error code for insertion failure
   END IF;
   RETURN my_id_user;
-end$function$
+end
+$function$
 language plpgsql;
 
 select sp_add_user('user1');
@@ -2308,7 +2337,8 @@ declare
     select * from tenk1 where thousand = p1 and tenthous = p2;
 begin
   open c1 (p2 := 77, p1 := 42/0);
-end $function$
+end
+$function$
 language plpgsql;
 
 select namedparmcursor_test7();
@@ -2325,7 +2355,8 @@ begin
   , 42);
   fetch c1 into n;
   return n;
-end $function$
+end
+$function$
 language plpgsql;
 
 select namedparmcursor_test8();
@@ -2344,7 +2375,8 @@ begin
   open c1 (p1 := p1, p2 => p2, debug => 2);
   fetch c1 into n;
   return n;
-end $function$
+end
+$function$
 language plpgsql;
 
 select namedparmcursor_test9(6);
@@ -2415,7 +2447,8 @@ begin
     Johnny Yuma;
     a := 10;
     return a;
-end$function$
+end
+$function$
 language plpgsql;
 
 create function bad_sql2()
@@ -2427,7 +2460,8 @@ begin
         raise notice 'in loop';
     end loop;
     return 5;
-end;$function$
+end;
+$function$
 language plpgsql;
 
 create function missing_return_expr()
@@ -2435,7 +2469,8 @@ returns int
 as $function$
 begin
     return ;
-end;$function$
+end;
+$function$
 language plpgsql;
 
 create function void_return_expr()
@@ -2443,7 +2478,8 @@ returns void
 as $function$
 begin
     return 5;
-end;$function$
+end;
+$function$
 language plpgsql;
 
 create function void_return_expr()
@@ -2451,7 +2487,8 @@ returns void
 as $function$
 begin
     perform 2+2;
-end;$function$
+end;
+$function$
 language plpgsql;
 
 select void_return_expr();
@@ -2461,7 +2498,8 @@ returns int
 as $function$
 begin
     perform 2+2;
-end;$function$
+end;
+$function$
 language plpgsql;
 
 select missing_return_expr();
@@ -2497,7 +2535,8 @@ begin
     raise notice '% % %', i, j, k;
     execute 'select 1,2' into _v;
     return _v;
-end; $function$
+end;
+$function$
 language plpgsql;
 
 select execute_into_test('eifoo');
@@ -2511,7 +2550,8 @@ returns void
 as $function$
 begin
     raise notice '% %', sqlstate, sqlerrm;
-end; $function$
+end;
+$function$
 language plpgsql;
 
 select excpt_test1();
@@ -2525,7 +2565,8 @@ begin
             raise notice '% %', sqlstate, sqlerrm;
         end;
     end;
-end; $function$
+end;
+$function$
 language plpgsql;
 
 select excpt_test2();
@@ -2550,7 +2591,8 @@ begin
 	    end;
 	    raise notice '% %', sqlstate, sqlerrm;
     end;
-end; $function$
+end;
+$function$
 language plpgsql;
 
 select excpt_test3();
@@ -2561,7 +2603,8 @@ as $function$
 begin
 	begin perform 1/0;
 	exception when others then return sqlerrm; end;
-end; $function$
+end;
+$function$
 language plpgsql;
 
 select excpt_test4();
@@ -2584,7 +2627,8 @@ declare
 begin
     i := 2;
     raise notice '%; %; %; %; %; %', a, a[i], c, (select c || 'abc'), row(10,'aaa',NULL,30), NULL;
-end;$function$
+end;
+$function$
 language plpgsql;
 
 select raise_exprs();
@@ -2600,7 +2644,8 @@ declare
 begin
   select into x,y unique1/p1, unique1/$1 from tenk1 group by unique1/p1;
   return x = y;
-end$function$
+end
+$function$
 language plpgsql;
 
 select multi_datum_use(42);
@@ -2620,7 +2665,8 @@ begin
   -- should work
   insert into foo values(5,6) returning * into x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2633,7 +2679,8 @@ begin
   -- should fail due to implicit strict
   insert into foo values(7,8),(9,10) returning * into x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2646,7 +2693,8 @@ begin
   -- should work
   execute 'insert into foo values(5,6) returning *' into x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2659,7 +2707,8 @@ begin
   -- this should work since EXECUTE isn't as picky
   execute 'insert into foo values(7,8),(9,10) returning *' into x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2674,7 +2723,8 @@ begin
   -- should work
   select * from foo where f1 = 3 into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2687,7 +2737,8 @@ begin
   -- should fail, no rows
   select * from foo where f1 = 0 into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2700,7 +2751,8 @@ begin
   -- should fail, too many rows
   select * from foo where f1 > 3 into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2713,7 +2765,8 @@ begin
   -- should work
   execute 'select * from foo where f1 = 3' into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2726,7 +2779,8 @@ begin
   -- should fail, no rows
   execute 'select * from foo where f1 = 0' into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2739,7 +2793,8 @@ begin
   -- should fail, too many rows
   execute 'select * from foo where f1 > 3' into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2759,7 +2814,8 @@ begin
   -- no rows
   select * from foo where f1 = p1 and f1::text = p3 into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2775,7 +2831,8 @@ begin
   -- no rows
   select * from foo where f1 = p1 and f1::text = p3 into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2791,7 +2848,8 @@ begin
   -- too many rows
   select * from foo where f1 > p1 or f1::text = p3  into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2804,7 +2862,8 @@ begin
   -- too many rows, no params
   select * from foo where f1 > 3 into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2817,7 +2876,8 @@ begin
   -- no rows
   execute 'select * from foo where f1 = $1 or f1::text = $2' using 0, 'foo' into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2830,7 +2890,8 @@ begin
   -- too many rows
   execute 'select * from foo where f1 > $1' using 1 into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2843,7 +2904,8 @@ begin
   -- too many rows, no parameters
   execute 'select * from foo where f1 > 3' into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2861,7 +2923,8 @@ begin
   -- too many rows
   select * from foo where f1 > p1 or f1::text = p3  into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2881,7 +2944,8 @@ begin
   -- too many rows
   select * from foo where f1 > p1 or f1::text = p3  into strict x;
   raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
-end$function$
+end
+$function$
 language plpgsql;
 
 select stricttest();
@@ -2942,7 +3006,8 @@ begin
 	f1 int;
 	begin
 	end;
-end$function$
+end
+$function$
 language plpgsql;
 
 drop function shadowtest();
@@ -2957,7 +3022,8 @@ begin
 	in1 int;
 	begin
 	end;
-end$function$
+end
+$function$
 language plpgsql;
 
 drop function shadowtest(int);
@@ -2969,7 +3035,8 @@ declare
 f1 int;
 c1 cursor (f1 int) for select 1;
 begin
-end$function$
+end
+$function$
 language plpgsql;
 
 drop function shadowtest();
@@ -2979,7 +3046,8 @@ set plpgsql.extra_errors = shadowed_variables;
 create or replace function shadowtest(f1 int)
 returns boolean
 as $function$
-declare f1 int; begin return 1; end $function$
+declare f1 int; begin return 1; end
+$function$
 language plpgsql;
 
 select shadowtest(1);
@@ -2991,7 +3059,8 @@ reset plpgsql.extra_warnings;
 create or replace function shadowtest(f1 int)
 returns boolean
 as $function$
-declare f1 int; begin return 1; end $function$
+declare f1 int; begin return 1; end
+$function$
 language plpgsql;
 
 select shadowtest(1);
@@ -3082,7 +3151,8 @@ begin
 end;
 $do$;
 
-do $do$
+do
+$do$
 declare
   t test_01;
 begin
@@ -3447,7 +3517,8 @@ begin
     end;
   end loop;
   raise notice 'cnt = %', cnt;
-end $do$;
+end
+$do$;
 
 create or replace function forc_bad()
 returns void
@@ -4232,7 +4303,9 @@ language plpgsql;
 
 create function sql_recurse(double precision)
 returns double precision
-as $function$ select recurse($1) limit 1; $function$
+as $function$
+select recurse($1) limit 1;
+$function$
 language sql;
 
 select recurse(10);
@@ -4240,7 +4313,9 @@ select recurse(10);
 create function error1(text)
 returns text
 language sql
-as $function$ SELECT relname::text FROM pg_class c WHERE c.oid = $1::regclass $function$;
+as $function$
+SELECT relname::text FROM pg_class c WHERE c.oid = $1::regclass
+$function$;
 
 create function error2(p_name_table text)
 returns text
@@ -4248,7 +4323,8 @@ language plpgsql
 as $function$
 begin
   return error1(p_name_table);
-end$function$;
+end
+$function$;
 
 begin;
 
@@ -4284,7 +4360,8 @@ returns date
 as $function$
 begin
   return $1;
-end$function$
+end
+$function$
 language plpgsql;
 
 select cast_invoker(20150717);
@@ -4317,9 +4394,15 @@ drop function sql_to_date(int) cascade;
 
 begin;
 
-do $do$ declare x text[]; begin x := '{1.23, 4.56}'::numeric[]; end $do$;
+do
+$do$
+declare x text[]; begin x := '{1.23, 4.56}'::numeric[]; end
+$do$;
 
-do $do$ declare x text[]; begin x := '{1.23, 4.56}'::numeric[]; end $do$;
+do
+$do$
+declare x text[]; begin x := '{1.23, 4.56}'::numeric[]; end
+$do$;
 
 commit;
 
@@ -4400,9 +4483,14 @@ BEGIN
     LOOP
         RAISE NOTICE '%, %', r.roomno, r.comment;
     END LOOP;
-END$do$;
+END
+$do$;
 
-do language plpgsql $do$begin return 1; end$do$;
+do
+language plpgsql
+$do$
+begin return 1; end
+$do$;
 
 do
 $do$
@@ -4412,7 +4500,8 @@ BEGIN
     LOOP
         RAISE NOTICE '%, %', r.roomno, r.comment;
     END LOOP;
-END$do$;
+END
+$do$;
 
 do
 $do$
@@ -4728,7 +4817,8 @@ begin
   r := row(12, '{foo,bar,baz}')::rtype;
   r.ar[2] := 'replace';
   return r.ar;
-end$function$;
+end
+$function$;
 
 select arrayassign1();
 
@@ -4750,7 +4840,8 @@ begin
   res := array[x1, x2];
   res[2] := x3;
   return res;
-end$function$;
+end
+$function$;
 
 select testoa(1, 2, 3);
 
@@ -4768,7 +4859,7 @@ create function returns_rw_array(int)
 returns int[]
 language plpgsql
 as $function$
-  declare r int[];
+declare r int[];
   begin r := array[$1, $1]; return r; end;
 $function$
 stable;
@@ -4777,7 +4868,7 @@ create function consumes_rw_array(int[])
 returns int
 language plpgsql
 as $function$
-  begin return $1[1]; end;
+begin return $1[1]; end;
 $function$
 stable;
 
@@ -4835,7 +4926,8 @@ declare a int[] := array[1,2];
 begin
   a := a || 3;
   raise notice 'a = %', a;
-end$do$;
+end
+$do$;
 
 create function inner_func(int)
 returns int
@@ -4979,19 +5071,22 @@ begin
 end;
 $do$;
 
-do $do$
+do
+$do$
 begin
   assert 1=1;  -- should succeed
 end;
 $do$;
 
-do $do$
+do
+$do$
 begin
   assert 1=0;  -- should fail
 end;
 $do$;
 
-do $do$
+do
+$do$
 begin
   assert NULL;  -- should fail
 end;
@@ -4999,7 +5094,8 @@ $do$;
 
 set plpgsql.check_asserts = off;
 
-do $do$
+do
+$do$
 begin
   assert 1=0;  -- won't be tested
 end;
@@ -5034,7 +5130,8 @@ immutable;
 
 create domain plpgsql_domain as int check (plpgsql_domain_check(value));
 
-do $do$
+do
+$do$
 declare v_test plpgsql_domain;
 begin
   v_test := 1;
@@ -5182,7 +5279,7 @@ create function transition_table_level1_ri_parent_del_func()
 returns trigger
 language plpgsql
 as $function$
-  DECLARE n bigint;
+DECLARE n bigint;
   BEGIN
     PERFORM FROM p JOIN transition_table_level2 c ON c.parent_no = p.level1_no;
     IF FOUND THEN
@@ -5203,7 +5300,7 @@ create function transition_table_level1_ri_parent_upd_func()
 returns trigger
 language plpgsql
 as $function$
-  DECLARE
+DECLARE
     x int;
   BEGIN
     WITH p AS (SELECT level1_no, sum(delta) cnt
@@ -5234,7 +5331,7 @@ create function transition_table_level2_ri_child_insupd_func()
 returns trigger
 language plpgsql
 as $function$
-  BEGIN
+BEGIN
     PERFORM FROM i
       LEFT JOIN transition_table_level1 p
         ON p.level1_no IS NOT NULL AND p.level1_no = i.parent_no
@@ -5300,7 +5397,7 @@ create function transition_table_level2_bad_usage_func()
 returns trigger
 language plpgsql
 as $function$
-  BEGIN
+BEGIN
     INSERT INTO dx VALUES (1000000, 1000000, 'x');
     RETURN NULL;
   END;
@@ -5406,7 +5503,8 @@ BEGIN
       (SELECT COUNT(*)
        FROM (SELECT * FROM new_test UNION ALL SELECT * FROM new_test) ss);
     RETURN NULL;
-END$function$;
+END
+$function$;
 
 create trigger my_trigger
 after update
@@ -5446,7 +5544,8 @@ BEGIN
     a_val := $1;
     SELECT * INTO result FROM partitioned_table WHERE a = a_val;
     RETURN result;
-END; $function$
+END;
+$function$
 language plpgsql;
 
 select * from get_from_partitioned_table(1) as t;
@@ -5463,7 +5562,8 @@ BEGIN
         RETURN NEXT a_val;
     END LOOP;
     RETURN;
-END; $function$
+END;
+$function$
 language plpgsql;
 
 select * from list_partitioned_table() as t;
@@ -5474,5 +5574,6 @@ as $function$
 BEGIN
   GET DIAGNOSTICS x = ROW_COUNT;
   RETURN;
-END; $function$
+END;
+$function$
 language plpgsql;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__polymorphism_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__polymorphism_100.snap
@@ -1,12 +1,11 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/polymorphism.sql
-snapshot_kind: text
 ---
 create function polyf(x anyelement)
 returns anyelement
 as $function$
-  select x + 1
+select x + 1
 $function$
 language sql;
 
@@ -19,7 +18,7 @@ drop function polyf(anyelement);
 create function polyf(x anyelement)
 returns anyarray
 as $function$
-  select array[x + 1, x + 2]
+select array[x + 1, x + 2]
 $function$
 language sql;
 
@@ -30,7 +29,7 @@ drop function polyf(anyelement);
 create function polyf(x anyarray)
 returns anyelement
 as $function$
-  select x[1]
+select x[1]
 $function$
 language sql;
 
@@ -43,7 +42,7 @@ drop function polyf(anyarray);
 create function polyf(x anyarray)
 returns anyarray
 as $function$
-  select x
+select x
 $function$
 language sql;
 
@@ -56,14 +55,14 @@ drop function polyf(anyarray);
 create function polyf(x anyelement)
 returns anyrange
 as $function$
-  select array[x + 1, x + 2]
+select array[x + 1, x + 2]
 $function$
 language sql;
 
 create function polyf(x anyrange)
 returns anyarray
 as $function$
-  select array[lower(x), upper(x)]
+select array[lower(x), upper(x)]
 $function$
 language sql;
 
@@ -74,7 +73,7 @@ drop function polyf(anyrange);
 create function polyf(x anycompatible, y anycompatible)
 returns anycompatiblearray
 as $function$
-  select array[x, y]
+select array[x, y]
 $function$
 language sql;
 
@@ -85,7 +84,7 @@ drop function polyf(anycompatible, anycompatible);
 create function polyf(x anycompatiblerange, y anycompatible, z anycompatible)
 returns anycompatiblearray
 as $function$
-  select array[lower(x), upper(x), y, z]
+select array[lower(x), upper(x), y, z]
 $function$
 language sql;
 
@@ -106,7 +105,7 @@ drop function polyf(anycompatiblerange, anycompatible, anycompatible);
 create function polyf(x anycompatiblemultirange, y anycompatible, z anycompatible)
 returns anycompatiblearray
 as $function$
-  select array[lower(x), upper(x), y, z]
+select array[lower(x), upper(x), y, z]
 $function$
 language sql;
 
@@ -131,14 +130,14 @@ drop function polyf(anycompatiblemultirange, anycompatible, anycompatible);
 create function polyf(x anycompatible)
 returns anycompatiblerange
 as $function$
-  select array[x + 1, x + 2]
+select array[x + 1, x + 2]
 $function$
 language sql;
 
 create function polyf(x anycompatiblerange, y anycompatiblearray)
 returns anycompatiblerange
 as $function$
-  select x
+select x
 $function$
 language sql;
 
@@ -149,14 +148,14 @@ drop function polyf(anycompatiblerange, anycompatiblearray);
 create function polyf(x anycompatible)
 returns anycompatiblemultirange
 as $function$
-  select array[x + 1, x + 2]
+select array[x + 1, x + 2]
 $function$
 language sql;
 
 create function polyf(x anycompatiblemultirange, y anycompatiblearray)
 returns anycompatiblemultirange
 as $function$
-  select x
+select x
 $function$
 language sql;
 
@@ -178,7 +177,7 @@ polyf(
   out y anycompatiblearray
 )
 as $function$
-  select a || b, array[c, d]
+select a || b, array[c, d]
 $function$
 language sql;
 
@@ -194,7 +193,9 @@ drop function polyf(anyelement, anyarray, anycompatible, anycompatible);
 
 create function polyf(anyrange)
 returns anymultirange
-as $function$select multirange($1);$function$
+as $function$
+select multirange($1);
+$function$
 language sql;
 
 select polyf(int4range(1, 10));
@@ -205,7 +206,9 @@ drop function polyf(anyrange);
 
 create function polyf(anymultirange)
 returns anyelement
-as $function$select lower($1);$function$
+as $function$
+select lower($1);
+$function$
 language sql;
 
 select polyf(int4multirange(int4range(1, 10), int4range(20, 30)));
@@ -216,7 +219,9 @@ drop function polyf(anymultirange);
 
 create function polyf(anycompatiblerange)
 returns anycompatiblemultirange
-as $function$select multirange($1);$function$
+as $function$
+select multirange($1);
+$function$
 language sql;
 
 select polyf(int4range(1, 10));
@@ -227,7 +232,9 @@ drop function polyf(anycompatiblerange);
 
 create function polyf(anymultirange)
 returns anyrange
-as $function$select range_merge($1);$function$
+as $function$
+select range_merge($1);
+$function$
 language sql;
 
 select polyf(int4multirange(int4range(1, 10), int4range(20, 30)));
@@ -238,7 +245,9 @@ drop function polyf(anymultirange);
 
 create function polyf(anycompatiblemultirange)
 returns anycompatiblerange
-as $function$select range_merge($1);$function$
+as $function$
+select range_merge($1);
+$function$
 language sql;
 
 select polyf(int4multirange(int4range(1, 10), int4range(20, 30)));
@@ -249,7 +258,9 @@ drop function polyf(anycompatiblemultirange);
 
 create function polyf(anycompatiblemultirange)
 returns anycompatible
-as $function$select lower($1);$function$
+as $function$
+select lower($1);
+$function$
 language sql;
 
 select polyf(int4multirange(int4range(1, 10), int4range(20, 30)));
@@ -260,48 +271,66 @@ drop function polyf(anycompatiblemultirange);
 
 create function stfp(anyarray)
 returns anyarray
-as $function$select $1$function$
+as $function$
+select $1
+$function$
 language sql;
 
 create function stfnp(int[])
 returns int[]
-as $function$select $1$function$
+as $function$
+select $1
+$function$
 language sql;
 
 create function tfp(anyarray, anyelement)
 returns anyarray
-as $function$select $1 || $2$function$
+as $function$
+select $1 || $2
+$function$
 language sql;
 
 create function tfnp(int[], int)
 returns int[]
-as $function$select $1 || $2$function$
+as $function$
+select $1 || $2
+$function$
 language sql;
 
 create function tf1p(anyarray, int)
 returns anyarray
-as $function$select $1$function$
+as $function$
+select $1
+$function$
 language sql;
 
 create function tf2p(int[], anyelement)
 returns int[]
-as $function$select $1$function$
+as $function$
+select $1
+$function$
 language sql;
 
 create function sum3(anyelement, anyelement, anyelement)
 returns anyelement
-as $function$select $1+$2+$3$function$
+as $function$
+select $1+$2+$3
+$function$
 language sql
 strict;
 
 create function ffp(anyarray)
 returns anyarray
-as $function$select $1$function$
+as $function$
+select $1
+$function$
 language sql;
 
 create function ffnp(int[])
 returns int[]
-as $function$select $1$function$
+as $function$
+select $1
+$function$
 language sql;
 
 create aggregate myaggp01a (*) (sfunc = stfnp, stype = int[], finalfunc = ffp, initcond = '{}');
@@ -694,13 +723,15 @@ as $function$
 begin
   raise notice 'bleat %', $1;
   return $1;
-end$function$
+end
+$function$
 language plpgsql;
 
 create function sql_if(boolean, anyelement, anyelement)
 returns anyelement
 as $function$
-select case when $1 then $2 else $3 end $function$
+select case when $1 then $2 else $3 end
+$function$
 language sql;
 
 select f1, sql_if(f1 > 0, bleat(f1), bleat(f1 + 1)) from int4_tbl;
@@ -753,13 +784,17 @@ create aggregate build_group (bigint, int) (sfunc = add_group, stype = bigint[])
 
 create function first_el_transfn(anyarray, anyelement)
 returns anyarray
-as $function$select $1 || $2$function$
+as $function$
+select $1 || $2
+$function$
 language sql
 immutable;
 
 create function first_el(anyarray)
 returns anyelement
-as $function$select $1[1]$function$
+as $function$
+select $1[1]
+$function$
 language sql
 strict
 immutable;
@@ -809,7 +844,7 @@ select anyrange_in('[10,20)', cast('int4range' as regtype), -1);
 create function myleast(variadic anyarray)
 returns anyelement
 as $function$
-  select min($1[i]) from generate_subscripts($1,1) g(i)
+select min($1[i]) from generate_subscripts($1,1) g(i)
 $function$
 language sql
 immutable
@@ -832,7 +867,7 @@ select myleast(variadic cast(array[] as int[]));
 create function concat(text, variadic anyarray)
 returns text
 as $function$
-  select array_to_string($2, $1);
+select array_to_string($2, $1);
 $function$
 language sql
 immutable
@@ -851,7 +886,7 @@ drop function concat(text, anyarray);
 create function formarray(anyelement, variadic anyarray)
 returns anyarray
 as $function$
-  select array_prepend($1, $2);
+select array_prepend($1, $2);
 $function$
 language sql
 immutable
@@ -890,7 +925,7 @@ select pg_typeof(myleast(10, 1, 20, 33));
 create function dfunc(a int default 1, int default 2)
 returns int
 as $function$
-  select $1 + $2;
+select $1 + $2;
 $function$
 language sql;
 
@@ -911,13 +946,13 @@ drop function dfunc(int, int);
 create function dfunc(a int default 1, b int)
 returns int
 as $function$
-  select $1 + $2;
+select $1 + $2;
 $function$
 language sql;
 
 create function dfunc(a int default 1, out sum int, b int default 2)
 as $function$
-  select $1 + $2;
+select $1 + $2;
 $function$
 language sql;
 
@@ -928,7 +963,7 @@ drop function dfunc(int, int);
 create function dfunc(a int default 1.0, int default '-1')
 returns int
 as $function$
-  select $1 + $2;
+select $1 + $2;
 $function$
 language sql;
 
@@ -937,7 +972,7 @@ select dfunc();
 create function dfunc(a text default 'Hello', b text default 'World')
 returns text
 as $function$
-  select $1 || ', ' || $2;
+select $1 || ', ' || $2;
 $function$
 language sql;
 
@@ -958,14 +993,14 @@ drop function dfunc(text, text);
 create function dfunc(int default 1, int default 2)
 returns int
 as $function$
-  select 2;
+select 2;
 $function$
 language sql;
 
 create function dfunc(int default 1, int default 2, int default 3, int default 4)
 returns int
 as $function$
-  select 4;
+select 4;
 $function$
 language sql;
 
@@ -986,14 +1021,14 @@ drop function dfunc(int, int, int, int);
 create function dfunc(out int default 20)
 returns int
 as $function$
-  select 1;
+select 1;
 $function$
 language sql;
 
 create function dfunc(anyelement default cast('World' as text))
 returns text
 as $function$
-  select 'Hello, ' || $1::text;
+select 'Hello, ' || $1::text;
 $function$
 language sql;
 
@@ -1009,7 +1044,9 @@ drop function dfunc(anyelement);
 
 create function dfunc(variadic a int[])
 returns int
-as $function$ select array_upper($1, 1) $function$
+as $function$
+select array_upper($1, 1)
+$function$
 language sql;
 
 select dfunc();
@@ -1020,7 +1057,9 @@ select dfunc(10, 20);
 
 create or replace function dfunc(variadic a int[] default cast(array[] as int[]))
 returns int
-as $function$ select array_upper($1, 1) $function$
+as $function$
+select array_upper($1, 1)
+$function$
 language sql;
 
 select dfunc();
@@ -1031,7 +1070,9 @@ select dfunc(10, 20);
 
 create or replace function dfunc(variadic a int[])
 returns int
-as $function$ select array_upper($1, 1) $function$
+as $function$
+select array_upper($1, 1)
+$function$
 language sql;
 
 drop function dfunc(int[]);
@@ -1039,21 +1080,21 @@ drop function dfunc(int[]);
 create function dfunc(int default 1, int default 2, int default 3)
 returns int
 as $function$
-  select 3;
+select 3;
 $function$
 language sql;
 
 create function dfunc(int default 1, int default 2)
 returns int
 as $function$
-  select 2;
+select 2;
 $function$
 language sql;
 
 create function dfunc(text)
 returns text
 as $function$
-  select $1;
+select $1;
 $function$
 language sql;
 
@@ -1075,7 +1116,7 @@ returns table (
   d int
 )
 as $function$
-  select $1, $2, $3, $4;
+select $1, $2, $3, $4;
 $function$
 language sql;
 
@@ -1110,7 +1151,7 @@ drop function dfunc(int, int, int, int);
 create function xleast(x numeric, variadic arr numeric[])
 returns numeric
 as $function$
-  select least(x, min(arr[i])) from generate_subscripts(arr, 1) g(i);
+select least(x, min(arr[i])) from generate_subscripts(arr, 1) g(i);
 $function$
 language sql;
 
@@ -1145,7 +1186,7 @@ returns table (
   c date
 )
 as $function$
-  select $1, $2, $3;
+select $1, $2, $3;
 $function$
 language sql;
 
@@ -1172,7 +1213,7 @@ dfunc(
 )
 returns record
 as $function$
-  select $1, $2;
+select $1, $2;
 $function$
 language sql;
 
@@ -1201,7 +1242,7 @@ dfunc(
 )
 returns record
 as $function$
-  select $1, $2;
+select $1, $2;
 $function$
 language sql;
 
@@ -1214,7 +1255,7 @@ dfunc(
 )
 returns record
 as $function$
-  select $1, $2;
+select $1, $2;
 $function$
 language sql;
 
@@ -1222,27 +1263,37 @@ drop function dfunc(varchar, numeric);
 
 create function testpolym(a int, a int)
 returns int
-as $function$ select 1;$function$
+as $function$
+select 1;
+$function$
 language sql;
 
 create function testpolym(int, out a int, out a int)
 returns int
-as $function$ select 1;$function$
+as $function$
+select 1;
+$function$
 language sql;
 
 create function testpolym(out a int, inout a int)
 returns int
-as $function$ select 1;$function$
+as $function$
+select 1;
+$function$
 language sql;
 
 create function testpolym(a int, inout a int)
 returns int
-as $function$ select 1;$function$
+as $function$
+select 1;
+$function$
 language sql;
 
 create function testpolym(a int, out a int)
 returns int
-as $function$ select $1;$function$
+as $function$
+select $1;
+$function$
 language sql;
 
 select testpolym(37);
@@ -1253,7 +1304,9 @@ create function testpolym(a int)
 returns table (
   a int
 )
-as $function$ select $1;$function$
+as $function$
+select $1;
+$function$
 language sql;
 
 select * from testpolym(37);
@@ -1263,7 +1316,7 @@ drop function testpolym(int);
 create function dfunc(a anyelement, b anyelement default null, flag boolean default true)
 returns anyelement
 as $function$
-  select case when $3 then $1 else $2 end;
+select case when $3 then $1 else $2 end;
 $function$
 language sql;
 
@@ -1325,7 +1378,7 @@ select dfunc("a" := 1);
 
 do
 $do$
-  declare r integer;
+declare r integer;
   begin
     select dfunc(a=>-- comment
       1) into r;
@@ -1351,7 +1404,7 @@ drop function dfunc(anyelement, anyelement, boolean);
 create function anyctest(anycompatible, anycompatible)
 returns anycompatible
 as $function$
-  select greatest($1, $2)
+select greatest($1, $2)
 $function$
 language sql;
 
@@ -1368,7 +1421,7 @@ drop function anyctest(anycompatible, anycompatible);
 create function anyctest(anycompatible, anycompatible)
 returns anycompatiblearray
 as $function$
-  select array[$1, $2]
+select array[$1, $2]
 $function$
 language sql;
 
@@ -1383,7 +1436,7 @@ drop function anyctest(anycompatible, anycompatible);
 create function anyctest(anycompatible, anycompatiblearray)
 returns anycompatiblearray
 as $function$
-  select array[$1] || $2
+select array[$1] || $2
 $function$
 language sql;
 
@@ -1404,7 +1457,7 @@ drop function anyctest(anycompatible, anycompatiblearray);
 create function anyctest(anycompatible, anycompatiblerange)
 returns anycompatiblerange
 as $function$
-  select $2
+select $2
 $function$
 language sql;
 
@@ -1423,7 +1476,7 @@ drop function anyctest(anycompatible, anycompatiblerange);
 create function anyctest(anycompatiblerange, anycompatiblerange)
 returns anycompatible
 as $function$
-  select lower($1) + upper($2)
+select lower($1) + upper($2)
 $function$
 language sql;
 
@@ -1436,14 +1489,14 @@ drop function anyctest(anycompatiblerange, anycompatiblerange);
 create function anyctest(anycompatible)
 returns anycompatiblerange
 as $function$
-  select $1
+select $1
 $function$
 language sql;
 
 create function anyctest(anycompatible, anycompatiblemultirange)
 returns anycompatiblemultirange
 as $function$
-  select $2
+select $2
 $function$
 language sql;
 
@@ -1462,7 +1515,7 @@ drop function anyctest(anycompatible, anycompatiblemultirange);
 create function anyctest(anycompatiblemultirange, anycompatiblemultirange)
 returns anycompatible
 as $function$
-  select lower($1) + upper($2)
+select lower($1) + upper($2)
 $function$
 language sql;
 
@@ -1491,14 +1544,14 @@ drop function anyctest(anycompatiblemultirange, anycompatiblemultirange);
 create function anyctest(anycompatible)
 returns anycompatiblemultirange
 as $function$
-  select $1
+select $1
 $function$
 language sql;
 
 create function anyctest(anycompatiblenonarray, anycompatiblenonarray)
 returns anycompatiblearray
 as $function$
-  select array[$1, $2]
+select array[$1, $2]
 $function$
 language sql;
 
@@ -1513,7 +1566,7 @@ drop function anyctest(anycompatiblenonarray, anycompatiblenonarray);
 create function anyctest(a anyelement, b anyarray, c anycompatible, d anycompatible)
 returns anycompatiblearray
 as $function$
-  select array[c, d]
+select array[c, d]
 $function$
 language sql;
 
@@ -1530,7 +1583,7 @@ drop function anyctest(anyelement, anyarray, anycompatible, anycompatible);
 create function anyctest(variadic anycompatiblearray)
 returns anycompatiblearray
 as $function$
-  select $1
+select $1
 $function$
 language sql;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__polymorphism_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__polymorphism_80.snap
@@ -1,12 +1,11 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/polymorphism.sql
-snapshot_kind: text
 ---
 create function polyf(x anyelement)
 returns anyelement
 as $function$
-  select x + 1
+select x + 1
 $function$
 language sql;
 
@@ -19,7 +18,7 @@ drop function polyf(anyelement);
 create function polyf(x anyelement)
 returns anyarray
 as $function$
-  select array[x + 1, x + 2]
+select array[x + 1, x + 2]
 $function$
 language sql;
 
@@ -30,7 +29,7 @@ drop function polyf(anyelement);
 create function polyf(x anyarray)
 returns anyelement
 as $function$
-  select x[1]
+select x[1]
 $function$
 language sql;
 
@@ -43,7 +42,7 @@ drop function polyf(anyarray);
 create function polyf(x anyarray)
 returns anyarray
 as $function$
-  select x
+select x
 $function$
 language sql;
 
@@ -56,14 +55,14 @@ drop function polyf(anyarray);
 create function polyf(x anyelement)
 returns anyrange
 as $function$
-  select array[x + 1, x + 2]
+select array[x + 1, x + 2]
 $function$
 language sql;
 
 create function polyf(x anyrange)
 returns anyarray
 as $function$
-  select array[lower(x), upper(x)]
+select array[lower(x), upper(x)]
 $function$
 language sql;
 
@@ -74,7 +73,7 @@ drop function polyf(anyrange);
 create function polyf(x anycompatible, y anycompatible)
 returns anycompatiblearray
 as $function$
-  select array[x, y]
+select array[x, y]
 $function$
 language sql;
 
@@ -85,7 +84,7 @@ drop function polyf(anycompatible, anycompatible);
 create function polyf(x anycompatiblerange, y anycompatible, z anycompatible)
 returns anycompatiblearray
 as $function$
-  select array[lower(x), upper(x), y, z]
+select array[lower(x), upper(x), y, z]
 $function$
 language sql;
 
@@ -115,7 +114,7 @@ polyf(
 )
 returns anycompatiblearray
 as $function$
-  select array[lower(x), upper(x), y, z]
+select array[lower(x), upper(x), y, z]
 $function$
 language sql;
 
@@ -140,14 +139,14 @@ drop function polyf(anycompatiblemultirange, anycompatible, anycompatible);
 create function polyf(x anycompatible)
 returns anycompatiblerange
 as $function$
-  select array[x + 1, x + 2]
+select array[x + 1, x + 2]
 $function$
 language sql;
 
 create function polyf(x anycompatiblerange, y anycompatiblearray)
 returns anycompatiblerange
 as $function$
-  select x
+select x
 $function$
 language sql;
 
@@ -162,14 +161,14 @@ drop function polyf(anycompatiblerange, anycompatiblearray);
 create function polyf(x anycompatible)
 returns anycompatiblemultirange
 as $function$
-  select array[x + 1, x + 2]
+select array[x + 1, x + 2]
 $function$
 language sql;
 
 create function polyf(x anycompatiblemultirange, y anycompatiblearray)
 returns anycompatiblemultirange
 as $function$
-  select x
+select x
 $function$
 language sql;
 
@@ -197,7 +196,7 @@ polyf(
   out y anycompatiblearray
 )
 as $function$
-  select a || b, array[c, d]
+select a || b, array[c, d]
 $function$
 language sql;
 
@@ -230,7 +229,9 @@ drop function polyf(anyelement, anyarray, anycompatible, anycompatible);
 
 create function polyf(anyrange)
 returns anymultirange
-as $function$select multirange($1);$function$
+as $function$
+select multirange($1);
+$function$
 language sql;
 
 select polyf(int4range(1, 10));
@@ -241,7 +242,9 @@ drop function polyf(anyrange);
 
 create function polyf(anymultirange)
 returns anyelement
-as $function$select lower($1);$function$
+as $function$
+select lower($1);
+$function$
 language sql;
 
 select polyf(int4multirange(int4range(1, 10), int4range(20, 30)));
@@ -252,7 +255,9 @@ drop function polyf(anymultirange);
 
 create function polyf(anycompatiblerange)
 returns anycompatiblemultirange
-as $function$select multirange($1);$function$
+as $function$
+select multirange($1);
+$function$
 language sql;
 
 select polyf(int4range(1, 10));
@@ -263,7 +268,9 @@ drop function polyf(anycompatiblerange);
 
 create function polyf(anymultirange)
 returns anyrange
-as $function$select range_merge($1);$function$
+as $function$
+select range_merge($1);
+$function$
 language sql;
 
 select polyf(int4multirange(int4range(1, 10), int4range(20, 30)));
@@ -274,7 +281,9 @@ drop function polyf(anymultirange);
 
 create function polyf(anycompatiblemultirange)
 returns anycompatiblerange
-as $function$select range_merge($1);$function$
+as $function$
+select range_merge($1);
+$function$
 language sql;
 
 select polyf(int4multirange(int4range(1, 10), int4range(20, 30)));
@@ -285,7 +294,9 @@ drop function polyf(anycompatiblemultirange);
 
 create function polyf(anycompatiblemultirange)
 returns anycompatible
-as $function$select lower($1);$function$
+as $function$
+select lower($1);
+$function$
 language sql;
 
 select polyf(int4multirange(int4range(1, 10), int4range(20, 30)));
@@ -296,48 +307,66 @@ drop function polyf(anycompatiblemultirange);
 
 create function stfp(anyarray)
 returns anyarray
-as $function$select $1$function$
+as $function$
+select $1
+$function$
 language sql;
 
 create function stfnp(int[])
 returns int[]
-as $function$select $1$function$
+as $function$
+select $1
+$function$
 language sql;
 
 create function tfp(anyarray, anyelement)
 returns anyarray
-as $function$select $1 || $2$function$
+as $function$
+select $1 || $2
+$function$
 language sql;
 
 create function tfnp(int[], int)
 returns int[]
-as $function$select $1 || $2$function$
+as $function$
+select $1 || $2
+$function$
 language sql;
 
 create function tf1p(anyarray, int)
 returns anyarray
-as $function$select $1$function$
+as $function$
+select $1
+$function$
 language sql;
 
 create function tf2p(int[], anyelement)
 returns int[]
-as $function$select $1$function$
+as $function$
+select $1
+$function$
 language sql;
 
 create function sum3(anyelement, anyelement, anyelement)
 returns anyelement
-as $function$select $1+$2+$3$function$
+as $function$
+select $1+$2+$3
+$function$
 language sql
 strict;
 
 create function ffp(anyarray)
 returns anyarray
-as $function$select $1$function$
+as $function$
+select $1
+$function$
 language sql;
 
 create function ffnp(int[])
 returns int[]
-as $function$select $1$function$
+as $function$
+select $1
+$function$
 language sql;
 
 create aggregate myaggp01a (
@@ -884,13 +913,15 @@ as $function$
 begin
   raise notice 'bleat %', $1;
   return $1;
-end$function$
+end
+$function$
 language plpgsql;
 
 create function sql_if(boolean, anyelement, anyelement)
 returns anyelement
 as $function$
-select case when $1 then $2 else $3 end $function$
+select case when $1 then $2 else $3 end
+$function$
 language sql;
 
 select f1, sql_if(f1 > 0, bleat(f1), bleat(f1 + 1)) from int4_tbl;
@@ -964,13 +995,17 @@ create aggregate build_group (
 
 create function first_el_transfn(anyarray, anyelement)
 returns anyarray
-as $function$select $1 || $2$function$
+as $function$
+select $1 || $2
+$function$
 language sql
 immutable;
 
 create function first_el(anyarray)
 returns anyelement
-as $function$select $1[1]$function$
+as $function$
+select $1[1]
+$function$
 language sql
 strict
 immutable;
@@ -1030,7 +1065,7 @@ select anyrange_in('[10,20)', cast('int4range' as regtype), -1);
 create function myleast(variadic anyarray)
 returns anyelement
 as $function$
-  select min($1[i]) from generate_subscripts($1,1) g(i)
+select min($1[i]) from generate_subscripts($1,1) g(i)
 $function$
 language sql
 immutable
@@ -1053,7 +1088,7 @@ select myleast(variadic cast(array[] as int[]));
 create function concat(text, variadic anyarray)
 returns text
 as $function$
-  select array_to_string($2, $1);
+select array_to_string($2, $1);
 $function$
 language sql
 immutable
@@ -1072,7 +1107,7 @@ drop function concat(text, anyarray);
 create function formarray(anyelement, variadic anyarray)
 returns anyarray
 as $function$
-  select array_prepend($1, $2);
+select array_prepend($1, $2);
 $function$
 language sql
 immutable
@@ -1111,7 +1146,7 @@ select pg_typeof(myleast(10, 1, 20, 33));
 create function dfunc(a int default 1, int default 2)
 returns int
 as $function$
-  select $1 + $2;
+select $1 + $2;
 $function$
 language sql;
 
@@ -1132,13 +1167,13 @@ drop function dfunc(int, int);
 create function dfunc(a int default 1, b int)
 returns int
 as $function$
-  select $1 + $2;
+select $1 + $2;
 $function$
 language sql;
 
 create function dfunc(a int default 1, out sum int, b int default 2)
 as $function$
-  select $1 + $2;
+select $1 + $2;
 $function$
 language sql;
 
@@ -1149,7 +1184,7 @@ drop function dfunc(int, int);
 create function dfunc(a int default 1.0, int default '-1')
 returns int
 as $function$
-  select $1 + $2;
+select $1 + $2;
 $function$
 language sql;
 
@@ -1158,7 +1193,7 @@ select dfunc();
 create function dfunc(a text default 'Hello', b text default 'World')
 returns text
 as $function$
-  select $1 || ', ' || $2;
+select $1 || ', ' || $2;
 $function$
 language sql;
 
@@ -1179,7 +1214,7 @@ drop function dfunc(text, text);
 create function dfunc(int default 1, int default 2)
 returns int
 as $function$
-  select 2;
+select 2;
 $function$
 language sql;
 
@@ -1192,7 +1227,7 @@ dfunc(
 )
 returns int
 as $function$
-  select 4;
+select 4;
 $function$
 language sql;
 
@@ -1213,14 +1248,14 @@ drop function dfunc(int, int, int, int);
 create function dfunc(out int default 20)
 returns int
 as $function$
-  select 1;
+select 1;
 $function$
 language sql;
 
 create function dfunc(anyelement default cast('World' as text))
 returns text
 as $function$
-  select 'Hello, ' || $1::text;
+select 'Hello, ' || $1::text;
 $function$
 language sql;
 
@@ -1236,7 +1271,9 @@ drop function dfunc(anyelement);
 
 create function dfunc(variadic a int[])
 returns int
-as $function$ select array_upper($1, 1) $function$
+as $function$
+select array_upper($1, 1)
+$function$
 language sql;
 
 select dfunc();
@@ -1250,7 +1287,9 @@ dfunc(
   variadic a int[] default cast(array[] as int[])
 )
 returns int
-as $function$ select array_upper($1, 1) $function$
+as $function$
+select array_upper($1, 1)
+$function$
 language sql;
 
 select dfunc();
@@ -1261,7 +1300,9 @@ select dfunc(10, 20);
 
 create or replace function dfunc(variadic a int[])
 returns int
-as $function$ select array_upper($1, 1) $function$
+as $function$
+select array_upper($1, 1)
+$function$
 language sql;
 
 drop function dfunc(int[]);
@@ -1269,21 +1310,21 @@ drop function dfunc(int[]);
 create function dfunc(int default 1, int default 2, int default 3)
 returns int
 as $function$
-  select 3;
+select 3;
 $function$
 language sql;
 
 create function dfunc(int default 1, int default 2)
 returns int
 as $function$
-  select 2;
+select 2;
 $function$
 language sql;
 
 create function dfunc(text)
 returns text
 as $function$
-  select $1;
+select $1;
 $function$
 language sql;
 
@@ -1305,7 +1346,7 @@ returns table (
   d int
 )
 as $function$
-  select $1, $2, $3, $4;
+select $1, $2, $3, $4;
 $function$
 language sql;
 
@@ -1340,7 +1381,7 @@ drop function dfunc(int, int, int, int);
 create function xleast(x numeric, variadic arr numeric[])
 returns numeric
 as $function$
-  select least(x, min(arr[i])) from generate_subscripts(arr, 1) g(i);
+select least(x, min(arr[i])) from generate_subscripts(arr, 1) g(i);
 $function$
 language sql;
 
@@ -1375,7 +1416,7 @@ returns table (
   c date
 )
 as $function$
-  select $1, $2, $3;
+select $1, $2, $3;
 $function$
 language sql;
 
@@ -1430,7 +1471,7 @@ dfunc(
 )
 returns record
 as $function$
-  select $1, $2;
+select $1, $2;
 $function$
 language sql;
 
@@ -1459,7 +1500,7 @@ dfunc(
 )
 returns record
 as $function$
-  select $1, $2;
+select $1, $2;
 $function$
 language sql;
 
@@ -1472,7 +1513,7 @@ dfunc(
 )
 returns record
 as $function$
-  select $1, $2;
+select $1, $2;
 $function$
 language sql;
 
@@ -1480,27 +1521,37 @@ drop function dfunc(varchar, numeric);
 
 create function testpolym(a int, a int)
 returns int
-as $function$ select 1;$function$
+as $function$
+select 1;
+$function$
 language sql;
 
 create function testpolym(int, out a int, out a int)
 returns int
-as $function$ select 1;$function$
+as $function$
+select 1;
+$function$
 language sql;
 
 create function testpolym(out a int, inout a int)
 returns int
-as $function$ select 1;$function$
+as $function$
+select 1;
+$function$
 language sql;
 
 create function testpolym(a int, inout a int)
 returns int
-as $function$ select 1;$function$
+as $function$
+select 1;
+$function$
 language sql;
 
 create function testpolym(a int, out a int)
 returns int
-as $function$ select $1;$function$
+as $function$
+select $1;
+$function$
 language sql;
 
 select testpolym(37);
@@ -1511,7 +1562,9 @@ create function testpolym(a int)
 returns table (
   a int
 )
-as $function$ select $1;$function$
+as $function$
+select $1;
+$function$
 language sql;
 
 select * from testpolym(37);
@@ -1526,7 +1579,7 @@ dfunc(
 )
 returns anyelement
 as $function$
-  select case when $3 then $1 else $2 end;
+select case when $3 then $1 else $2 end;
 $function$
 language sql;
 
@@ -1588,7 +1641,7 @@ select dfunc("a" := 1);
 
 do
 $do$
-  declare r integer;
+declare r integer;
   begin
     select dfunc(a=>-- comment
       1) into r;
@@ -1615,7 +1668,7 @@ drop function dfunc(anyelement, anyelement, boolean);
 create function anyctest(anycompatible, anycompatible)
 returns anycompatible
 as $function$
-  select greatest($1, $2)
+select greatest($1, $2)
 $function$
 language sql;
 
@@ -1632,7 +1685,7 @@ drop function anyctest(anycompatible, anycompatible);
 create function anyctest(anycompatible, anycompatible)
 returns anycompatiblearray
 as $function$
-  select array[$1, $2]
+select array[$1, $2]
 $function$
 language sql;
 
@@ -1647,7 +1700,7 @@ drop function anyctest(anycompatible, anycompatible);
 create function anyctest(anycompatible, anycompatiblearray)
 returns anycompatiblearray
 as $function$
-  select array[$1] || $2
+select array[$1] || $2
 $function$
 language sql;
 
@@ -1668,7 +1721,7 @@ drop function anyctest(anycompatible, anycompatiblearray);
 create function anyctest(anycompatible, anycompatiblerange)
 returns anycompatiblerange
 as $function$
-  select $2
+select $2
 $function$
 language sql;
 
@@ -1687,7 +1740,7 @@ drop function anyctest(anycompatible, anycompatiblerange);
 create function anyctest(anycompatiblerange, anycompatiblerange)
 returns anycompatible
 as $function$
-  select lower($1) + upper($2)
+select lower($1) + upper($2)
 $function$
 language sql;
 
@@ -1700,14 +1753,14 @@ drop function anyctest(anycompatiblerange, anycompatiblerange);
 create function anyctest(anycompatible)
 returns anycompatiblerange
 as $function$
-  select $1
+select $1
 $function$
 language sql;
 
 create function anyctest(anycompatible, anycompatiblemultirange)
 returns anycompatiblemultirange
 as $function$
-  select $2
+select $2
 $function$
 language sql;
 
@@ -1726,7 +1779,7 @@ drop function anyctest(anycompatible, anycompatiblemultirange);
 create function anyctest(anycompatiblemultirange, anycompatiblemultirange)
 returns anycompatible
 as $function$
-  select lower($1) + upper($2)
+select lower($1) + upper($2)
 $function$
 language sql;
 
@@ -1755,14 +1808,14 @@ drop function anyctest(anycompatiblemultirange, anycompatiblemultirange);
 create function anyctest(anycompatible)
 returns anycompatiblemultirange
 as $function$
-  select $1
+select $1
 $function$
 language sql;
 
 create function anyctest(anycompatiblenonarray, anycompatiblenonarray)
 returns anycompatiblearray
 as $function$
-  select array[$1, $2]
+select array[$1, $2]
 $function$
 language sql;
 
@@ -1783,7 +1836,7 @@ anyctest(
 )
 returns anycompatiblearray
 as $function$
-  select array[c, d]
+select array[c, d]
 $function$
 language sql;
 
@@ -1810,7 +1863,7 @@ drop function anyctest(anyelement, anyarray, anycompatible, anycompatible);
 create function anyctest(variadic anycompatiblearray)
 returns anycompatiblearray
 as $function$
-  select $1
+select $1
 $function$
 language sql;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__privileges_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__privileges_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/privileges.sql
-snapshot_kind: text
 ---
 set client_min_messages = warning;
 
@@ -305,7 +304,9 @@ grant REGRESS_PRIV_GROUP2 to regress_priv_user4 with ADMIN true;
 
 create function leak(int, int)
 returns boolean
-as $function$int4lt$function$
+as $function$
+int4lt
+$function$
 language internal
 immutable
 strict;
@@ -529,7 +530,9 @@ set session authorization regress_priv_user2;
 
 create function leak2(int, int)
 returns boolean
-as $function$begin raise notice 'leak % %', $1, $2; return $1 > $2; end$function$
+as $function$
+begin raise notice 'leak % %', $1, $2; return $1 > $2; end
+$function$
 language plpgsql
 immutable;
 
@@ -1211,18 +1214,24 @@ grant USAGE on language sql to regress_priv_user2;
 
 create function priv_testfunc1(int)
 returns int
-as $function$select 2 * $1;$function$
+as $function$
+select 2 * $1;
+$function$
 language sql;
 
 create function priv_testfunc2(int)
 returns int
-as $function$select 3 * $1;$function$
+as $function$
+select 3 * $1;
+$function$
 language sql;
 
 create aggregate priv_testagg1 (int) (sfunc = int4pl, stype = int);
 
 create procedure priv_testproc1(int)
-as $procedure$select $1;$procedure$
+as $procedure$
+select $1;
+$procedure$
 language sql;
 
 revoke all on function priv_testfunc1(int), priv_testfunc2(int), priv_testagg1(int) from public;
@@ -1255,7 +1264,9 @@ grant all on procedure priv_testproc1(int) to regress_priv_user4;
 
 create function priv_testfunc4(boolean)
 returns text
-as $function$select col1 from atest2 where col2 = $1;$function$
+as $function$
+select col1 from atest2 where col2 = $1;
+$function$
 language sql
 security definer;
 
@@ -1267,7 +1278,9 @@ select priv_testfunc1(5), priv_testfunc2(5);
 
 create function priv_testfunc3(int)
 returns int
-as $function$select 2 * $1;$function$
+as $function$
+select 2 * $1;
+$function$
 language sql;
 
 select priv_testagg1(x) from (values (1), (2), (3)) as _ (x);
@@ -1346,7 +1359,9 @@ create domain priv_testdomain3a as int;
 
 create function castfunc(int)
 returns priv_testdomain3a
-as $function$ SELECT $1::priv_testdomain3a $function$
+as $function$
+SELECT $1::priv_testdomain3a
+$function$
 language sql;
 
 create cast (priv_testdomain1 as priv_testdomain3a) with function castfunc(int);
@@ -1358,12 +1373,16 @@ drop domain priv_testdomain3a;
 create function priv_testfunc5a(a priv_testdomain1)
 returns int
 language sql
-as $function$ SELECT $1 $function$;
+as $function$
+SELECT $1
+$function$;
 
 create function priv_testfunc6a(b int)
 returns priv_testdomain1
 language sql
-as $function$ SELECT $1::priv_testdomain1 $function$;
+as $function$
+SELECT $1::priv_testdomain1
+$function$;
 
 create operator !+! (PROCEDURE = int4pl, LEFTARG = priv_testdomain1, RIGHTARG = priv_testdomain1);
 
@@ -1414,7 +1433,9 @@ create domain priv_testdomain3b as int;
 
 create function castfunc(int)
 returns priv_testdomain3b
-as $function$ SELECT $1::priv_testdomain3b $function$
+as $function$
+SELECT $1::priv_testdomain3b
+$function$
 language sql;
 
 create cast (priv_testdomain1 as priv_testdomain3b) with function castfunc(int);
@@ -1422,12 +1443,16 @@ create cast (priv_testdomain1 as priv_testdomain3b) with function castfunc(int);
 create function priv_testfunc5b(a priv_testdomain1)
 returns int
 language sql
-as $function$ SELECT $1 $function$;
+as $function$
+SELECT $1
+$function$;
 
 create function priv_testfunc6b(b int)
 returns priv_testdomain1
 language sql
-as $function$ SELECT $1::priv_testdomain1 $function$;
+as $function$
+SELECT $1::priv_testdomain1
+$function$;
 
 create operator !! (PROCEDURE = priv_testfunc5b, RIGHTARG = priv_testdomain1);
 
@@ -2030,12 +2055,16 @@ set session authorization regress_sro_user;
 create function unwanted_grant()
 returns void
 language sql
-as $function$GRANT regress_priv_group2 TO regress_sro_user$function$;
+as $function$
+GRANT regress_priv_group2 TO regress_sro_user
+$function$;
 
 create function mv_action()
 returns boolean
 language sql
-as $function$DECLARE c CURSOR WITH HOLD FOR SELECT public.unwanted_grant(); SELECT true$function$;
+as $function$
+DECLARE c CURSOR WITH HOLD FOR SELECT public.unwanted_grant(); SELECT true
+$function$;
 
 create materialized view sro_mv as select mv_action() with no data;
 
@@ -2050,7 +2079,9 @@ create table sro_trojan_table ();
 create function sro_trojan()
 returns trigger
 language plpgsql
-as $function$BEGIN PERFORM public.unwanted_grant(); RETURN NULL; END$function$;
+as $function$
+BEGIN PERFORM public.unwanted_grant(); RETURN NULL; END
+$function$;
 
 create constraint trigger t
 after insert
@@ -2063,7 +2094,9 @@ execute function sro_trojan();
 create or replace function mv_action()
 returns boolean
 language sql
-as $function$INSERT INTO public.sro_trojan_table DEFAULT VALUES; SELECT true$function$;
+as $function$
+INSERT INTO public.sro_trojan_table DEFAULT VALUES; SELECT true
+$function$;
 
 refresh materialized view sro_mv;
 
@@ -2090,7 +2123,8 @@ BEGIN
 	RETURN 1;
 EXCEPTION WHEN OTHERS THEN
 	RETURN 2;
-END$function$;
+END
+$function$;
 
 create materialized view sro_index_mv as select 1 as c;
 
@@ -2117,7 +2151,9 @@ create function dogrant_ok()
 returns void
 language sql
 security definer
-as $function$GRANT regress_priv_group2 TO regress_priv_user5$function$;
+as $function$
+GRANT regress_priv_group2 TO regress_priv_user5
+$function$;
 
 grant REGRESS_PRIV_GROUP2 to regress_priv_user5;
 
@@ -2355,7 +2391,8 @@ BEGIN
 	RETURN pg_terminate_backend($1);
 EXCEPTION WHEN OTHERS THEN
 	RETURN false;
-END$function$;
+END
+$function$;
 
 alter function terminate_nothrow owner to pg_signal_backend;
 
@@ -2407,8 +2444,10 @@ select
 begin;
 
 do
-$do$BEGIN EXECUTE format(
-	'ALTER DATABASE %I OWNER TO regress_priv_group2', current_catalog); END$do$;
+$do$
+BEGIN EXECUTE format(
+	'ALTER DATABASE %I OWNER TO regress_priv_group2', current_catalog); END
+$do$;
 
 select
   pg_has_role(
@@ -2660,13 +2699,17 @@ set role to regress_priv_user1;
 
 create function testns.foo()
 returns int
-as $function$select 1$function$
+as $function$
+select 1
+$function$
 language sql;
 
 create aggregate testns.agg1 (int) (sfunc = int4pl, stype = int);
 
 create procedure testns.bar()
-as $procedure$select 1$procedure$
+as $procedure$
+select 1
+$procedure$
 language sql;
 
 select has_function_privilege('regress_priv_user2', 'testns.foo()', 'EXECUTE');
@@ -2681,7 +2724,9 @@ drop function testns.foo();
 
 create function testns.foo()
 returns int
-as $function$select 1$function$
+as $function$
+select 1
+$function$
 language sql;
 
 drop aggregate testns.agg1(int);
@@ -2691,7 +2736,9 @@ create aggregate testns.agg1 (int) (sfunc = int4pl, stype = int);
 drop procedure testns.bar();
 
 create procedure testns.bar()
-as $procedure$select 1$procedure$
+as $procedure$
+select 1
+$procedure$
 language sql;
 
 select has_function_privilege('regress_priv_user2', 'testns.foo()', 'EXECUTE');
@@ -2776,13 +2823,17 @@ select has_table_privilege('regress_priv_user1', 'testns.t2', 'SELECT');
 
 create function testns.priv_testfunc(int)
 returns int
-as $function$select 3 * $1;$function$
+as $function$
+select 3 * $1;
+$function$
 language sql;
 
 create aggregate testns.priv_testagg (int) (sfunc = int4pl, stype = int);
 
 create procedure testns.priv_testproc(int)
-as $procedure$select 3$procedure$
+as $procedure$
+select 3
+$procedure$
 language sql;
 
 select has_function_privilege('regress_priv_user1', 'testns.priv_testfunc(int)', 'EXECUTE');

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__privileges_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__privileges_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/privileges.sql
-snapshot_kind: text
 ---
 set client_min_messages = warning;
 
@@ -351,7 +350,9 @@ grant REGRESS_PRIV_GROUP2 to regress_priv_user4 with ADMIN true;
 
 create function leak(int, int)
 returns boolean
-as $function$int4lt$function$
+as $function$
+int4lt
+$function$
 language internal
 immutable
 strict;
@@ -614,7 +615,9 @@ set session authorization regress_priv_user2;
 
 create function leak2(int, int)
 returns boolean
-as $function$begin raise notice 'leak % %', $1, $2; return $1 > $2; end$function$
+as $function$
+begin raise notice 'leak % %', $1, $2; return $1 > $2; end
+$function$
 language plpgsql
 immutable;
 
@@ -1464,18 +1467,24 @@ grant USAGE on language sql to regress_priv_user2;
 
 create function priv_testfunc1(int)
 returns int
-as $function$select 2 * $1;$function$
+as $function$
+select 2 * $1;
+$function$
 language sql;
 
 create function priv_testfunc2(int)
 returns int
-as $function$select 3 * $1;$function$
+as $function$
+select 3 * $1;
+$function$
 language sql;
 
 create aggregate priv_testagg1 (int) (sfunc = int4pl, stype = int);
 
 create procedure priv_testproc1(int)
-as $procedure$select $1;$procedure$
+as $procedure$
+select $1;
+$procedure$
 language sql;
 
 revoke all
@@ -1512,7 +1521,9 @@ grant all on procedure priv_testproc1(int) to regress_priv_user4;
 
 create function priv_testfunc4(boolean)
 returns text
-as $function$select col1 from atest2 where col2 = $1;$function$
+as $function$
+select col1 from atest2 where col2 = $1;
+$function$
 language sql
 security definer;
 
@@ -1524,7 +1535,9 @@ select priv_testfunc1(5), priv_testfunc2(5);
 
 create function priv_testfunc3(int)
 returns int
-as $function$select 2 * $1;$function$
+as $function$
+select 2 * $1;
+$function$
 language sql;
 
 select priv_testagg1(x) from (values (1), (2), (3)) as _ (x);
@@ -1608,7 +1621,9 @@ create domain priv_testdomain3a as int;
 
 create function castfunc(int)
 returns priv_testdomain3a
-as $function$ SELECT $1::priv_testdomain3a $function$
+as $function$
+SELECT $1::priv_testdomain3a
+$function$
 language sql;
 
 create cast (priv_testdomain1 as priv_testdomain3a) with function castfunc(int);
@@ -1620,12 +1635,16 @@ drop domain priv_testdomain3a;
 create function priv_testfunc5a(a priv_testdomain1)
 returns int
 language sql
-as $function$ SELECT $1 $function$;
+as $function$
+SELECT $1
+$function$;
 
 create function priv_testfunc6a(b int)
 returns priv_testdomain1
 language sql
-as $function$ SELECT $1::priv_testdomain1 $function$;
+as $function$
+SELECT $1::priv_testdomain1
+$function$;
 
 create operator !+! (PROCEDURE = int4pl,
 LEFTARG = priv_testdomain1,
@@ -1683,7 +1702,9 @@ create domain priv_testdomain3b as int;
 
 create function castfunc(int)
 returns priv_testdomain3b
-as $function$ SELECT $1::priv_testdomain3b $function$
+as $function$
+SELECT $1::priv_testdomain3b
+$function$
 language sql;
 
 create cast (priv_testdomain1 as priv_testdomain3b) with function castfunc(int);
@@ -1691,12 +1712,16 @@ create cast (priv_testdomain1 as priv_testdomain3b) with function castfunc(int);
 create function priv_testfunc5b(a priv_testdomain1)
 returns int
 language sql
-as $function$ SELECT $1 $function$;
+as $function$
+SELECT $1
+$function$;
 
 create function priv_testfunc6b(b int)
 returns priv_testdomain1
 language sql
-as $function$ SELECT $1::priv_testdomain1 $function$;
+as $function$
+SELECT $1::priv_testdomain1
+$function$;
 
 create operator !! (PROCEDURE = priv_testfunc5b, RIGHTARG = priv_testdomain1);
 
@@ -2387,12 +2412,16 @@ set session authorization regress_sro_user;
 create function unwanted_grant()
 returns void
 language sql
-as $function$GRANT regress_priv_group2 TO regress_sro_user$function$;
+as $function$
+GRANT regress_priv_group2 TO regress_sro_user
+$function$;
 
 create function mv_action()
 returns boolean
 language sql
-as $function$DECLARE c CURSOR WITH HOLD FOR SELECT public.unwanted_grant(); SELECT true$function$;
+as $function$
+DECLARE c CURSOR WITH HOLD FOR SELECT public.unwanted_grant(); SELECT true
+$function$;
 
 create materialized view sro_mv as select mv_action() with no data;
 
@@ -2407,7 +2436,9 @@ create table sro_trojan_table ();
 create function sro_trojan()
 returns trigger
 language plpgsql
-as $function$BEGIN PERFORM public.unwanted_grant(); RETURN NULL; END$function$;
+as $function$
+BEGIN PERFORM public.unwanted_grant(); RETURN NULL; END
+$function$;
 
 create constraint trigger t
 after insert
@@ -2420,7 +2451,9 @@ execute function sro_trojan();
 create or replace function mv_action()
 returns boolean
 language sql
-as $function$INSERT INTO public.sro_trojan_table DEFAULT VALUES; SELECT true$function$;
+as $function$
+INSERT INTO public.sro_trojan_table DEFAULT VALUES; SELECT true
+$function$;
 
 refresh materialized view sro_mv;
 
@@ -2447,7 +2480,8 @@ BEGIN
 	RETURN 1;
 EXCEPTION WHEN OTHERS THEN
 	RETURN 2;
-END$function$;
+END
+$function$;
 
 create materialized view sro_index_mv as select 1 as c;
 
@@ -2474,7 +2508,9 @@ create function dogrant_ok()
 returns void
 language sql
 security definer
-as $function$GRANT regress_priv_group2 TO regress_priv_user5$function$;
+as $function$
+GRANT regress_priv_group2 TO regress_priv_user5
+$function$;
 
 grant REGRESS_PRIV_GROUP2 to regress_priv_user5;
 
@@ -2712,7 +2748,8 @@ BEGIN
 	RETURN pg_terminate_backend($1);
 EXCEPTION WHEN OTHERS THEN
 	RETURN false;
-END$function$;
+END
+$function$;
 
 alter function terminate_nothrow owner to pg_signal_backend;
 
@@ -2764,8 +2801,10 @@ select
 begin;
 
 do
-$do$BEGIN EXECUTE format(
-	'ALTER DATABASE %I OWNER TO regress_priv_group2', current_catalog); END$do$;
+$do$
+BEGIN EXECUTE format(
+	'ALTER DATABASE %I OWNER TO regress_priv_group2', current_catalog); END
+$do$;
 
 select
   pg_has_role(
@@ -3055,13 +3094,17 @@ set role to regress_priv_user1;
 
 create function testns.foo()
 returns int
-as $function$select 1$function$
+as $function$
+select 1
+$function$
 language sql;
 
 create aggregate testns.agg1 (int) (sfunc = int4pl, stype = int);
 
 create procedure testns.bar()
-as $procedure$select 1$procedure$
+as $procedure$
+select 1
+$procedure$
 language sql;
 
 select has_function_privilege('regress_priv_user2', 'testns.foo()', 'EXECUTE');
@@ -3081,7 +3124,9 @@ drop function testns.foo();
 
 create function testns.foo()
 returns int
-as $function$select 1$function$
+as $function$
+select 1
+$function$
 language sql;
 
 drop aggregate testns.agg1(int);
@@ -3091,7 +3136,9 @@ create aggregate testns.agg1 (int) (sfunc = int4pl, stype = int);
 drop procedure testns.bar();
 
 create procedure testns.bar()
-as $procedure$select 1$procedure$
+as $procedure$
+select 1
+$procedure$
 language sql;
 
 select has_function_privilege('regress_priv_user2', 'testns.foo()', 'EXECUTE');
@@ -3193,13 +3240,17 @@ select has_table_privilege('regress_priv_user1', 'testns.t2', 'SELECT');
 
 create function testns.priv_testfunc(int)
 returns int
-as $function$select 3 * $1;$function$
+as $function$
+select 3 * $1;
+$function$
 language sql;
 
 create aggregate testns.priv_testagg (int) (sfunc = int4pl, stype = int);
 
 create procedure testns.priv_testproc(int)
-as $procedure$select 3$procedure$
+as $procedure$
+select 3
+$procedure$
 language sql;
 
 select

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__publication_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__publication_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/publication.sql
-snapshot_kind: text
 ---
 create role regress_publication_user login superuser;
 
@@ -286,7 +285,9 @@ alter publication testpub5 set table testpub_rf_tbl3 where ( e < AVG(e));
 
 create function testpub_rf_func1(int, int)
 returns boolean
-as $function$ SELECT hashint4($1) > $2 $function$
+as $function$
+SELECT hashint4($1) > $2
+$function$
 language sql;
 
 create operator =#> (PROCEDURE = testpub_rf_func1, LEFTARG = int, RIGHTARG = int);
@@ -296,7 +297,9 @@ create publication testpub6 for table testpub_rf_tbl3 where (e =#> 27);
 create function testpub_rf_func2()
 returns int
 immutable
-as $function$ BEGIN RETURN 123; END; $function$
+as $function$
+BEGIN RETURN 123; END;
+$function$
 language plpgsql;
 
 alter publication testpub5 add table testpub_rf_tbl1 where ( a >= testpub_rf_func2());

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__publication_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__publication_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/publication.sql
-snapshot_kind: text
 ---
 create role regress_publication_user login superuser;
 
@@ -305,7 +304,9 @@ alter publication testpub5 set table testpub_rf_tbl3 where ( e < AVG(e));
 
 create function testpub_rf_func1(int, int)
 returns boolean
-as $function$ SELECT hashint4($1) > $2 $function$
+as $function$
+SELECT hashint4($1) > $2
+$function$
 language sql;
 
 create operator =#> (PROCEDURE = testpub_rf_func1,
@@ -317,7 +318,9 @@ create publication testpub6 for table testpub_rf_tbl3 where (e =#> 27);
 create function testpub_rf_func2()
 returns int
 immutable
-as $function$ BEGIN RETURN 123; END; $function$
+as $function$
+BEGIN RETURN 123; END;
+$function$
 language plpgsql;
 
 alter publication testpub5 add

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__rangefuncs_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__rangefuncs_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/rangefuncs.sql
-snapshot_kind: text
 ---
 create table rngfunc2 (
   rngfuncid int,
@@ -16,7 +15,9 @@ insert into rngfunc2 values (1, 111);
 
 create function rngfunct(int)
 returns setof rngfunc2
-as $function$SELECT * FROM rngfunc2 WHERE rngfuncid = $1 ORDER BY f2;$function$
+as $function$
+SELECT * FROM rngfunc2 WHERE rngfuncid = $1 ORDER BY f2;
+$function$
 language sql;
 
 select * from rngfunct(1) with ordinality as z (a, b, ord);
@@ -270,7 +271,9 @@ insert into rngfunc values (2, 1, 'Mary');
 
 create function getrngfunc1(int)
 returns int
-as $function$SELECT $1;$function$
+as $function$
+SELECT $1;
+$function$
 language sql;
 
 select * from getrngfunc1(1) as t1;
@@ -296,7 +299,9 @@ drop view vw_getrngfunc;
 
 create function getrngfunc2(int)
 returns setof int
-as $function$SELECT rngfuncid FROM rngfunc WHERE rngfuncid = $1;$function$
+as $function$
+SELECT rngfuncid FROM rngfunc WHERE rngfuncid = $1;
+$function$
 language sql;
 
 select * from getrngfunc2(1) as t1;
@@ -322,7 +327,9 @@ drop view vw_getrngfunc;
 
 create function getrngfunc3(int)
 returns setof text
-as $function$SELECT rngfuncname FROM rngfunc WHERE rngfuncid = $1;$function$
+as $function$
+SELECT rngfuncname FROM rngfunc WHERE rngfuncid = $1;
+$function$
 language sql;
 
 select * from getrngfunc3(1) as t1;
@@ -348,7 +355,9 @@ drop view vw_getrngfunc;
 
 create function getrngfunc4(int)
 returns rngfunc
-as $function$SELECT * FROM rngfunc WHERE rngfuncid = $1;$function$
+as $function$
+SELECT * FROM rngfunc WHERE rngfuncid = $1;
+$function$
 language sql;
 
 select * from getrngfunc4(1) as t1;
@@ -374,7 +383,9 @@ drop view vw_getrngfunc;
 
 create function getrngfunc5(int)
 returns setof rngfunc
-as $function$SELECT * FROM rngfunc WHERE rngfuncid = $1;$function$
+as $function$
+SELECT * FROM rngfunc WHERE rngfuncid = $1;
+$function$
 language sql;
 
 select * from getrngfunc5(1) as t1;
@@ -400,7 +411,9 @@ drop view vw_getrngfunc;
 
 create function getrngfunc6(int)
 returns record
-as $function$SELECT * FROM rngfunc WHERE rngfuncid = $1;$function$
+as $function$
+SELECT * FROM rngfunc WHERE rngfuncid = $1;
+$function$
 language sql;
 
 select * from getrngfunc6(1) as t1 (rngfuncid int, rngfuncsubid int, rngfuncname text);
@@ -439,7 +452,9 @@ drop view vw_getrngfunc;
 
 create function getrngfunc7(int)
 returns setof record
-as $function$SELECT * FROM rngfunc WHERE rngfuncid = $1;$function$
+as $function$
+SELECT * FROM rngfunc WHERE rngfuncid = $1;
+$function$
 language sql;
 
 select * from getrngfunc7(1) as t1 (rngfuncid int, rngfuncsubid int, rngfuncname text);
@@ -478,7 +493,9 @@ drop view vw_getrngfunc;
 
 create function getrngfunc8(int)
 returns int
-as $function$DECLARE rngfuncint int; BEGIN SELECT rngfuncid into rngfuncint FROM rngfunc WHERE rngfuncid = $1; RETURN rngfuncint; END;$function$
+as $function$
+DECLARE rngfuncint int; BEGIN SELECT rngfuncid into rngfuncint FROM rngfunc WHERE rngfuncid = $1; RETURN rngfuncint; END;
+$function$
 language plpgsql;
 
 select * from getrngfunc8(1) as t1;
@@ -504,7 +521,9 @@ drop view vw_getrngfunc;
 
 create function getrngfunc9(int)
 returns rngfunc
-as $function$DECLARE rngfunctup rngfunc%ROWTYPE; BEGIN SELECT * into rngfunctup FROM rngfunc WHERE rngfuncid = $1; RETURN rngfunctup; END;$function$
+as $function$
+DECLARE rngfunctup rngfunc%ROWTYPE; BEGIN SELECT * into rngfunctup FROM rngfunc WHERE rngfuncid = $1; RETURN rngfunctup; END;
+$function$
 language plpgsql;
 
 select * from getrngfunc9(1) as t1;
@@ -646,12 +665,16 @@ create type rngfunc_rescan_t as (i int, s bigint);
 
 create function rngfunc_sql(int, int)
 returns setof rngfunc_rescan_t
-as $function$SELECT i, nextval('rngfunc_rescan_seq1') FROM generate_series($1,$2) i;$function$
+as $function$
+SELECT i, nextval('rngfunc_rescan_seq1') FROM generate_series($1,$2) i;
+$function$
 language sql;
 
 create function rngfunc_mat(int, int)
 returns setof rngfunc_rescan_t
-as $function$begin for i in $1..$2 loop return next (i, nextval('rngfunc_rescan_seq2')); end loop; end;$function$
+as $function$
+begin for i in $1..$2 loop return next (i, nextval('rngfunc_rescan_seq2')); end loop; end;
+$function$
 language plpgsql;
 
 select setval('rngfunc_rescan_seq1', 1, false), setval('rngfunc_rescan_seq2', 1, false);
@@ -980,7 +1003,9 @@ drop sequence rngfunc_rescan_seq1;
 drop sequence rngfunc_rescan_seq2;
 
 create function rngfunc(in f1 int, out f2 int)
-as $function$select $1+1$function$
+as $function$
+select $1+1
+$function$
 language sql;
 
 select rngfunc(42);
@@ -991,26 +1016,36 @@ select * from rngfunc(42) as p (x);
 
 create or replace function rngfunc(in f1 int, out f2 int)
 returns int
-as $function$select $1+1$function$
+as $function$
+select $1+1
+$function$
 language sql;
 
 create or replace function rngfunc(in f1 int, out f2 int)
 returns double precision
-as $function$select $1+1$function$
+as $function$
+select $1+1
+$function$
 language sql;
 
 create or replace function rngfunc(in f1 int, out f2 int, out f3 text)
 returns int
-as $function$select $1+1$function$
+as $function$
+select $1+1
+$function$
 language sql;
 
 create or replace function rngfunc(in f1 int, out f2 int, out f3 text)
 returns record
-as $function$select $1+1$function$
+as $function$
+select $1+1
+$function$
 language sql;
 
 create or replace function rngfuncr(in f1 int, out f2 int, out text)
-as $function$select $1-1, $1::text || 'z'$function$
+as $function$
+select $1-1, $1::text || 'z'
+$function$
 language sql;
 
 select f1, rngfuncr(f1) from int4_tbl;
@@ -1020,7 +1055,9 @@ select * from rngfuncr(42);
 select * from rngfuncr(42) as p (a, b);
 
 create or replace function rngfuncb(in f1 int, inout f2 int, out text)
-as $function$select $2-1, $1::text || 'z'$function$
+as $function$
+select $2-1, $1::text || 'z'
+$function$
 language sql;
 
 select f1, rngfuncb(f1, f1 / 2) from int4_tbl;
@@ -1036,7 +1073,9 @@ drop function rngfuncr(int);
 drop function rngfuncb(int, int);
 
 create function dup(f1 anyelement, out f2 anyelement, out f3 anyarray)
-as $function$select $1, array[$1,$1]$function$
+as $function$
+select $1, array[$1,$1]
+$function$
 language sql;
 
 select dup(22);
@@ -1048,13 +1087,17 @@ select dup(cast('xyz' as text));
 select * from dup(cast('xyz' as text));
 
 create or replace function dup(inout f2 anyelement, out f3 anyarray)
-as $function$select $1, array[$1,$1]$function$
+as $function$
+select $1, array[$1,$1]
+$function$
 language sql;
 
 drop function dup(anyelement);
 
 create or replace function dup(inout f2 anyelement, out f3 anyarray)
-as $function$select $1, array[$1,$1]$function$
+as $function$
+select $1, array[$1,$1]
+$function$
 language sql;
 
 select dup(22);
@@ -1062,7 +1105,9 @@ select dup(22);
 drop function dup(anyelement);
 
 create function bad(f1 int, out f2 anyelement, out f3 anyarray)
-as $function$select $1, array[$1,$1]$function$
+as $function$
+select $1, array[$1,$1]
+$function$
 language sql;
 
 create function
@@ -1072,7 +1117,9 @@ dup(
   out f3 anycompatible,
   out f4 anycompatiblearray
 )
-as $function$select $1, $2$function$
+as $function$
+select $1, $2
+$function$
 language sql;
 
 select dup(22, array[44]);
@@ -1092,7 +1139,9 @@ dup(
   out f3 anycompatiblearray,
   out f4 anycompatiblerange
 )
-as $function$select lower($1), array[lower($1), upper($1)], $1$function$
+as $function$
+select lower($1), array[lower($1), upper($1)], $1
+$function$
 language sql;
 
 select dup(int4range(4, 7));
@@ -1104,14 +1153,18 @@ select dup(textrange('aaa', 'bbb'));
 drop function dup(anycompatiblerange);
 
 create function bad(f1 anyarray, out f2 anycompatible, out f3 anycompatiblearray)
-as $function$select $1, array[$1,$1]$function$
+as $function$
+select $1, array[$1,$1]
+$function$
 language sql;
 
 create or replace function rngfunc()
 returns table (
   a int
 )
-as $function$ SELECT a FROM generate_series(1,5) a(a) $function$
+as $function$
+SELECT a FROM generate_series(1,5) a(a)
+$function$
 language sql;
 
 select * from rngfunc();
@@ -1123,9 +1176,11 @@ returns table (
   a int,
   b int
 )
-as $function$ SELECT a, b
+as $function$
+SELECT a, b
          FROM generate_series(1,$1) a(a),
-              generate_series(1,$1) b(b) $function$
+              generate_series(1,$1) b(b)
+$function$
 language sql;
 
 select * from rngfunc(3);
@@ -1136,7 +1191,9 @@ create or replace function rngfunc()
 returns table (
   a varchar(5)
 )
-as $function$ SELECT 'hello'::varchar(5) $function$
+as $function$
+SELECT 'hello'::varchar(5)
+$function$
 language sql
 stable;
 
@@ -1151,7 +1208,9 @@ create temporary table tt (
 
 create function insert_tt(text)
 returns int
-as $function$ insert into tt(data) values($1) returning f1 $function$
+as $function$
+insert into tt(data) values($1) returning f1
+$function$
 language sql;
 
 select insert_tt('foo');
@@ -1162,7 +1221,9 @@ select * from tt;
 
 create or replace function insert_tt(text)
 returns int
-as $function$ insert into tt(data) values($1),($1||$1) returning f1 $function$
+as $function$
+insert into tt(data) values($1),($1||$1) returning f1
+$function$
 language sql;
 
 select insert_tt('fool');
@@ -1171,7 +1232,9 @@ select * from tt;
 
 create or replace function insert_tt2(text, text)
 returns setof int
-as $function$ insert into tt(data) values($1),($2) returning f1 $function$
+as $function$
+insert into tt(data) values($1),($2) returning f1
+$function$
 language sql;
 
 select insert_tt2('foolish', 'barrish');
@@ -1190,7 +1253,8 @@ as $function$
 begin
   raise notice 'noticetrigger % %', new.f1, new.data;
   return null;
-end $function$
+end
+$function$
 language plpgsql;
 
 create trigger tnoticetrigger after insert on tt for each row execute function noticetrigger();
@@ -1218,7 +1282,9 @@ select * from tt_log;
 create function rngfunc1(n int, out a text, out b text)
 returns setof record
 language sql
-as $function$ select 'foo ' || i, 'bar ' || i from generate_series(1,$1) i $function$;
+as $function$
+select 'foo ' || i, 'bar ' || i from generate_series(1,$1) i
+$function$;
 
 set work_mem = '64kB';
 
@@ -1233,7 +1299,7 @@ drop function rngfunc1(int);
 create function array_to_set(anyarray)
 returns setof record
 as $function$
-  select i AS "index", $1[i] AS "value" from generate_subscripts($1, 1) i
+select i AS "index", $1[i] AS "value" from generate_subscripts($1, 1) i
 $function$
 language sql
 strict
@@ -1254,7 +1320,7 @@ select * from array_to_set(array['one', 'two']) as t (f1 numeric(4, 2), f2 text)
 create or replace function array_to_set(anyarray)
 returns setof record
 as $function$
-  select i AS "index", $1[i] AS "value" from generate_subscripts($1, 1) i
+select i AS "index", $1[i] AS "value" from generate_subscripts($1, 1) i
 $function$
 language sql
 immutable;
@@ -1277,7 +1343,7 @@ create temporary table rngfunc (
 create function testrngfunc()
 returns record
 as $function$
-  insert into rngfunc values (1,2) returning *;
+insert into rngfunc values (1,2) returning *;
 $function$
 language sql;
 
@@ -1292,7 +1358,7 @@ drop function testrngfunc();
 create function testrngfunc()
 returns setof record
 as $function$
-  insert into rngfunc values (1,2), (3,4) returning *;
+insert into rngfunc values (1,2), (3,4) returning *;
 $function$
 language sql;
 
@@ -1309,7 +1375,7 @@ create type rngfunc_type as (f1 numeric(35, 6), f2 numeric(35, 2));
 create function testrngfunc()
 returns rngfunc_type
 as $function$
-  select 7.136178319899999964, 7.136178319899999964;
+select 7.136178319899999964, 7.136178319899999964;
 $function$
 language sql
 immutable;
@@ -1325,7 +1391,7 @@ select * from testrngfunc();
 create or replace function testrngfunc()
 returns rngfunc_type
 as $function$
-  select 7.136178319899999964, 7.136178319899999964;
+select 7.136178319899999964, 7.136178319899999964;
 $function$
 language sql
 volatile;
@@ -1343,7 +1409,7 @@ drop function testrngfunc();
 create function testrngfunc()
 returns setof rngfunc_type
 as $function$
-  select 7.136178319899999964, 7.136178319899999964;
+select 7.136178319899999964, 7.136178319899999964;
 $function$
 language sql
 immutable;
@@ -1359,7 +1425,7 @@ select * from testrngfunc();
 create or replace function testrngfunc()
 returns setof rngfunc_type
 as $function$
-  select 7.136178319899999964, 7.136178319899999964;
+select 7.136178319899999964, 7.136178319899999964;
 $function$
 language sql
 volatile;
@@ -1375,7 +1441,7 @@ select * from testrngfunc();
 create or replace function testrngfunc()
 returns setof rngfunc_type
 as $function$
-  select 1, 2 union select 3, 4 order by 1;
+select 1, 2 union select 3, 4 order by 1;
 $function$
 language sql
 immutable;
@@ -1414,7 +1480,9 @@ alter table users
 
 create or replace function get_first_user()
 returns users
-as $function$ SELECT * FROM users ORDER BY userid LIMIT 1; $function$
+as $function$
+SELECT * FROM users ORDER BY userid LIMIT 1;
+$function$
 language sql
 stable;
 
@@ -1424,7 +1492,9 @@ select * from get_first_user();
 
 create or replace function get_users()
 returns setof users
-as $function$ SELECT * FROM users ORDER BY userid; $function$
+as $function$
+SELECT * FROM users ORDER BY userid;
+$function$
 language sql
 stable;
 
@@ -1533,7 +1603,9 @@ drop table users;
 
 create or replace function rngfuncbar()
 returns setof text
-as $function$ select 'foo'::varchar union all select 'bar'::varchar ; $function$
+as $function$
+select 'foo'::varchar union all select 'bar'::varchar ;
+$function$
 language sql
 stable;
 
@@ -1546,19 +1618,25 @@ select * from rngfuncbar();
 drop function rngfuncbar();
 
 create or replace function rngfuncbar(out int, out numeric)
-as $function$ select (1, 2.1) $function$
+as $function$
+select (1, 2.1)
+$function$
 language sql;
 
 select * from rngfuncbar();
 
 create or replace function rngfuncbar(out int, out numeric)
-as $function$ select (1, 2) $function$
+as $function$
+select (1, 2)
+$function$
 language sql;
 
 select * from rngfuncbar();
 
 create or replace function rngfuncbar(out int, out numeric)
-as $function$ select (1, 2.1, 3) $function$
+as $function$
+select (1, 2.1, 3)
+$function$
 language sql;
 
 select * from rngfuncbar();
@@ -1568,7 +1646,7 @@ drop function rngfuncbar();
 create function extractq2(t int8_tbl)
 returns bigint
 as $function$
-  select t.q2
+select t.q2
 $function$
 language sql
 immutable;
@@ -1582,7 +1660,7 @@ returns table (
   ret1 bigint
 )
 as $function$
-  select extractq2(t) offset 0
+select extractq2(t) offset 0
 $function$
 language sql
 immutable;
@@ -1596,7 +1674,7 @@ returns table (
   ret1 bigint
 )
 as $function$
-  select extractq2(t)
+select extractq2(t)
 $function$
 language sql
 immutable;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__rangefuncs_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__rangefuncs_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/rangefuncs.sql
-snapshot_kind: text
 ---
 create table rngfunc2 (
   rngfuncid int,
@@ -16,7 +15,9 @@ insert into rngfunc2 values (1, 111);
 
 create function rngfunct(int)
 returns setof rngfunc2
-as $function$SELECT * FROM rngfunc2 WHERE rngfuncid = $1 ORDER BY f2;$function$
+as $function$
+SELECT * FROM rngfunc2 WHERE rngfuncid = $1 ORDER BY f2;
+$function$
 language sql;
 
 select * from rngfunct(1) with ordinality as z (a, b, ord);
@@ -311,7 +312,9 @@ insert into rngfunc values (2, 1, 'Mary');
 
 create function getrngfunc1(int)
 returns int
-as $function$SELECT $1;$function$
+as $function$
+SELECT $1;
+$function$
 language sql;
 
 select * from getrngfunc1(1) as t1;
@@ -339,7 +342,9 @@ drop view vw_getrngfunc;
 
 create function getrngfunc2(int)
 returns setof int
-as $function$SELECT rngfuncid FROM rngfunc WHERE rngfuncid = $1;$function$
+as $function$
+SELECT rngfuncid FROM rngfunc WHERE rngfuncid = $1;
+$function$
 language sql;
 
 select * from getrngfunc2(1) as t1;
@@ -367,7 +372,9 @@ drop view vw_getrngfunc;
 
 create function getrngfunc3(int)
 returns setof text
-as $function$SELECT rngfuncname FROM rngfunc WHERE rngfuncid = $1;$function$
+as $function$
+SELECT rngfuncname FROM rngfunc WHERE rngfuncid = $1;
+$function$
 language sql;
 
 select * from getrngfunc3(1) as t1;
@@ -395,7 +402,9 @@ drop view vw_getrngfunc;
 
 create function getrngfunc4(int)
 returns rngfunc
-as $function$SELECT * FROM rngfunc WHERE rngfuncid = $1;$function$
+as $function$
+SELECT * FROM rngfunc WHERE rngfuncid = $1;
+$function$
 language sql;
 
 select * from getrngfunc4(1) as t1;
@@ -423,7 +432,9 @@ drop view vw_getrngfunc;
 
 create function getrngfunc5(int)
 returns setof rngfunc
-as $function$SELECT * FROM rngfunc WHERE rngfuncid = $1;$function$
+as $function$
+SELECT * FROM rngfunc WHERE rngfuncid = $1;
+$function$
 language sql;
 
 select * from getrngfunc5(1) as t1;
@@ -451,7 +462,9 @@ drop view vw_getrngfunc;
 
 create function getrngfunc6(int)
 returns record
-as $function$SELECT * FROM rngfunc WHERE rngfuncid = $1;$function$
+as $function$
+SELECT * FROM rngfunc WHERE rngfuncid = $1;
+$function$
 language sql;
 
 select
@@ -503,7 +516,9 @@ drop view vw_getrngfunc;
 
 create function getrngfunc7(int)
 returns setof record
-as $function$SELECT * FROM rngfunc WHERE rngfuncid = $1;$function$
+as $function$
+SELECT * FROM rngfunc WHERE rngfuncid = $1;
+$function$
 language sql;
 
 select
@@ -555,7 +570,9 @@ drop view vw_getrngfunc;
 
 create function getrngfunc8(int)
 returns int
-as $function$DECLARE rngfuncint int; BEGIN SELECT rngfuncid into rngfuncint FROM rngfunc WHERE rngfuncid = $1; RETURN rngfuncint; END;$function$
+as $function$
+DECLARE rngfuncint int; BEGIN SELECT rngfuncid into rngfuncint FROM rngfunc WHERE rngfuncid = $1; RETURN rngfuncint; END;
+$function$
 language plpgsql;
 
 select * from getrngfunc8(1) as t1;
@@ -583,7 +600,9 @@ drop view vw_getrngfunc;
 
 create function getrngfunc9(int)
 returns rngfunc
-as $function$DECLARE rngfunctup rngfunc%ROWTYPE; BEGIN SELECT * into rngfunctup FROM rngfunc WHERE rngfuncid = $1; RETURN rngfunctup; END;$function$
+as $function$
+DECLARE rngfunctup rngfunc%ROWTYPE; BEGIN SELECT * into rngfunctup FROM rngfunc WHERE rngfuncid = $1; RETURN rngfunctup; END;
+$function$
 language plpgsql;
 
 select * from getrngfunc9(1) as t1;
@@ -737,12 +756,16 @@ create type rngfunc_rescan_t as (i int, s bigint);
 
 create function rngfunc_sql(int, int)
 returns setof rngfunc_rescan_t
-as $function$SELECT i, nextval('rngfunc_rescan_seq1') FROM generate_series($1,$2) i;$function$
+as $function$
+SELECT i, nextval('rngfunc_rescan_seq1') FROM generate_series($1,$2) i;
+$function$
 language sql;
 
 create function rngfunc_mat(int, int)
 returns setof rngfunc_rescan_t
-as $function$begin for i in $1..$2 loop return next (i, nextval('rngfunc_rescan_seq2')); end loop; end;$function$
+as $function$
+begin for i in $1..$2 loop return next (i, nextval('rngfunc_rescan_seq2')); end loop; end;
+$function$
 language plpgsql;
 
 select
@@ -1156,7 +1179,9 @@ drop sequence rngfunc_rescan_seq1;
 drop sequence rngfunc_rescan_seq2;
 
 create function rngfunc(in f1 int, out f2 int)
-as $function$select $1+1$function$
+as $function$
+select $1+1
+$function$
 language sql;
 
 select rngfunc(42);
@@ -1167,26 +1192,36 @@ select * from rngfunc(42) as p (x);
 
 create or replace function rngfunc(in f1 int, out f2 int)
 returns int
-as $function$select $1+1$function$
+as $function$
+select $1+1
+$function$
 language sql;
 
 create or replace function rngfunc(in f1 int, out f2 int)
 returns double precision
-as $function$select $1+1$function$
+as $function$
+select $1+1
+$function$
 language sql;
 
 create or replace function rngfunc(in f1 int, out f2 int, out f3 text)
 returns int
-as $function$select $1+1$function$
+as $function$
+select $1+1
+$function$
 language sql;
 
 create or replace function rngfunc(in f1 int, out f2 int, out f3 text)
 returns record
-as $function$select $1+1$function$
+as $function$
+select $1+1
+$function$
 language sql;
 
 create or replace function rngfuncr(in f1 int, out f2 int, out text)
-as $function$select $1-1, $1::text || 'z'$function$
+as $function$
+select $1-1, $1::text || 'z'
+$function$
 language sql;
 
 select f1, rngfuncr(f1) from int4_tbl;
@@ -1196,7 +1231,9 @@ select * from rngfuncr(42);
 select * from rngfuncr(42) as p (a, b);
 
 create or replace function rngfuncb(in f1 int, inout f2 int, out text)
-as $function$select $2-1, $1::text || 'z'$function$
+as $function$
+select $2-1, $1::text || 'z'
+$function$
 language sql;
 
 select f1, rngfuncb(f1, f1 / 2) from int4_tbl;
@@ -1212,7 +1249,9 @@ drop function rngfuncr(int);
 drop function rngfuncb(int, int);
 
 create function dup(f1 anyelement, out f2 anyelement, out f3 anyarray)
-as $function$select $1, array[$1,$1]$function$
+as $function$
+select $1, array[$1,$1]
+$function$
 language sql;
 
 select dup(22);
@@ -1224,13 +1263,17 @@ select dup(cast('xyz' as text));
 select * from dup(cast('xyz' as text));
 
 create or replace function dup(inout f2 anyelement, out f3 anyarray)
-as $function$select $1, array[$1,$1]$function$
+as $function$
+select $1, array[$1,$1]
+$function$
 language sql;
 
 drop function dup(anyelement);
 
 create or replace function dup(inout f2 anyelement, out f3 anyarray)
-as $function$select $1, array[$1,$1]$function$
+as $function$
+select $1, array[$1,$1]
+$function$
 language sql;
 
 select dup(22);
@@ -1238,7 +1281,9 @@ select dup(22);
 drop function dup(anyelement);
 
 create function bad(f1 int, out f2 anyelement, out f3 anyarray)
-as $function$select $1, array[$1,$1]$function$
+as $function$
+select $1, array[$1,$1]
+$function$
 language sql;
 
 create function
@@ -1248,7 +1293,9 @@ dup(
   out f3 anycompatible,
   out f4 anycompatiblearray
 )
-as $function$select $1, $2$function$
+as $function$
+select $1, $2
+$function$
 language sql;
 
 select dup(22, array[44]);
@@ -1268,7 +1315,9 @@ dup(
   out f3 anycompatiblearray,
   out f4 anycompatiblerange
 )
-as $function$select lower($1), array[lower($1), upper($1)], $1$function$
+as $function$
+select lower($1), array[lower($1), upper($1)], $1
+$function$
 language sql;
 
 select dup(int4range(4, 7));
@@ -1285,14 +1334,18 @@ bad(
   out f2 anycompatible,
   out f3 anycompatiblearray
 )
-as $function$select $1, array[$1,$1]$function$
+as $function$
+select $1, array[$1,$1]
+$function$
 language sql;
 
 create or replace function rngfunc()
 returns table (
   a int
 )
-as $function$ SELECT a FROM generate_series(1,5) a(a) $function$
+as $function$
+SELECT a FROM generate_series(1,5) a(a)
+$function$
 language sql;
 
 select * from rngfunc();
@@ -1304,9 +1357,11 @@ returns table (
   a int,
   b int
 )
-as $function$ SELECT a, b
+as $function$
+SELECT a, b
          FROM generate_series(1,$1) a(a),
-              generate_series(1,$1) b(b) $function$
+              generate_series(1,$1) b(b)
+$function$
 language sql;
 
 select * from rngfunc(3);
@@ -1317,7 +1372,9 @@ create or replace function rngfunc()
 returns table (
   a varchar(5)
 )
-as $function$ SELECT 'hello'::varchar(5) $function$
+as $function$
+SELECT 'hello'::varchar(5)
+$function$
 language sql
 stable;
 
@@ -1332,7 +1389,9 @@ create temporary table tt (
 
 create function insert_tt(text)
 returns int
-as $function$ insert into tt(data) values($1) returning f1 $function$
+as $function$
+insert into tt(data) values($1) returning f1
+$function$
 language sql;
 
 select insert_tt('foo');
@@ -1343,7 +1402,9 @@ select * from tt;
 
 create or replace function insert_tt(text)
 returns int
-as $function$ insert into tt(data) values($1),($1||$1) returning f1 $function$
+as $function$
+insert into tt(data) values($1),($1||$1) returning f1
+$function$
 language sql;
 
 select insert_tt('fool');
@@ -1352,7 +1413,9 @@ select * from tt;
 
 create or replace function insert_tt2(text, text)
 returns setof int
-as $function$ insert into tt(data) values($1),($2) returning f1 $function$
+as $function$
+insert into tt(data) values($1),($2) returning f1
+$function$
 language sql;
 
 select insert_tt2('foolish', 'barrish');
@@ -1371,7 +1434,8 @@ as $function$
 begin
   raise notice 'noticetrigger % %', new.f1, new.data;
   return null;
-end $function$
+end
+$function$
 language plpgsql;
 
 create trigger tnoticetrigger
@@ -1403,7 +1467,9 @@ select * from tt_log;
 create function rngfunc1(n int, out a text, out b text)
 returns setof record
 language sql
-as $function$ select 'foo ' || i, 'bar ' || i from generate_series(1,$1) i $function$;
+as $function$
+select 'foo ' || i, 'bar ' || i from generate_series(1,$1) i
+$function$;
 
 set work_mem = '64kB';
 
@@ -1418,7 +1484,7 @@ drop function rngfunc1(int);
 create function array_to_set(anyarray)
 returns setof record
 as $function$
-  select i AS "index", $1[i] AS "value" from generate_subscripts($1, 1) i
+select i AS "index", $1[i] AS "value" from generate_subscripts($1, 1) i
 $function$
 language sql
 strict
@@ -1449,7 +1515,7 @@ from
 create or replace function array_to_set(anyarray)
 returns setof record
 as $function$
-  select i AS "index", $1[i] AS "value" from generate_subscripts($1, 1) i
+select i AS "index", $1[i] AS "value" from generate_subscripts($1, 1) i
 $function$
 language sql
 immutable;
@@ -1482,7 +1548,7 @@ create temporary table rngfunc (
 create function testrngfunc()
 returns record
 as $function$
-  insert into rngfunc values (1,2) returning *;
+insert into rngfunc values (1,2) returning *;
 $function$
 language sql;
 
@@ -1497,7 +1563,7 @@ drop function testrngfunc();
 create function testrngfunc()
 returns setof record
 as $function$
-  insert into rngfunc values (1,2), (3,4) returning *;
+insert into rngfunc values (1,2), (3,4) returning *;
 $function$
 language sql;
 
@@ -1514,7 +1580,7 @@ create type rngfunc_type as (f1 numeric(35, 6), f2 numeric(35, 2));
 create function testrngfunc()
 returns rngfunc_type
 as $function$
-  select 7.136178319899999964, 7.136178319899999964;
+select 7.136178319899999964, 7.136178319899999964;
 $function$
 language sql
 immutable;
@@ -1530,7 +1596,7 @@ select * from testrngfunc();
 create or replace function testrngfunc()
 returns rngfunc_type
 as $function$
-  select 7.136178319899999964, 7.136178319899999964;
+select 7.136178319899999964, 7.136178319899999964;
 $function$
 language sql
 volatile;
@@ -1548,7 +1614,7 @@ drop function testrngfunc();
 create function testrngfunc()
 returns setof rngfunc_type
 as $function$
-  select 7.136178319899999964, 7.136178319899999964;
+select 7.136178319899999964, 7.136178319899999964;
 $function$
 language sql
 immutable;
@@ -1564,7 +1630,7 @@ select * from testrngfunc();
 create or replace function testrngfunc()
 returns setof rngfunc_type
 as $function$
-  select 7.136178319899999964, 7.136178319899999964;
+select 7.136178319899999964, 7.136178319899999964;
 $function$
 language sql
 volatile;
@@ -1580,7 +1646,7 @@ select * from testrngfunc();
 create or replace function testrngfunc()
 returns setof rngfunc_type
 as $function$
-  select 1, 2 union select 3, 4 order by 1;
+select 1, 2 union select 3, 4 order by 1;
 $function$
 language sql
 immutable;
@@ -1619,7 +1685,9 @@ alter table users
 
 create or replace function get_first_user()
 returns users
-as $function$ SELECT * FROM users ORDER BY userid LIMIT 1; $function$
+as $function$
+SELECT * FROM users ORDER BY userid LIMIT 1;
+$function$
 language sql
 stable;
 
@@ -1629,7 +1697,9 @@ select * from get_first_user();
 
 create or replace function get_users()
 returns setof users
-as $function$ SELECT * FROM users ORDER BY userid; $function$
+as $function$
+SELECT * FROM users ORDER BY userid;
+$function$
 language sql
 stable;
 
@@ -1746,7 +1816,9 @@ drop table users;
 
 create or replace function rngfuncbar()
 returns setof text
-as $function$ select 'foo'::varchar union all select 'bar'::varchar ; $function$
+as $function$
+select 'foo'::varchar union all select 'bar'::varchar ;
+$function$
 language sql
 stable;
 
@@ -1759,19 +1831,25 @@ select * from rngfuncbar();
 drop function rngfuncbar();
 
 create or replace function rngfuncbar(out int, out numeric)
-as $function$ select (1, 2.1) $function$
+as $function$
+select (1, 2.1)
+$function$
 language sql;
 
 select * from rngfuncbar();
 
 create or replace function rngfuncbar(out int, out numeric)
-as $function$ select (1, 2) $function$
+as $function$
+select (1, 2)
+$function$
 language sql;
 
 select * from rngfuncbar();
 
 create or replace function rngfuncbar(out int, out numeric)
-as $function$ select (1, 2.1, 3) $function$
+as $function$
+select (1, 2.1, 3)
+$function$
 language sql;
 
 select * from rngfuncbar();
@@ -1781,7 +1859,7 @@ drop function rngfuncbar();
 create function extractq2(t int8_tbl)
 returns bigint
 as $function$
-  select t.q2
+select t.q2
 $function$
 language sql
 immutable;
@@ -1795,7 +1873,7 @@ returns table (
   ret1 bigint
 )
 as $function$
-  select extractq2(t) offset 0
+select extractq2(t) offset 0
 $function$
 language sql
 immutable;
@@ -1809,7 +1887,7 @@ returns table (
   ret1 bigint
 )
 as $function$
-  select extractq2(t)
+select extractq2(t)
 $function$
 language sql
 immutable;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__rangetypes_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__rangetypes_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/rangetypes.sql
-snapshot_kind: text
 ---
 select cast('' as textrange);
 
@@ -931,7 +930,9 @@ drop type textrange2;
 
 create function anyarray_anyrange_func(a anyarray, r anyrange)
 returns anyelement
-as $function$select $1[1] + lower($2);$function$
+as $function$
+select $1[1] + lower($2);
+$function$
 language sql;
 
 select anyarray_anyrange_func(array[1, 2], int4range(10, 20));
@@ -942,17 +943,23 @@ drop function anyarray_anyrange_func(anyarray, anyrange);
 
 create function bogus_func(anyelement)
 returns anyrange
-as $function$select int4range(1,10)$function$
+as $function$
+select int4range(1,10)
+$function$
 language sql;
 
 create function bogus_func(int)
 returns anyrange
-as $function$select int4range(1,10)$function$
+as $function$
+select int4range(1,10)
+$function$
 language sql;
 
 create function range_add_bounds(anyrange)
 returns anyelement
-as $function$select lower($1) + upper($1)$function$
+as $function$
+select lower($1) + upper($1)
+$function$
 language sql;
 
 select range_add_bounds(int4range(1, 17));
@@ -960,7 +967,9 @@ select range_add_bounds(int4range(1, 17));
 select range_add_bounds(numrange(1.0001, 123.123));
 
 create function rangetypes_sql(q anyrange, b anyarray, out c anyelement)
-as $function$ select upper($1) + $2[1] $function$
+as $function$
+select upper($1) + $2[1]
+$function$
 language sql;
 
 select rangetypes_sql(int4range(1, 10), array[2, 20]);
@@ -973,7 +982,9 @@ anycompatiblearray_anycompatiblerange_func(
   r anycompatiblerange
 )
 returns anycompatible
-as $function$select $1[1] + lower($2);$function$
+as $function$
+select $1[1] + lower($2);
+$function$
 language sql;
 
 select anycompatiblearray_anycompatiblerange_func(array[1, 2], int4range(10, 20));
@@ -986,7 +997,9 @@ drop function anycompatiblearray_anycompatiblerange_func(anycompatiblearray, any
 
 create function bogus_func(anycompatible)
 returns anycompatiblerange
-as $function$select int4range(1,10)$function$
+as $function$
+select int4range(1,10)
+$function$
 language sql;
 
 select array[numrange(1.1, 1.2), numrange(12.3, 155.5)];
@@ -1041,25 +1054,33 @@ select cast('(01,10)' as varbitrange) except select cast('(10,11)' as varbitrang
 reset enable_sort;
 
 create function outparam_succeed(i anyrange, out r anyrange, out t text)
-as $function$ select $1, 'foo'::text $function$
+as $function$
+select $1, 'foo'::text
+$function$
 language sql;
 
 select * from outparam_succeed(int4range(1, 2));
 
 create function outparam2_succeed(r anyrange, out lu anyarray, out ul anyarray)
-as $function$ select array[lower($1), upper($1)], array[upper($1), lower($1)] $function$
+as $function$
+select array[lower($1), upper($1)], array[upper($1), lower($1)]
+$function$
 language sql;
 
 select * from outparam2_succeed(int4range(1, 11));
 
 create function outparam_succeed2(i anyrange, out r anyarray, out t text)
-as $function$ select ARRAY[upper($1)], 'foo'::text $function$
+as $function$
+select ARRAY[upper($1)], 'foo'::text
+$function$
 language sql;
 
 select * from outparam_succeed2(int4range(int4range(1, 2)));
 
 create function inoutparam_succeed(out i anyelement, inout r anyrange)
-as $function$ select upper($1), $1 $function$
+as $function$
+select upper($1), $1
+$function$
 language sql;
 
 select * from inoutparam_succeed(int4range(1, 2));
@@ -1069,17 +1090,23 @@ returns table (
   l anyelement,
   u anyelement
 )
-as $function$ select lower($1), upper($1) $function$
+as $function$
+select lower($1), upper($1)
+$function$
 language sql;
 
 select * from table_succeed(int4range(1, 11));
 
 create function outparam_fail(i anyelement, out r anyrange, out t text)
-as $function$ select '[1,10]', 'foo' $function$
+as $function$
+select '[1,10]', 'foo'
+$function$
 language sql;
 
 create function inoutparam_fail(inout i anyelement, out r anyrange)
-as $function$ select $1, '[1,10]' $function$
+as $function$
+select $1, '[1,10]'
+$function$
 language sql;
 
 create function table_fail(i anyelement)
@@ -1087,7 +1114,9 @@ returns table (
   i anyelement,
   r anyrange
 )
-as $function$ select $1, '[1,10]' $function$
+as $function$
+select $1, '[1,10]'
+$function$
 language sql;
 
 select current_date <@ cast('empty' as daterange);

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__rangetypes_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__rangetypes_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/rangetypes.sql
-snapshot_kind: text
 ---
 select cast('' as textrange);
 
@@ -1024,7 +1023,9 @@ drop type textrange2;
 
 create function anyarray_anyrange_func(a anyarray, r anyrange)
 returns anyelement
-as $function$select $1[1] + lower($2);$function$
+as $function$
+select $1[1] + lower($2);
+$function$
 language sql;
 
 select anyarray_anyrange_func(array[1, 2], int4range(10, 20));
@@ -1035,17 +1036,23 @@ drop function anyarray_anyrange_func(anyarray, anyrange);
 
 create function bogus_func(anyelement)
 returns anyrange
-as $function$select int4range(1,10)$function$
+as $function$
+select int4range(1,10)
+$function$
 language sql;
 
 create function bogus_func(int)
 returns anyrange
-as $function$select int4range(1,10)$function$
+as $function$
+select int4range(1,10)
+$function$
 language sql;
 
 create function range_add_bounds(anyrange)
 returns anyelement
-as $function$select lower($1) + upper($1)$function$
+as $function$
+select lower($1) + upper($1)
+$function$
 language sql;
 
 select range_add_bounds(int4range(1, 17));
@@ -1053,7 +1060,9 @@ select range_add_bounds(int4range(1, 17));
 select range_add_bounds(numrange(1.0001, 123.123));
 
 create function rangetypes_sql(q anyrange, b anyarray, out c anyelement)
-as $function$ select upper($1) + $2[1] $function$
+as $function$
+select upper($1) + $2[1]
+$function$
 language sql;
 
 select rangetypes_sql(int4range(1, 10), array[2, 20]);
@@ -1066,7 +1075,9 @@ anycompatiblearray_anycompatiblerange_func(
   r anycompatiblerange
 )
 returns anycompatible
-as $function$select $1[1] + lower($2);$function$
+as $function$
+select $1[1] + lower($2);
+$function$
 language sql;
 
 select
@@ -1094,7 +1105,9 @@ drop function
 
 create function bogus_func(anycompatible)
 returns anycompatiblerange
-as $function$select int4range(1,10)$function$
+as $function$
+select int4range(1,10)
+$function$
 language sql;
 
 select array[numrange(1.1, 1.2), numrange(12.3, 155.5)];
@@ -1151,25 +1164,33 @@ select cast('(10,11)' as varbitrange);
 reset enable_sort;
 
 create function outparam_succeed(i anyrange, out r anyrange, out t text)
-as $function$ select $1, 'foo'::text $function$
+as $function$
+select $1, 'foo'::text
+$function$
 language sql;
 
 select * from outparam_succeed(int4range(1, 2));
 
 create function outparam2_succeed(r anyrange, out lu anyarray, out ul anyarray)
-as $function$ select array[lower($1), upper($1)], array[upper($1), lower($1)] $function$
+as $function$
+select array[lower($1), upper($1)], array[upper($1), lower($1)]
+$function$
 language sql;
 
 select * from outparam2_succeed(int4range(1, 11));
 
 create function outparam_succeed2(i anyrange, out r anyarray, out t text)
-as $function$ select ARRAY[upper($1)], 'foo'::text $function$
+as $function$
+select ARRAY[upper($1)], 'foo'::text
+$function$
 language sql;
 
 select * from outparam_succeed2(int4range(int4range(1, 2)));
 
 create function inoutparam_succeed(out i anyelement, inout r anyrange)
-as $function$ select upper($1), $1 $function$
+as $function$
+select upper($1), $1
+$function$
 language sql;
 
 select * from inoutparam_succeed(int4range(1, 2));
@@ -1179,17 +1200,23 @@ returns table (
   l anyelement,
   u anyelement
 )
-as $function$ select lower($1), upper($1) $function$
+as $function$
+select lower($1), upper($1)
+$function$
 language sql;
 
 select * from table_succeed(int4range(1, 11));
 
 create function outparam_fail(i anyelement, out r anyrange, out t text)
-as $function$ select '[1,10]', 'foo' $function$
+as $function$
+select '[1,10]', 'foo'
+$function$
 language sql;
 
 create function inoutparam_fail(inout i anyelement, out r anyrange)
-as $function$ select $1, '[1,10]' $function$
+as $function$
+select $1, '[1,10]'
+$function$
 language sql;
 
 create function table_fail(i anyelement)
@@ -1197,7 +1224,9 @@ returns table (
   i anyelement,
   r anyrange
 )
-as $function$ select $1, '[1,10]' $function$
+as $function$
+select $1, '[1,10]'
+$function$
 language sql;
 
 select current_date <@ cast('empty' as daterange);

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__returning_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__returning_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/returning.sql
-snapshot_kind: text
 ---
 create temporary table foo (
   f1 serial,
@@ -172,7 +171,9 @@ select * from foo;
 
 create function foo_f()
 returns setof foo
-as $function$ SELECT * FROM foo OFFSET 0 $function$
+as $function$
+SELECT * FROM foo OFFSET 0
+$function$
 language sql
 stable;
 
@@ -186,7 +187,9 @@ create type foo_t as (f1 int, f2 text, f3 int, f4 bigint);
 
 create function foo_f()
 returns setof foo_t
-as $function$ SELECT * FROM foo OFFSET 0 $function$
+as $function$
+SELECT * FROM foo OFFSET 0
+$function$
 language sql
 stable;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__returning_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__returning_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/returning.sql
-snapshot_kind: text
 ---
 create temporary table foo (
   f1 serial,
@@ -185,7 +184,9 @@ select * from foo;
 
 create function foo_f()
 returns setof foo
-as $function$ SELECT * FROM foo OFFSET 0 $function$
+as $function$
+SELECT * FROM foo OFFSET 0
+$function$
 language sql
 stable;
 
@@ -204,7 +205,9 @@ create type foo_t as (f1 int, f2 text, f3 int, f4 bigint);
 
 create function foo_f()
 returns setof foo_t
-as $function$ SELECT * FROM foo OFFSET 0 $function$
+as $function$
+SELECT * FROM foo OFFSET 0
+$function$
 language sql
 stable;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__rowsecurity_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__rowsecurity_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/rowsecurity.sql
-snapshot_kind: text
 ---
 set client_min_messages = warning;
 
@@ -51,7 +50,9 @@ create or replace function f_leak(text)
 returns boolean
 cost 0.0000001
 language plpgsql
-as $function$BEGIN RAISE NOTICE 'f_leak => %', $1; RETURN true; END$function$;
+as $function$
+BEGIN RAISE NOTICE 'f_leak => %', $1; RETURN true; END
+$function$;
 
 grant EXECUTE on function f_leak(text) to public;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__rowsecurity_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__rowsecurity_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/rowsecurity.sql
-snapshot_kind: text
 ---
 set client_min_messages = warning;
 
@@ -51,7 +50,9 @@ create or replace function f_leak(text)
 returns boolean
 cost 0.0000001
 language plpgsql
-as $function$BEGIN RAISE NOTICE 'f_leak => %', $1; RETURN true; END$function$;
+as $function$
+BEGIN RAISE NOTICE 'f_leak => %', $1; RETURN true; END
+$function$;
 
 grant EXECUTE on function f_leak(text) to public;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__rowtypes_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__rowtypes_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/rowtypes.sql
-snapshot_kind: text
 ---
 create type complex as (r double precision, i double precision);
 
@@ -458,14 +457,14 @@ create type price_key as (id int);
 create function price_key_from_table(price)
 returns price_key
 as $function$
-    SELECT $1.id
+SELECT $1.id
 $function$
 language sql;
 
 create function price_key_from_input(price_input)
 returns price_key
 as $function$
-    SELECT $1.id
+SELECT $1.id
 $function$
 language sql;
 
@@ -553,7 +552,9 @@ select last(f) from fullname as f;
 create function longname(fullname)
 returns text
 language sql
-as $function$select $1.first || ' ' || $1.last$function$;
+as $function$
+select $1.first || ' ' || $1.last
+$function$;
 
 select f.longname from fullname as f;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__rowtypes_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__rowtypes_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/rowtypes.sql
-snapshot_kind: text
 ---
 create type complex as (r double precision, i double precision);
 
@@ -483,14 +482,14 @@ create type price_key as (id int);
 create function price_key_from_table(price)
 returns price_key
 as $function$
-    SELECT $1.id
+SELECT $1.id
 $function$
 language sql;
 
 create function price_key_from_input(price_input)
 returns price_key
 as $function$
-    SELECT $1.id
+SELECT $1.id
 $function$
 language sql;
 
@@ -578,7 +577,9 @@ select last(f) from fullname as f;
 create function longname(fullname)
 returns text
 language sql
-as $function$select $1.first || ' ' || $1.last$function$;
+as $function$
+select $1.first || ' ' || $1.last
+$function$;
 
 select f.longname from fullname as f;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__security_label_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__security_label_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/security_label.sql
-snapshot_kind: text
 ---
 set client_min_messages = warning;
 
@@ -30,7 +29,9 @@ as select * from seclabel_tbl2;
 
 create function seclabel_four()
 returns int
-as $function$SELECT 4$function$
+as $function$
+SELECT 4
+$function$
 language sql;
 
 create domain seclabel_domain as text;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__security_label_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__security_label_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/security_label.sql
-snapshot_kind: text
 ---
 set client_min_messages = warning;
 
@@ -30,7 +29,9 @@ as select * from seclabel_tbl2;
 
 create function seclabel_four()
 returns int
-as $function$SELECT 4$function$
+as $function$
+SELECT 4
+$function$
 language sql;
 
 create domain seclabel_domain as text;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__select_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__select_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/select.sql
-snapshot_kind: text
 ---
 select * from onek where onek.unique1 < 10 order by onek.unique1;
 
@@ -237,7 +236,9 @@ select 1 as x order by x;
 
 create function sillysrf(int)
 returns setof int
-as $function$values (1),(10),(2),($1)$function$
+as $function$
+values (1),(10),(2),($1)
+$function$
 language sql
 immutable;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__select_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__select_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/select.sql
-snapshot_kind: text
 ---
 select * from onek where onek.unique1 < 10 order by onek.unique1;
 
@@ -295,7 +294,9 @@ select 1 as x order by x;
 
 create function sillysrf(int)
 returns setof int
-as $function$values (1),(10),(2),($1)$function$
+as $function$
+values (1),(10),(2),($1)
+$function$
 language sql
 immutable;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__select_distinct_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__select_distinct_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/select_distinct.sql
-snapshot_kind: text
 ---
 select distinct two from onek order by 1;
 
@@ -104,7 +103,7 @@ select distinct four from tenk1;
 create or replace function distinct_func(a int)
 returns int
 as $function$
-  BEGIN
+BEGIN
     RETURN a;
   END;
 $function$
@@ -116,7 +115,7 @@ select distinct distinct_func(1) from tenk1;
 create or replace function distinct_func(a int)
 returns int
 as $function$
-  BEGIN
+BEGIN
     RETURN a;
   END;
 $function$

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__select_distinct_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__select_distinct_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/select_distinct.sql
-snapshot_kind: text
 ---
 select distinct two from onek order by 1;
 
@@ -122,7 +121,7 @@ select distinct four from tenk1;
 create or replace function distinct_func(a int)
 returns int
 as $function$
-  BEGIN
+BEGIN
     RETURN a;
   END;
 $function$
@@ -134,7 +133,7 @@ select distinct distinct_func(1) from tenk1;
 create or replace function distinct_func(a int)
 returns int
 as $function$
-  BEGIN
+BEGIN
     RETURN a;
   END;
 $function$

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__select_into_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__select_into_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/select_into.sql
-snapshot_kind: text
 ---
 select * into sitmp1 from onek where onek.unique1 < 2;
 
@@ -99,7 +98,7 @@ drop table ctas_nodata_4;
 create function make_table()
 returns void
 as $function$
-  CREATE TABLE created_table AS SELECT * FROM int8_tbl;
+CREATE TABLE created_table AS SELECT * FROM int8_tbl;
 $function$
 language sql;
 
@@ -112,7 +111,8 @@ $do$
 BEGIN
 	EXECUTE 'EXPLAIN ANALYZE SELECT * INTO TABLE easi FROM int8_tbl';
 	EXECUTE 'EXPLAIN ANALYZE CREATE TABLE easi2 AS SELECT * FROM int8_tbl WITH NO DATA';
-END$do$;
+END
+$do$;
 
 drop table created_table;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__select_into_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__select_into_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/select_into.sql
-snapshot_kind: text
 ---
 select * into sitmp1 from onek where onek.unique1 < 2;
 
@@ -111,7 +110,7 @@ drop table ctas_nodata_4;
 create function make_table()
 returns void
 as $function$
-  CREATE TABLE created_table AS SELECT * FROM int8_tbl;
+CREATE TABLE created_table AS SELECT * FROM int8_tbl;
 $function$
 language sql;
 
@@ -124,7 +123,8 @@ $do$
 BEGIN
 	EXECUTE 'EXPLAIN ANALYZE SELECT * INTO TABLE easi FROM int8_tbl';
 	EXECUTE 'EXPLAIN ANALYZE CREATE TABLE easi2 AS SELECT * FROM int8_tbl WITH NO DATA';
-END$do$;
+END
+$do$;
 
 drop table created_table;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__select_parallel_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__select_parallel_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/select_parallel.sql
-snapshot_kind: text
 ---
 select pg_stat_force_next_flush();
 
@@ -17,7 +16,9 @@ where
 
 create function sp_parallel_restricted(int)
 returns int
-as $function$begin return $1; end$function$
+as $function$
+begin return $1; end
+$function$
 language plpgsql
 parallel RESTRICTED;
 
@@ -89,7 +90,9 @@ reset enable_parallel_append;
 
 create function sp_test_func()
 returns setof text
-as $function$ select 'foo'::varchar union all select 'bar'::varchar $function$
+as $function$
+select 'foo'::varchar union all select 'bar'::varchar
+$function$
 language sql
 stable;
 
@@ -396,7 +399,8 @@ $do$
 BEGIN
  SET effective_io_concurrency = 50;
 EXCEPTION WHEN invalid_parameter_value THEN
-END $do$;
+END
+$do$;
 
 set work_mem = '64kB';
 
@@ -602,7 +606,9 @@ reset max_parallel_workers;
 
 create function parallel_safe_volatile(a int)
 returns int
-as $function$ begin return a; end; $function$
+as $function$
+begin return a; end;
+$function$
 parallel SAFE
 volatile
 language plpgsql;
@@ -786,12 +792,14 @@ order by pathkey;
 
 create function make_some_array(int, int)
 returns int[]
-as $function$declare x int[];
+as $function$
+declare x int[];
   begin
     x[1] := $1;
     x[2] := $2;
     return x;
-  end$function$
+  end
+$function$
 language plpgsql
 parallel SAFE;
 
@@ -837,14 +845,18 @@ create role regress_parallel_worker;
 
 create function set_and_report_role()
 returns text
-as $function$ select current_setting('role') $function$
+as $function$
+select current_setting('role')
+$function$
 language sql
 parallel SAFE
 set role to regress_parallel_worker;
 
 create function set_role_and_error(int)
 returns int
-as $function$ select 1 / $1 $function$
+as $function$
+select 1 / $1
+$function$
 language sql
 parallel SAFE
 set role to regress_parallel_worker;
@@ -875,7 +887,7 @@ create function my_cmp(int, int)
 returns int
 language sql
 as $function$
-	SELECT
+SELECT
 		CASE WHEN $1 < $2 THEN -1
 				WHEN $1 > $2 THEN  1
 				ELSE 0

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__select_parallel_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__select_parallel_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/select_parallel.sql
-snapshot_kind: text
 ---
 select pg_stat_force_next_flush();
 
@@ -17,7 +16,9 @@ where
 
 create function sp_parallel_restricted(int)
 returns int
-as $function$begin return $1; end$function$
+as $function$
+begin return $1; end
+$function$
 language plpgsql
 parallel RESTRICTED;
 
@@ -89,7 +90,9 @@ reset enable_parallel_append;
 
 create function sp_test_func()
 returns setof text
-as $function$ select 'foo'::varchar union all select 'bar'::varchar $function$
+as $function$
+select 'foo'::varchar union all select 'bar'::varchar
+$function$
 language sql
 stable;
 
@@ -447,7 +450,8 @@ $do$
 BEGIN
  SET effective_io_concurrency = 50;
 EXCEPTION WHEN invalid_parameter_value THEN
-END $do$;
+END
+$do$;
 
 set work_mem = '64kB';
 
@@ -671,7 +675,9 @@ reset max_parallel_workers;
 
 create function parallel_safe_volatile(a int)
 returns int
-as $function$ begin return a; end; $function$
+as $function$
+begin return a; end;
+$function$
 parallel SAFE
 volatile
 language plpgsql;
@@ -886,12 +892,14 @@ order by pathkey;
 
 create function make_some_array(int, int)
 returns int[]
-as $function$declare x int[];
+as $function$
+declare x int[];
   begin
     x[1] := $1;
     x[2] := $2;
     return x;
-  end$function$
+  end
+$function$
 language plpgsql
 parallel SAFE;
 
@@ -950,14 +958,18 @@ create role regress_parallel_worker;
 
 create function set_and_report_role()
 returns text
-as $function$ select current_setting('role') $function$
+as $function$
+select current_setting('role')
+$function$
 language sql
 parallel SAFE
 set role to regress_parallel_worker;
 
 create function set_role_and_error(int)
 returns int
-as $function$ select 1 / $1 $function$
+as $function$
+select 1 / $1
+$function$
 language sql
 parallel SAFE
 set role to regress_parallel_worker;
@@ -988,7 +1000,7 @@ create function my_cmp(int, int)
 returns int
 language sql
 as $function$
-	SELECT
+SELECT
 		CASE WHEN $1 < $2 THEN -1
 				WHEN $1 > $2 THEN  1
 				ELSE 0

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__select_views_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__select_views_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/select_views.sql
-snapshot_kind: text
 ---
 select * from street;
 
@@ -15,7 +14,9 @@ create function f_leak(text)
 returns boolean
 language plpgsql
 cost 0.0000001
-as $function$BEGIN RAISE NOTICE 'f_leak => %', $1; RETURN true; END$function$;
+as $function$
+BEGIN RAISE NOTICE 'f_leak => %', $1; RETURN true; END
+$function$;
 
 create table customer (
   cid int primary key,

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__select_views_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__select_views_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/select_views.sql
-snapshot_kind: text
 ---
 select * from street;
 
@@ -15,7 +14,9 @@ create function f_leak(text)
 returns boolean
 language plpgsql
 cost 0.0000001
-as $function$BEGIN RAISE NOTICE 'f_leak => %', $1; RETURN true; END$function$;
+as $function$
+BEGIN RAISE NOTICE 'f_leak => %', $1; RETURN true; END
+$function$;
 
 create table customer (
   cid int primary key,

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__sqljson_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__sqljson_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/sqljson.sql
-snapshot_kind: text
 ---
 select json(null);
 
@@ -222,7 +221,7 @@ create type mood as enum ('happy', 'sad', 'neutral');
 create function mood_to_json(mood)
 returns json
 as $function$
-  SELECT to_json($1::text);
+SELECT to_json($1::text);
 $function$
 language sql
 immutable;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__sqljson_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__sqljson_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/sqljson.sql
-snapshot_kind: text
 ---
 select json(null);
 
@@ -230,7 +229,7 @@ create type mood as enum ('happy', 'sad', 'neutral');
 create function mood_to_json(mood)
 returns json
 as $function$
-  SELECT to_json($1::text);
+SELECT to_json($1::text);
 $function$
 language sql
 immutable;

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__stats_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__stats_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/stats.sql
-snapshot_kind: text
 ---
 show "track_counts";
 
@@ -199,14 +198,18 @@ commit;
 create function stats_test_func1()
 returns void
 language plpgsql
-as $function$BEGIN END;$function$;
+as $function$
+BEGIN END;
+$function$;
 
 select cast(cast('stats_test_func1()' as regprocedure) as oid) as stats_test_func1_oid;
 
 create function stats_test_func2()
 returns void
 language plpgsql
-as $function$BEGIN END;$function$;
+as $function$
+BEGIN END;
+$function$;
 
 select cast(cast('stats_test_func2()' as regprocedure) as oid) as stats_test_func2_oid;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__stats_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__stats_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/stats.sql
-snapshot_kind: text
 ---
 show "track_counts";
 
@@ -211,7 +210,9 @@ commit;
 create function stats_test_func1()
 returns void
 language plpgsql
-as $function$BEGIN END;$function$;
+as $function$
+BEGIN END;
+$function$;
 
 select
   cast(cast('stats_test_func1()'
@@ -222,7 +223,9 @@ select
 create function stats_test_func2()
 returns void
 language plpgsql
-as $function$BEGIN END;$function$;
+as $function$
+BEGIN END;
+$function$;
 
 select
   cast(cast('stats_test_func2()'

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__stats_ext_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__stats_ext_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/stats_ext.sql
-snapshot_kind: text
 ---
 create function check_estimated_rows(text)
 returns table (
@@ -3030,14 +3029,18 @@ select * from tststats.priv_test_tbl where a = 1 and tststats.priv_test_tbl.* > 
 
 create function op_leak(int, int)
 returns boolean
-as $function$BEGIN RAISE NOTICE 'op_leak => %, %', $1, $2; RETURN $1 < $2; END$function$
+as $function$
+BEGIN RAISE NOTICE 'op_leak => %, %', $1, $2; RETURN $1 < $2; END
+$function$
 language plpgsql;
 
 create operator <<< (PROCEDURE = op_leak, LEFTARG = int, RIGHTARG = int, RESTRICT = scalarltsel);
 
 create function op_leak(record, record)
 returns boolean
-as $function$BEGIN RAISE NOTICE 'op_leak => %, %', $1, $2; RETURN $1 < $2; END$function$
+as $function$
+BEGIN RAISE NOTICE 'op_leak => %, %', $1, $2; RETURN $1 < $2; END
+$function$
 language plpgsql;
 
 create operator <<< (PROCEDURE = op_leak,
@@ -3300,7 +3303,9 @@ returns boolean
 strict
 immutable
 language plpgsql
-as $function$ BEGIN RETURN x < 1; END $function$;
+as $function$
+BEGIN RETURN x < 1; END
+$function$;
 
 select * from check_estimated_rows('SELECT * FROM sb_2 WHERE extstat_small(y)');
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__stats_ext_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__stats_ext_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/stats_ext.sql
-snapshot_kind: text
 ---
 create function check_estimated_rows(text)
 returns table (
@@ -3976,7 +3975,9 @@ where
 
 create function op_leak(int, int)
 returns boolean
-as $function$BEGIN RAISE NOTICE 'op_leak => %, %', $1, $2; RETURN $1 < $2; END$function$
+as $function$
+BEGIN RAISE NOTICE 'op_leak => %, %', $1, $2; RETURN $1 < $2; END
+$function$
 language plpgsql;
 
 create operator <<< (PROCEDURE = op_leak,
@@ -3986,7 +3987,9 @@ RESTRICT = scalarltsel);
 
 create function op_leak(record, record)
 returns boolean
-as $function$BEGIN RAISE NOTICE 'op_leak => %, %', $1, $2; RETURN $1 < $2; END$function$
+as $function$
+BEGIN RAISE NOTICE 'op_leak => %, %', $1, $2; RETURN $1 < $2; END
+$function$
 language plpgsql;
 
 create operator <<< (PROCEDURE = op_leak,
@@ -4276,7 +4279,9 @@ returns boolean
 strict
 immutable
 language plpgsql
-as $function$ BEGIN RETURN x < 1; END $function$;
+as $function$
+BEGIN RETURN x < 1; END
+$function$;
 
 select * from check_estimated_rows('SELECT * FROM sb_2 WHERE extstat_small(y)');
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__subscription_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__subscription_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/subscription.sql
-snapshot_kind: text
 ---
 create role regress_subscription_user login superuser;
 
@@ -254,7 +253,9 @@ commit;
 
 create function func()
 returns void
-as $function$ ALTER SUBSCRIPTION regress_testsub SET PUBLICATION mypub WITH (refresh = true) $function$
+as $function$
+ALTER SUBSCRIPTION regress_testsub SET PUBLICATION mypub WITH (refresh = true)
+$function$
 language sql;
 
 select func();

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__subscription_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__subscription_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/subscription.sql
-snapshot_kind: text
 ---
 create role regress_subscription_user login superuser;
 
@@ -267,7 +266,9 @@ commit;
 
 create function func()
 returns void
-as $function$ ALTER SUBSCRIPTION regress_testsub SET PUBLICATION mypub WITH (refresh = true) $function$
+as $function$
+ALTER SUBSCRIPTION regress_testsub SET PUBLICATION mypub WITH (refresh = true)
+$function$
 language sql;
 
 select func();

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__subselect_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__subselect_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/subselect.sql
-snapshot_kind: text
 ---
 select 1 as one where 1 in (select 1);
 
@@ -892,7 +891,9 @@ begin;
 create function bogus_int8_text_eq(bigint, text)
 returns boolean
 language sql
-as $function$select $1::text = $2$function$;
+as $function$
+select $1::text = $2
+$function$;
 
 create operator = (PROCEDURE = bogus_int8_text_eq, LEFTARG = bigint, RIGHTARG = text);
 
@@ -903,7 +904,9 @@ select * from int8_tbl where q1 in (select c1 from inner_text);
 create or replace function bogus_int8_text_eq(bigint, text)
 returns boolean
 language sql
-as $function$select $1::text = $2 and $1::text = $2$function$;
+as $function$
+select $1::text = $2 and $1::text = $2
+$function$;
 
 select * from int8_tbl where q1 in (select c1 from inner_text);
 
@@ -912,7 +915,9 @@ select * from int8_tbl where q1 in (select c1 from inner_text);
 create or replace function bogus_int8_text_eq(bigint, text)
 returns boolean
 language sql
-as $function$select $2 = $1::text$function$;
+as $function$
+select $2 = $1::text
+$function$;
 
 select * from int8_tbl where q1 in (select c1 from inner_text);
 
@@ -1411,7 +1416,8 @@ as $function$
 begin
   raise notice 'x = %, y = %', x, y;
   return x > y;
-end$function$;
+end
+$function$;
 
 select * from (select 9 as x, unnest(array[1, 2, 3, 11, 12, 13]) as u) as ss where tattle(x, 8);
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__subselect_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__subselect_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/subselect.sql
-snapshot_kind: text
 ---
 select 1 as one where 1 in (select 1);
 
@@ -1154,7 +1153,9 @@ begin;
 create function bogus_int8_text_eq(bigint, text)
 returns boolean
 language sql
-as $function$select $1::text = $2$function$;
+as $function$
+select $1::text = $2
+$function$;
 
 create operator = (PROCEDURE = bogus_int8_text_eq,
 LEFTARG = bigint,
@@ -1167,7 +1168,9 @@ select * from int8_tbl where q1 in (select c1 from inner_text);
 create or replace function bogus_int8_text_eq(bigint, text)
 returns boolean
 language sql
-as $function$select $1::text = $2 and $1::text = $2$function$;
+as $function$
+select $1::text = $2 and $1::text = $2
+$function$;
 
 select * from int8_tbl where q1 in (select c1 from inner_text);
 
@@ -1176,7 +1179,9 @@ select * from int8_tbl where q1 in (select c1 from inner_text);
 create or replace function bogus_int8_text_eq(bigint, text)
 returns boolean
 language sql
-as $function$select $2 = $1::text$function$;
+as $function$
+select $2 = $1::text
+$function$;
 
 select * from int8_tbl where q1 in (select c1 from inner_text);
 
@@ -1769,7 +1774,8 @@ as $function$
 begin
   raise notice 'x = %, y = %', x, y;
   return x > y;
-end$function$;
+end
+$function$;
 
 select
   *

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__temp_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__temp_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/temp.sql
-snapshot_kind: text
 ---
 create table temptest (col int);
 
@@ -103,7 +102,8 @@ begin
   $cmd$,
     (SELECT string_agg(g.i::text || ':' || random()::text, '|')
      FROM generate_series(1, 100) g(i)));
-end$do$;
+end
+$do$;
 
 select * from temptest;
 
@@ -141,12 +141,16 @@ insert into whereami values ('temp');
 
 create function public.whoami()
 returns text
-as $function$select 'public'::text$function$
+as $function$
+select 'public'::text
+$function$
 language sql;
 
 create function pg_temp.whoami()
 returns text
-as $function$select 'temp'::text$function$
+as $function$
+select 'temp'::text
+$function$
 language sql;
 
 select * from whereami;
@@ -262,14 +266,18 @@ begin;
 
 create function pg_temp.twophase_func()
 returns void
-as $function$ select '2pc_func'::text $function$
+as $function$
+select '2pc_func'::text
+$function$
 language sql;
 
 prepare transaction 'twophase_func';
 
 create function pg_temp.twophase_func()
 returns void
-as $function$ select '2pc_func'::text $function$
+as $function$
+select '2pc_func'::text
+$function$
 language sql;
 
 begin;
@@ -353,7 +361,7 @@ create function test_temp_pin(p_start int, p_end int)
 returns void
 language plpgsql
 as $function$
-  DECLARE
+DECLARE
       cursorname text;
       query text;
   BEGIN

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__temp_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__temp_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/temp.sql
-snapshot_kind: text
 ---
 create table temptest (col int);
 
@@ -103,7 +102,8 @@ begin
   $cmd$,
     (SELECT string_agg(g.i::text || ':' || random()::text, '|')
      FROM generate_series(1, 100) g(i)));
-end$do$;
+end
+$do$;
 
 select * from temptest;
 
@@ -141,12 +141,16 @@ insert into whereami values ('temp');
 
 create function public.whoami()
 returns text
-as $function$select 'public'::text$function$
+as $function$
+select 'public'::text
+$function$
 language sql;
 
 create function pg_temp.whoami()
 returns text
-as $function$select 'temp'::text$function$
+as $function$
+select 'temp'::text
+$function$
 language sql;
 
 select * from whereami;
@@ -268,14 +272,18 @@ begin;
 
 create function pg_temp.twophase_func()
 returns void
-as $function$ select '2pc_func'::text $function$
+as $function$
+select '2pc_func'::text
+$function$
 language sql;
 
 prepare transaction 'twophase_func';
 
 create function pg_temp.twophase_func()
 returns void
-as $function$ select '2pc_func'::text $function$
+as $function$
+select '2pc_func'::text
+$function$
 language sql;
 
 begin;
@@ -367,7 +375,7 @@ create function test_temp_pin(p_start int, p_end int)
 returns void
 language plpgsql
 as $function$
-  DECLARE
+DECLARE
       cursorname text;
       query text;
   BEGIN

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__test_setup_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__test_setup_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/test_setup.sql
-snapshot_kind: text
 ---
 set synchronous_commit = 'on';
 
@@ -218,8 +217,8 @@ parallel SAFE;
 create function part_hashint4_noop(value int, seed bigint)
 returns bigint
 as $function$
-    select value + seed;
-    $function$
+select value + seed;
+$function$
 language sql
 strict
 immutable
@@ -234,8 +233,8 @@ create operator class part_test_int4_ops
 create function part_hashtext_length(value text, seed bigint)
 returns bigint
 as $function$
-    select length(coalesce(value, ''))::int8
-    $function$
+select length(coalesce(value, ''))::int8
+$function$
 language sql
 strict
 immutable

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__test_setup_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__test_setup_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/test_setup.sql
-snapshot_kind: text
 ---
 set synchronous_commit = 'on';
 
@@ -236,8 +235,8 @@ parallel SAFE;
 create function part_hashint4_noop(value int, seed bigint)
 returns bigint
 as $function$
-    select value + seed;
-    $function$
+select value + seed;
+$function$
 language sql
 strict
 immutable
@@ -252,8 +251,8 @@ create operator class part_test_int4_ops
 create function part_hashtext_length(value text, seed bigint)
 returns bigint
 as $function$
-    select length(coalesce(value, ''))::int8
-    $function$
+select length(coalesce(value, ''))::int8
+$function$
 language sql
 strict
 immutable

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__transactions_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__transactions_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/transactions.sql
-snapshot_kind: text
 ---
 begin;
 
@@ -59,7 +58,9 @@ commit;
 create function errfunc()
 returns int
 language sql
-as $function$SELECT 1$function$
+as $function$
+SELECT 1
+$function$
 set transaction_read_only = 'on';
 
 create table writetest (a int);
@@ -469,7 +470,9 @@ select * from xacttest;
 create or replace function max_xacttest()
 returns smallint
 language sql
-as $function$select max(a) from xacttest$function$
+as $function$
+select max(a) from xacttest
+$function$
 stable;
 
 begin;
@@ -483,7 +486,9 @@ rollback;
 create or replace function max_xacttest()
 returns smallint
 language sql
-as $function$select max(a) from xacttest$function$
+as $function$
+select max(a) from xacttest
+$function$
 volatile;
 
 begin;
@@ -497,7 +502,9 @@ rollback;
 create or replace function max_xacttest()
 returns smallint
 language plpgsql
-as $function$begin return max(a) from xacttest; end$function$
+as $function$
+begin return max(a) from xacttest; end
+$function$
 stable;
 
 begin;
@@ -511,7 +518,9 @@ rollback;
 create or replace function max_xacttest()
 returns smallint
 language plpgsql
-as $function$begin return max(a) from xacttest; end$function$
+as $function$
+begin return max(a) from xacttest; end
+$function$
 volatile;
 
 begin;
@@ -556,7 +565,8 @@ begin
   return 1::float8/$1;
 exception
   when division_by_zero then return 0;
-end$function$
+end
+$function$
 language plpgsql
 volatile;
 
@@ -617,7 +627,9 @@ rollback;
 create function invert(x double precision)
 returns double precision
 language plpgsql
-as $function$ begin return 1/x; end $function$;
+as $function$
+begin return 1/x; end
+$function$;
 
 create function create_temp_tab()
 returns text
@@ -629,7 +641,8 @@ BEGIN
   -- relcache reference to new_table
   INSERT INTO new_table SELECT invert(0.0);
   RETURN 'foo';
-END $function$;
+END
+$function$;
 
 begin;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__transactions_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__transactions_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/transactions.sql
-snapshot_kind: text
 ---
 begin;
 
@@ -64,7 +63,9 @@ commit;
 create function errfunc()
 returns int
 language sql
-as $function$SELECT 1$function$
+as $function$
+SELECT 1
+$function$
 set transaction_read_only = 'on';
 
 create table writetest (a int);
@@ -497,7 +498,9 @@ select * from xacttest;
 create or replace function max_xacttest()
 returns smallint
 language sql
-as $function$select max(a) from xacttest$function$
+as $function$
+select max(a) from xacttest
+$function$
 stable;
 
 begin;
@@ -511,7 +514,9 @@ rollback;
 create or replace function max_xacttest()
 returns smallint
 language sql
-as $function$select max(a) from xacttest$function$
+as $function$
+select max(a) from xacttest
+$function$
 volatile;
 
 begin;
@@ -525,7 +530,9 @@ rollback;
 create or replace function max_xacttest()
 returns smallint
 language plpgsql
-as $function$begin return max(a) from xacttest; end$function$
+as $function$
+begin return max(a) from xacttest; end
+$function$
 stable;
 
 begin;
@@ -539,7 +546,9 @@ rollback;
 create or replace function max_xacttest()
 returns smallint
 language plpgsql
-as $function$begin return max(a) from xacttest; end$function$
+as $function$
+begin return max(a) from xacttest; end
+$function$
 volatile;
 
 begin;
@@ -584,7 +593,8 @@ begin
   return 1::float8/$1;
 exception
   when division_by_zero then return 0;
-end$function$
+end
+$function$
 language plpgsql
 volatile;
 
@@ -645,7 +655,9 @@ rollback;
 create function invert(x double precision)
 returns double precision
 language plpgsql
-as $function$ begin return 1/x; end $function$;
+as $function$
+begin return 1/x; end
+$function$;
 
 create function create_temp_tab()
 returns text
@@ -657,7 +669,8 @@ BEGIN
   -- relcache reference to new_table
   INSERT INTO new_table SELECT invert(0.0);
   RETURN 'foo';
-END $function$;
+END
+$function$;
 
 begin;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__triggers_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__triggers_100.snap
@@ -1,11 +1,12 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/triggers.sql
-snapshot_kind: text
 ---
 create function trigger_return_old()
 returns trigger
-as $function$regresslib$function$
+as $function$
+regresslib
+$function$
 language c;
 
 create table trigtest (
@@ -33,7 +34,9 @@ select * from trigtest;
 
 create function f1_times_10()
 returns trigger
-as $function$ begin new.f1 := new.f1 * 10; return new; end $function$
+as $function$
+begin new.f1 := new.f1 * 10; return new; end
+$function$
 language plpgsql;
 
 create trigger trigger_alpha
@@ -138,7 +141,8 @@ as $function$
 BEGIN
 	RAISE NOTICE 'trigger_func(%) called: action = %, when = %, level = %', TG_ARGV[0], TG_OP, TG_WHEN, TG_LEVEL;
 	RETURN NULL;
-END;$function$;
+END;
+$function$;
 
 create trigger before_ins_stmt_trig
 before insert
@@ -469,7 +473,8 @@ as $function$
 begin
 	raise notice '% % % %', TG_TABLE_NAME, TG_OP, TG_WHEN, TG_LEVEL;
 	return new;
-end;$function$
+end;
+$function$
 language plpgsql;
 
 create trigger trigtest_b_row_tg
@@ -556,7 +561,6 @@ create or replace function trigger_data()
 returns trigger
 language plpgsql
 as $function$
-
 declare
 
 	argstr text;
@@ -642,7 +646,8 @@ begin
 		raise notice 'row % changed', new.f1;
 	end if;
 	return new;
-end$function$;
+end
+$function$;
 
 create trigger t before update on trigger_test for each row execute function mytrigger();
 
@@ -667,7 +672,8 @@ begin
 		raise notice 'row % not changed', new.f1;
 	end if;
 	return new;
-end$function$;
+end
+$function$;
 
 update trigger_test set f3 = 'bar';
 
@@ -1126,7 +1132,9 @@ select COUNT(*) from european_city_view;
 create function no_op_trig_fn()
 returns trigger
 language plpgsql
-as $function$begin RETURN NULL; end$function$;
+as $function$
+begin RETURN NULL; end
+$function$;
 
 create trigger no_op_trig
 instead of insert or delete or update
@@ -1521,7 +1529,8 @@ as $function$
 begin
   alter table trigger_ddl_table add primary key (col1);
   return new;
-end$function$
+end
+$function$
 language plpgsql;
 
 create trigger trigger_ddl_func
@@ -1538,7 +1547,8 @@ as $function$
 begin
   create index on trigger_ddl_table (col2);
   return new;
-end$function$
+end
+$function$
 language plpgsql;
 
 insert into trigger_ddl_table values (1, 42);
@@ -1678,7 +1688,9 @@ as select * from my_table;
 
 create function my_trigger_function()
 returns trigger
-as $function$ begin end; $function$
+as $function$
+begin end;
+$function$
 language plpgsql;
 
 create trigger my_trigger
@@ -1700,7 +1712,9 @@ partition by LIST(a);
 create function trigger_nothing()
 returns trigger
 language plpgsql
-as $function$ begin end; $function$;
+as $function$
+begin end;
+$function$;
 
 create trigger failed
 instead of update
@@ -1870,14 +1884,14 @@ create table parted2_stmt_trig2 partition of parted2_stmt_trig for values in (2)
 create or replace function trigger_notice()
 returns trigger
 as $function$
-  begin
+begin
     raise notice 'trigger % on % % % for %', TG_NAME, TG_TABLE_NAME, TG_WHEN, TG_OP, TG_LEVEL;
     if TG_LEVEL = 'ROW' then
        return NEW;
     end if;
     return null;
   end;
-  $function$
+$function$
 language plpgsql;
 
 create trigger trig_ins_before
@@ -2076,7 +2090,7 @@ insert into parted_trig values (1);
 create or replace function trigger_notice()
 returns trigger
 as $function$
-  begin
+begin
     raise notice 'trigger % on % % % for %', TG_NAME, TG_TABLE_NAME, TG_WHEN, TG_OP, TG_LEVEL;
     if TG_LEVEL = 'ROW' then
       if TG_OP = 'DELETE' then
@@ -2087,7 +2101,7 @@ as $function$
     end if;
     return null;
   end;
-  $function$
+$function$
 language plpgsql;
 
 create trigger parted_trig_before_stmt
@@ -2126,7 +2140,7 @@ create table parted_trig1 partition of parted_trig for values in (1);
 create or replace function trigger_notice()
 returns trigger
 as $function$
-  declare
+declare
     arg1 text = TG_ARGV[0];
     arg2 integer = TG_ARGV[1];
   begin
@@ -2134,7 +2148,7 @@ as $function$
 		TG_NAME, TG_TABLE_NAME, TG_WHEN, TG_OP, TG_LEVEL, arg1, arg2;
     return null;
   end;
-  $function$
+$function$
 language plpgsql;
 
 create trigger aaa
@@ -2160,12 +2174,14 @@ create function bark(text)
 returns boolean
 language plpgsql
 immutable
-as $function$ begin raise notice '% <- woof!', $1; return true; end; $function$;
+as $function$
+begin raise notice '% <- woof!', $1; return true; end;
+$function$;
 
 create or replace function trigger_notice_ab()
 returns trigger
 as $function$
-  begin
+begin
     raise notice 'trigger % on % % % for %: (a,b)=(%,%)',
 		TG_NAME, TG_TABLE_NAME, TG_WHEN, TG_OP, TG_LEVEL,
 		NEW.a, NEW.b;
@@ -2174,7 +2190,7 @@ as $function$
     end if;
     return null;
   end;
-  $function$
+$function$
 language plpgsql;
 
 create table parted_irreg_ancestor (
@@ -2664,7 +2680,9 @@ inherits (parent);
 create function trig_nothing()
 returns trigger
 language plpgsql
-as $function$ begin return null; end $function$;
+as $function$
+begin return null; end
+$function$;
 
 create trigger tg after insert on parent for each row execute function trig_nothing();
 
@@ -2842,7 +2860,9 @@ create table trgfire1 partition of trgfire for values from (1) to (10);
 create or replace function tgf()
 returns trigger
 language plpgsql
-as $function$ begin raise exception 'except'; end $function$;
+as $function$
+begin raise exception 'except'; end
+$function$;
 
 create trigger tg after insert on trgfire for each row execute function tgf();
 
@@ -2920,7 +2940,7 @@ create or replace function dump_insert()
 returns trigger
 language plpgsql
 as $function$
-  begin
+begin
     raise notice 'trigger = %, new table = %',
                  TG_NAME,
                  (select string_agg(new_table::text, ', ' order by a) from new_table);
@@ -2932,7 +2952,7 @@ create or replace function dump_update()
 returns trigger
 language plpgsql
 as $function$
-  begin
+begin
     raise notice 'trigger = %, old table = %, new table = %',
                  TG_NAME,
                  (select string_agg(old_table::text, ', ' order by a) from old_table),
@@ -2945,7 +2965,7 @@ create or replace function dump_delete()
 returns trigger
 language plpgsql
 as $function$
-  begin
+begin
     raise notice 'trigger = %, old table = %',
                  TG_NAME,
                  (select string_agg(old_table::text, ', ' order by a) from old_table);
@@ -3150,7 +3170,7 @@ create or replace function intercept_insert()
 returns trigger
 language plpgsql
 as $function$
-  begin
+begin
     new.b = new.b + 1000;
     return new;
   end;
@@ -3212,7 +3232,7 @@ create or replace function dump_update_new()
 returns trigger
 language plpgsql
 as $function$
-  begin
+begin
     raise notice 'trigger = %, new table = %', TG_NAME,
                  (select string_agg(new_table::text, ', ' order by a) from new_table);
     return null;
@@ -3223,7 +3243,7 @@ create or replace function dump_update_old()
 returns trigger
 language plpgsql
 as $function$
-  begin
+begin
     raise notice 'trigger = %, old table = %', TG_NAME,
                  (select string_agg(old_table::text, ', ' order by a) from old_table);
     return null;
@@ -3634,10 +3654,12 @@ create table my_table (a int);
 
 create function make_bogus_matview()
 returns trigger
-as $function$ begin
+as $function$
+begin
   create materialized view transition_test_mv as select * from new_table;
   return new;
-end $function$
+end
+$function$
 language plpgsql;
 
 create trigger make_bogus_matview
@@ -3823,7 +3845,8 @@ as $function$
 begin
   raise notice 'hello from funcA';
   return null;
-end; $function$
+end;
+$function$
 language plpgsql;
 
 create function funcb()
@@ -3832,7 +3855,8 @@ as $function$
 begin
   raise notice 'hello from funcB';
   return null;
-end; $function$
+end;
+$function$
 language plpgsql;
 
 create trigger my_trig after insert on my_table for each row execute function funca();
@@ -3911,7 +3935,9 @@ partition by LIST(a);
 create function trigger_parted_trigfunc()
 returns trigger
 language plpgsql
-as $function$ begin end; $function$;
+as $function$
+begin end;
+$function$;
 
 create trigger aft_row
 after insert or update
@@ -3964,7 +3990,8 @@ raise notice 'trigger = %, old_table = %',
           TG_NAME,
           (select string_agg(old_table::text, ', ' order by col1) from old_table);
 return null;
-end; $function$;
+end;
+$function$;
 
 create function convslot_trig2()
 returns trigger
@@ -3975,7 +4002,8 @@ raise notice 'trigger = %, new table = %',
           TG_NAME,
           (select string_agg(new_table::text, ', ' order by col1) from new_table);
 return null;
-end; $function$;
+end;
+$function$;
 
 create trigger but_trigger
 after update
@@ -3996,7 +4024,8 @@ raise notice 'trigger = %, old_table = %, new table = %',
           (select string_agg(old_table::text, ', ' order by col1) from old_table),
           (select string_agg(new_table::text, ', ' order by col1) from new_table);
 return null;
-end; $function$;
+end;
+$function$;
 
 create trigger but_trigger2
 after update
@@ -4042,7 +4071,9 @@ alter table convslot_test_parent
 
 create function convslot_trig4()
 returns trigger
-as $function$begin raise exception 'BOOM!'; end$function$
+as $function$
+begin raise exception 'BOOM!'; end
+$function$
 language plpgsql;
 
 create trigger convslot_test_parent_update
@@ -4083,7 +4114,9 @@ create table cho partition of middle for values from (6) to (10);
 
 create function f()
 returns trigger
-as $function$ begin return new; end; $function$
+as $function$
+begin return new; end;
+$function$
 language plpgsql;
 
 create trigger a after insert on grandparent for each row execute function f();

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__triggers_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__triggers_80.snap
@@ -1,11 +1,12 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/triggers.sql
-snapshot_kind: text
 ---
 create function trigger_return_old()
 returns trigger
-as $function$regresslib$function$
+as $function$
+regresslib
+$function$
 language c;
 
 create table trigtest (
@@ -33,7 +34,9 @@ select * from trigtest;
 
 create function f1_times_10()
 returns trigger
-as $function$ begin new.f1 := new.f1 * 10; return new; end $function$
+as $function$
+begin new.f1 := new.f1 * 10; return new; end
+$function$
 language plpgsql;
 
 create trigger trigger_alpha
@@ -141,7 +144,8 @@ as $function$
 BEGIN
 	RAISE NOTICE 'trigger_func(%) called: action = %, when = %, level = %', TG_ARGV[0], TG_OP, TG_WHEN, TG_LEVEL;
 	RETURN NULL;
-END;$function$;
+END;
+$function$;
 
 create trigger before_ins_stmt_trig
 before insert
@@ -479,7 +483,8 @@ as $function$
 begin
 	raise notice '% % % %', TG_TABLE_NAME, TG_OP, TG_WHEN, TG_LEVEL;
 	return new;
-end;$function$
+end;
+$function$
 language plpgsql;
 
 create trigger trigtest_b_row_tg
@@ -566,7 +571,6 @@ create or replace function trigger_data()
 returns trigger
 language plpgsql
 as $function$
-
 declare
 
 	argstr text;
@@ -652,7 +656,8 @@ begin
 		raise notice 'row % changed', new.f1;
 	end if;
 	return new;
-end$function$;
+end
+$function$;
 
 create trigger t
 before update
@@ -681,7 +686,8 @@ begin
 		raise notice 'row % not changed', new.f1;
 	end if;
 	return new;
-end$function$;
+end
+$function$;
 
 update trigger_test set f3 = 'bar';
 
@@ -1172,7 +1178,9 @@ select COUNT(*) from european_city_view;
 create function no_op_trig_fn()
 returns trigger
 language plpgsql
-as $function$begin RETURN NULL; end$function$;
+as $function$
+begin RETURN NULL; end
+$function$;
 
 create trigger no_op_trig
 instead of insert or delete or update
@@ -1597,7 +1605,8 @@ as $function$
 begin
   alter table trigger_ddl_table add primary key (col1);
   return new;
-end$function$
+end
+$function$
 language plpgsql;
 
 create trigger trigger_ddl_func
@@ -1614,7 +1623,8 @@ as $function$
 begin
   create index on trigger_ddl_table (col2);
   return new;
-end$function$
+end
+$function$
 language plpgsql;
 
 insert into trigger_ddl_table values (1, 42);
@@ -1754,7 +1764,9 @@ as select * from my_table;
 
 create function my_trigger_function()
 returns trigger
-as $function$ begin end; $function$
+as $function$
+begin end;
+$function$
 language plpgsql;
 
 create trigger my_trigger
@@ -1776,7 +1788,9 @@ partition by LIST(a);
 create function trigger_nothing()
 returns trigger
 language plpgsql
-as $function$ begin end; $function$;
+as $function$
+begin end;
+$function$;
 
 create trigger failed
 instead of update
@@ -1970,14 +1984,14 @@ for values in (2);
 create or replace function trigger_notice()
 returns trigger
 as $function$
-  begin
+begin
     raise notice 'trigger % on % % % for %', TG_NAME, TG_TABLE_NAME, TG_WHEN, TG_OP, TG_LEVEL;
     if TG_LEVEL = 'ROW' then
        return NEW;
     end if;
     return null;
   end;
-  $function$
+$function$
 language plpgsql;
 
 create trigger trig_ins_before
@@ -2206,7 +2220,7 @@ insert into parted_trig values (1);
 create or replace function trigger_notice()
 returns trigger
 as $function$
-  begin
+begin
     raise notice 'trigger % on % % % for %', TG_NAME, TG_TABLE_NAME, TG_WHEN, TG_OP, TG_LEVEL;
     if TG_LEVEL = 'ROW' then
       if TG_OP = 'DELETE' then
@@ -2217,7 +2231,7 @@ as $function$
     end if;
     return null;
   end;
-  $function$
+$function$
 language plpgsql;
 
 create trigger parted_trig_before_stmt
@@ -2256,7 +2270,7 @@ create table parted_trig1 partition of parted_trig for values in (1);
 create or replace function trigger_notice()
 returns trigger
 as $function$
-  declare
+declare
     arg1 text = TG_ARGV[0];
     arg2 integer = TG_ARGV[1];
   begin
@@ -2264,7 +2278,7 @@ as $function$
 		TG_NAME, TG_TABLE_NAME, TG_WHEN, TG_OP, TG_LEVEL, arg1, arg2;
     return null;
   end;
-  $function$
+$function$
 language plpgsql;
 
 create trigger aaa
@@ -2290,12 +2304,14 @@ create function bark(text)
 returns boolean
 language plpgsql
 immutable
-as $function$ begin raise notice '% <- woof!', $1; return true; end; $function$;
+as $function$
+begin raise notice '% <- woof!', $1; return true; end;
+$function$;
 
 create or replace function trigger_notice_ab()
 returns trigger
 as $function$
-  begin
+begin
     raise notice 'trigger % on % % % for %: (a,b)=(%,%)',
 		TG_NAME, TG_TABLE_NAME, TG_WHEN, TG_OP, TG_LEVEL,
 		NEW.a, NEW.b;
@@ -2304,7 +2320,7 @@ as $function$
     end if;
     return null;
   end;
-  $function$
+$function$
 language plpgsql;
 
 create table parted_irreg_ancestor (
@@ -2840,7 +2856,9 @@ inherits (parent);
 create function trig_nothing()
 returns trigger
 language plpgsql
-as $function$ begin return null; end $function$;
+as $function$
+begin return null; end
+$function$;
 
 create trigger tg
 after insert
@@ -3034,7 +3052,9 @@ create table trgfire1 partition of trgfire for values from (1) to (10);
 create or replace function tgf()
 returns trigger
 language plpgsql
-as $function$ begin raise exception 'except'; end $function$;
+as $function$
+begin raise exception 'except'; end
+$function$;
 
 create trigger tg after insert on trgfire for each row execute function tgf();
 
@@ -3115,7 +3135,7 @@ create or replace function dump_insert()
 returns trigger
 language plpgsql
 as $function$
-  begin
+begin
     raise notice 'trigger = %, new table = %',
                  TG_NAME,
                  (select string_agg(new_table::text, ', ' order by a) from new_table);
@@ -3127,7 +3147,7 @@ create or replace function dump_update()
 returns trigger
 language plpgsql
 as $function$
-  begin
+begin
     raise notice 'trigger = %, old table = %, new table = %',
                  TG_NAME,
                  (select string_agg(old_table::text, ', ' order by a) from old_table),
@@ -3140,7 +3160,7 @@ create or replace function dump_delete()
 returns trigger
 language plpgsql
 as $function$
-  begin
+begin
     raise notice 'trigger = %, old table = %',
                  TG_NAME,
                  (select string_agg(old_table::text, ', ' order by a) from old_table);
@@ -3345,7 +3365,7 @@ create or replace function intercept_insert()
 returns trigger
 language plpgsql
 as $function$
-  begin
+begin
     new.b = new.b + 1000;
     return new;
   end;
@@ -3407,7 +3427,7 @@ create or replace function dump_update_new()
 returns trigger
 language plpgsql
 as $function$
-  begin
+begin
     raise notice 'trigger = %, new table = %', TG_NAME,
                  (select string_agg(new_table::text, ', ' order by a) from new_table);
     return null;
@@ -3418,7 +3438,7 @@ create or replace function dump_update_old()
 returns trigger
 language plpgsql
 as $function$
-  begin
+begin
     raise notice 'trigger = %, old table = %', TG_NAME,
                  (select string_agg(old_table::text, ', ' order by a) from old_table);
     return null;
@@ -3836,10 +3856,12 @@ create table my_table (a int);
 
 create function make_bogus_matview()
 returns trigger
-as $function$ begin
+as $function$
+begin
   create materialized view transition_test_mv as select * from new_table;
   return new;
-end $function$
+end
+$function$
 language plpgsql;
 
 create trigger make_bogus_matview
@@ -4027,7 +4049,8 @@ as $function$
 begin
   raise notice 'hello from funcA';
   return null;
-end; $function$
+end;
+$function$
 language plpgsql;
 
 create function funcb()
@@ -4036,7 +4059,8 @@ as $function$
 begin
   raise notice 'hello from funcB';
   return null;
-end; $function$
+end;
+$function$
 language plpgsql;
 
 create trigger my_trig
@@ -4155,7 +4179,9 @@ partition by LIST(a);
 create function trigger_parted_trigfunc()
 returns trigger
 language plpgsql
-as $function$ begin end; $function$;
+as $function$
+begin end;
+$function$;
 
 create trigger aft_row
 after insert or update
@@ -4218,7 +4244,8 @@ raise notice 'trigger = %, old_table = %',
           TG_NAME,
           (select string_agg(old_table::text, ', ' order by col1) from old_table);
 return null;
-end; $function$;
+end;
+$function$;
 
 create function convslot_trig2()
 returns trigger
@@ -4229,7 +4256,8 @@ raise notice 'trigger = %, new table = %',
           TG_NAME,
           (select string_agg(new_table::text, ', ' order by col1) from new_table);
 return null;
-end; $function$;
+end;
+$function$;
 
 create trigger but_trigger
 after update
@@ -4250,7 +4278,8 @@ raise notice 'trigger = %, old_table = %, new table = %',
           (select string_agg(old_table::text, ', ' order by col1) from old_table),
           (select string_agg(new_table::text, ', ' order by col1) from new_table);
 return null;
-end; $function$;
+end;
+$function$;
 
 create trigger but_trigger2
 after update
@@ -4297,7 +4326,9 @@ alter table convslot_test_parent
 
 create function convslot_trig4()
 returns trigger
-as $function$begin raise exception 'BOOM!'; end$function$
+as $function$
+begin raise exception 'BOOM!'; end
+$function$
 language plpgsql;
 
 create trigger convslot_test_parent_update
@@ -4341,7 +4372,9 @@ create table cho partition of middle for values from (6) to (10);
 
 create function f()
 returns trigger
-as $function$ begin return new; end; $function$
+as $function$
+begin return new; end;
+$function$
 language plpgsql;
 
 create trigger a after insert on grandparent for each row execute function f();

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__truncate_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__truncate_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/truncate.sql
-snapshot_kind: text
 ---
 create table truncate_a (col1 int primary key);
 
@@ -367,7 +366,7 @@ create function tp_ins_data()
 returns void
 language plpgsql
 as $function$
-  BEGIN
+BEGIN
 	INSERT INTO truncprim VALUES (1), (100), (150);
 	INSERT INTO truncpart VALUES (1), (100), (150);
   END
@@ -377,7 +376,7 @@ create function tp_chk_data(out pktb regclass, out pkval int, out fktb regclass,
 returns setof record
 language plpgsql
 as $function$
-  BEGIN
+BEGIN
     RETURN QUERY SELECT
       pk.tableoid::regclass, pk.a, fk.tableoid::regclass, fk.a
     FROM truncprim pk FULL JOIN truncpart fk USING (a)

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__truncate_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__truncate_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/truncate.sql
-snapshot_kind: text
 ---
 create table truncate_a (col1 int primary key);
 
@@ -368,7 +367,7 @@ create function tp_ins_data()
 returns void
 language plpgsql
 as $function$
-  BEGIN
+BEGIN
 	INSERT INTO truncprim VALUES (1), (100), (150);
 	INSERT INTO truncpart VALUES (1), (100), (150);
   END
@@ -384,7 +383,7 @@ tp_chk_data(
 returns setof record
 language plpgsql
 as $function$
-  BEGIN
+BEGIN
     RETURN QUERY SELECT
       pk.tableoid::regclass, pk.a, fk.tableoid::regclass, fk.a
     FROM truncprim pk FULL JOIN truncpart fk USING (a)

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__typed_table_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__typed_table_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/typed_table.sql
-snapshot_kind: text
 ---
 create table ttable1 of nothing;
 
@@ -17,7 +16,7 @@ create function get_all_persons()
 returns setof person_type
 language sql
 as $function$
-    SELECT * FROM persons;
+SELECT * FROM persons;
 $function$;
 
 select * from get_all_persons();
@@ -69,7 +68,9 @@ insert into persons values (1, 'test');
 create function namelen(person_type)
 returns int
 language sql
-as $function$ SELECT length($1.name) $function$;
+as $function$
+SELECT length($1.name)
+$function$;
 
 select id, namelen(persons) from persons;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__typed_table_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__typed_table_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/typed_table.sql
-snapshot_kind: text
 ---
 create table ttable1 of nothing;
 
@@ -17,7 +16,7 @@ create function get_all_persons()
 returns setof person_type
 language sql
 as $function$
-    SELECT * FROM persons;
+SELECT * FROM persons;
 $function$;
 
 select * from get_all_persons();
@@ -85,7 +84,9 @@ insert into persons values (1, 'test');
 create function namelen(person_type)
 returns int
 language sql
-as $function$ SELECT length($1.name) $function$;
+as $function$
+SELECT length($1.name)
+$function$;
 
 select id, namelen(persons) from persons;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__updatable_views_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__updatable_views_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/updatable_views.sql
-snapshot_kind: text
 ---
 set extra_float_digits = 0;
 
@@ -849,7 +848,9 @@ as select b as bb, a as aa from base_tbl;
 
 create function rw_view1_aa(x rw_view1)
 returns int
-as $function$ SELECT x.aa $function$
+as $function$
+SELECT x.aa
+$function$
 language sql;
 
 update rw_view1 as v

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__updatable_views_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__updatable_views_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/updatable_views.sql
-snapshot_kind: text
 ---
 set extra_float_digits = 0;
 
@@ -905,7 +904,9 @@ as select b as bb, a as aa from base_tbl;
 
 create function rw_view1_aa(x rw_view1)
 returns int
-as $function$ SELECT x.aa $function$
+as $function$
+SELECT x.aa
+$function$
 language sql;
 
 update rw_view1 as v

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__update_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__update_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/update.sql
-snapshot_kind: text
 ---
 create table update_test (
   a int default 10,
@@ -394,7 +393,7 @@ create function trans_updatetrigfunc()
 returns trigger
 language plpgsql
 as $function$
-  begin
+begin
     raise notice 'trigger = %, old table = %, new table = %',
                  TG_NAME,
                  (select string_agg(old_table::text, ', ' ORDER BY a) FROM old_table),
@@ -442,7 +441,8 @@ as $function$
 BEGIN
    NEW.b = NEW.b + 1;
    return NEW;
-END $function$
+END
+$function$
 language plpgsql;
 
 create trigger trig_c1_100
@@ -511,7 +511,8 @@ as $function$
 BEGIN
    NEW.c = NEW.c + 1; -- Make even numbers odd, or vice versa
    return NEW;
-END $function$
+END
+$function$
 language plpgsql;
 
 create trigger trig_d_1_15 before insert on part_d_1_15 for each row execute function func_d_1_15();
@@ -587,7 +588,7 @@ create function trigfunc()
 returns trigger
 language plpgsql
 as $function$
-  begin
+begin
     raise notice 'trigger = % fired on table % during %',
                  TG_NAME, TG_TABLE_NAME, TG_OP;
     return null;
@@ -873,7 +874,8 @@ as $function$
 BEGIN
    NEW.b = 2; -- This is changing partition key column.
    return NEW;
-END $function$
+END
+$function$
 language plpgsql;
 
 create trigger parted_mod_b
@@ -896,7 +898,8 @@ as $function$
 BEGIN
    raise notice 'Trigger: Got OLD row %, but returning NULL', OLD;
    return NULL;
-END $function$
+END
+$function$
 language plpgsql;
 
 create trigger trig_skip_delete
@@ -931,7 +934,9 @@ drop table list_parted;
 
 create or replace function dummy_hashint4(a int, seed bigint)
 returns bigint
-as $function$ begin return (a + seed); end; $function$
+as $function$
+begin return (a + seed); end;
+$function$
 language plpgsql
 immutable;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__update_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__update_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/update.sql
-snapshot_kind: text
 ---
 create table update_test (
   a int default 10,
@@ -450,7 +449,7 @@ create function trans_updatetrigfunc()
 returns trigger
 language plpgsql
 as $function$
-  begin
+begin
     raise notice 'trigger = %, old table = %, new table = %',
                  TG_NAME,
                  (select string_agg(old_table::text, ', ' ORDER BY a) FROM old_table),
@@ -498,7 +497,8 @@ as $function$
 BEGIN
    NEW.b = NEW.b + 1;
    return NEW;
-END $function$
+END
+$function$
 language plpgsql;
 
 create trigger trig_c1_100
@@ -572,7 +572,8 @@ as $function$
 BEGIN
    NEW.c = NEW.c + 1; -- Make even numbers odd, or vice versa
    return NEW;
-END $function$
+END
+$function$
 language plpgsql;
 
 create trigger trig_d_1_15
@@ -655,7 +656,7 @@ create function trigfunc()
 returns trigger
 language plpgsql
 as $function$
-  begin
+begin
     raise notice 'trigger = % fired on table % during %',
                  TG_NAME, TG_TABLE_NAME, TG_OP;
     return null;
@@ -958,7 +959,8 @@ as $function$
 BEGIN
    NEW.b = 2; -- This is changing partition key column.
    return NEW;
-END $function$
+END
+$function$
 language plpgsql;
 
 create trigger parted_mod_b
@@ -997,7 +999,8 @@ as $function$
 BEGIN
    raise notice 'Trigger: Got OLD row %, but returning NULL', OLD;
    return NULL;
-END $function$
+END
+$function$
 language plpgsql;
 
 create trigger trig_skip_delete
@@ -1060,7 +1063,9 @@ drop table list_parted;
 
 create or replace function dummy_hashint4(a int, seed bigint)
 returns bigint
-as $function$ begin return (a + seed); end; $function$
+as $function$
+begin return (a + seed); end;
+$function$
 language plpgsql
 immutable;
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__vacuum_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__vacuum_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/vacuum.sql
-snapshot_kind: text
 ---
 create table vactst (i int);
 
@@ -90,13 +89,17 @@ create function do_analyze()
 returns void
 volatile
 language sql
-as $function$ANALYZE pg_am$function$;
+as $function$
+ANALYZE pg_am
+$function$;
 
 create function wrap_do_analyze(c int)
 returns int
 immutable
 language sql
-as $function$SELECT $1 FROM public.do_analyze()$function$;
+as $function$
+SELECT $1 FROM public.do_analyze()
+$function$;
 
 create index on vaccluster using btree ((wrap_do_analyze(i)));
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__vacuum_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__vacuum_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/vacuum.sql
-snapshot_kind: text
 ---
 create table vactst (i int);
 
@@ -90,13 +89,17 @@ create function do_analyze()
 returns void
 volatile
 language sql
-as $function$ANALYZE pg_am$function$;
+as $function$
+ANALYZE pg_am
+$function$;
 
 create function wrap_do_analyze(c int)
 returns int
 immutable
 language sql
-as $function$SELECT $1 FROM public.do_analyze()$function$;
+as $function$
+SELECT $1 FROM public.do_analyze()
+$function$;
 
 create index on vaccluster using btree ((wrap_do_analyze(i)));
 

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__window_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__window_100.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/window.sql
-snapshot_kind: text
 ---
 create temporary table empsalary (
   depname varchar,
@@ -1805,7 +1804,7 @@ returns table (
 )
 language sql
 as $function$
-  SELECT sum(unique1) over (rows between x preceding and x following),
+SELECT sum(unique1) over (rows between x preceding and x following),
          unique1, four
   FROM tenk1 WHERE unique1 < 10;
 $function$;
@@ -1842,7 +1841,7 @@ returns table (
 )
 language sql
 as $function$
-  SELECT sum(unique1) over (rows between unbounded preceding and unbounded following),
+SELECT sum(unique1) over (rows between unbounded preceding and unbounded following),
          unique1, four
   FROM tenk1 WHERE unique1 < 10;
 $function$;
@@ -4831,7 +4830,9 @@ language internal
 window
 immutable
 strict
-as $function$window_nth_value$function$;
+as $function$
+window_nth_value
+$function$;
 
 select
   nth_value_def(
@@ -4875,19 +4876,25 @@ from
 
 create function logging_sfunc_nonstrict(text, anyelement)
 returns text
-as $function$ SELECT COALESCE($1, '') || '*' || quote_nullable($2) $function$
+as $function$
+SELECT COALESCE($1, '') || '*' || quote_nullable($2)
+$function$
 language sql
 immutable;
 
 create function logging_msfunc_nonstrict(text, anyelement)
 returns text
-as $function$ SELECT COALESCE($1, '') || '+' || quote_nullable($2) $function$
+as $function$
+SELECT COALESCE($1, '') || '+' || quote_nullable($2)
+$function$
 language sql
 immutable;
 
 create function logging_minvfunc_nonstrict(text, anyelement)
 returns text
-as $function$ SELECT $1 || '-' || quote_nullable($2) $function$
+as $function$
+SELECT $1 || '-' || quote_nullable($2)
+$function$
 language sql
 immutable;
 
@@ -4915,21 +4922,27 @@ create aggregate logging_agg_nonstrict_initcond (
 
 create function logging_sfunc_strict(text, anyelement)
 returns text
-as $function$ SELECT $1 || '*' || quote_nullable($2) $function$
+as $function$
+SELECT $1 || '*' || quote_nullable($2)
+$function$
 language sql
 strict
 immutable;
 
 create function logging_msfunc_strict(text, anyelement)
 returns text
-as $function$ SELECT $1 || '+' || quote_nullable($2) $function$
+as $function$
+SELECT $1 || '+' || quote_nullable($2)
+$function$
 language sql
 strict
 immutable;
 
 create function logging_minvfunc_strict(text, anyelement)
 returns text
-as $function$ SELECT $1 || '-' || quote_nullable($2) $function$
+as $function$
+SELECT $1 || '-' || quote_nullable($2)
+$function$
 language sql
 strict
 immutable;
@@ -5119,7 +5132,9 @@ order by i;
 
 create function sum_int_randrestart_minvfunc(int, int)
 returns int
-as $function$ SELECT CASE WHEN random() < 0.2 THEN NULL ELSE $1 - $2 END $function$
+as $function$
+SELECT CASE WHEN random() < 0.2 THEN NULL ELSE $1 - $2 END
+$function$
 language sql
 strict;
 
@@ -6295,7 +6310,7 @@ window
 create function pg_temp.f(group_size bigint)
 returns setof int[]
 as $function$
-    SELECT array_agg(s) OVER w
+SELECT array_agg(s) OVER w
       FROM generate_series(1,5) s
     WINDOW w AS (ORDER BY s ROWS BETWEEN CURRENT ROW AND GROUP_SIZE FOLLOWING)
 $function$

--- a/crates/pgls_pretty_print/tests/snapshots/multi/tests__window_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/multi/tests__window_80.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/multi/window.sql
-snapshot_kind: text
 ---
 create temporary table empsalary (
   depname varchar,
@@ -2015,7 +2014,7 @@ returns table (
 )
 language sql
 as $function$
-  SELECT sum(unique1) over (rows between x preceding and x following),
+SELECT sum(unique1) over (rows between x preceding and x following),
          unique1, four
   FROM tenk1 WHERE unique1 < 10;
 $function$;
@@ -2052,7 +2051,7 @@ returns table (
 )
 language sql
 as $function$
-  SELECT sum(unique1) over (rows between unbounded preceding and unbounded following),
+SELECT sum(unique1) over (rows between unbounded preceding and unbounded following),
          unique1, four
   FROM tenk1 WHERE unique1 < 10;
 $function$;
@@ -5144,7 +5143,9 @@ language internal
 window
 immutable
 strict
-as $function$window_nth_value$function$;
+as $function$
+window_nth_value
+$function$;
 
 select
   nth_value_def(
@@ -5193,19 +5194,25 @@ from
 
 create function logging_sfunc_nonstrict(text, anyelement)
 returns text
-as $function$ SELECT COALESCE($1, '') || '*' || quote_nullable($2) $function$
+as $function$
+SELECT COALESCE($1, '') || '*' || quote_nullable($2)
+$function$
 language sql
 immutable;
 
 create function logging_msfunc_nonstrict(text, anyelement)
 returns text
-as $function$ SELECT COALESCE($1, '') || '+' || quote_nullable($2) $function$
+as $function$
+SELECT COALESCE($1, '') || '+' || quote_nullable($2)
+$function$
 language sql
 immutable;
 
 create function logging_minvfunc_nonstrict(text, anyelement)
 returns text
-as $function$ SELECT $1 || '-' || quote_nullable($2) $function$
+as $function$
+SELECT $1 || '-' || quote_nullable($2)
+$function$
 language sql
 immutable;
 
@@ -5233,21 +5240,27 @@ create aggregate logging_agg_nonstrict_initcond (
 
 create function logging_sfunc_strict(text, anyelement)
 returns text
-as $function$ SELECT $1 || '*' || quote_nullable($2) $function$
+as $function$
+SELECT $1 || '*' || quote_nullable($2)
+$function$
 language sql
 strict
 immutable;
 
 create function logging_msfunc_strict(text, anyelement)
 returns text
-as $function$ SELECT $1 || '+' || quote_nullable($2) $function$
+as $function$
+SELECT $1 || '+' || quote_nullable($2)
+$function$
 language sql
 strict
 immutable;
 
 create function logging_minvfunc_strict(text, anyelement)
 returns text
-as $function$ SELECT $1 || '-' || quote_nullable($2) $function$
+as $function$
+SELECT $1 || '-' || quote_nullable($2)
+$function$
 language sql
 strict
 immutable;
@@ -5472,7 +5485,9 @@ order by i;
 
 create function sum_int_randrestart_minvfunc(int, int)
 returns int
-as $function$ SELECT CASE WHEN random() < 0.2 THEN NULL ELSE $1 - $2 END $function$
+as $function$
+SELECT CASE WHEN random() < 0.2 THEN NULL ELSE $1 - $2 END
+$function$
 language sql
 strict;
 
@@ -6704,7 +6719,7 @@ window
 create function pg_temp.f(group_size bigint)
 returns setof int[]
 as $function$
-    SELECT array_agg(s) OVER w
+SELECT array_agg(s) OVER w
       FROM generate_series(1,5) s
     WINDOW w AS (ORDER BY s ROWS BETWEEN CURRENT ROW AND GROUP_SIZE FOLLOWING)
 $function$

--- a/crates/pgls_pretty_print/tests/snapshots/single/tests__create_function_stmt_0_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/single/tests__create_function_stmt_0_100.snap
@@ -1,9 +1,10 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/single/create_function_stmt_0.sql
-snapshot_kind: text
 ---
 create function add(a int, b int)
 returns int
-as $function$SELECT $1 + $2$function$
+as $function$
+SELECT $1 + $2
+$function$
 language sql;

--- a/crates/pgls_pretty_print/tests/snapshots/single/tests__create_function_stmt_0_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/single/tests__create_function_stmt_0_80.snap
@@ -1,9 +1,10 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/single/create_function_stmt_0.sql
-snapshot_kind: text
 ---
 create function add(a int, b int)
 returns int
-as $function$SELECT $1 + $2$function$
+as $function$
+SELECT $1 + $2
+$function$
 language sql;

--- a/crates/pgls_pretty_print/tests/snapshots/single/tests__do_stmt_0_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/single/tests__do_stmt_0_100.snap
@@ -1,6 +1,9 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/single/do_stmt_0.sql
-snapshot_kind: text
 ---
-do language plpgsql $do$BEGIN NULL; END$do$;
+do
+language plpgsql
+$do$
+BEGIN NULL; END
+$do$;

--- a/crates/pgls_pretty_print/tests/snapshots/single/tests__do_stmt_0_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/single/tests__do_stmt_0_80.snap
@@ -1,6 +1,9 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/single/do_stmt_0.sql
-snapshot_kind: text
 ---
-do language plpgsql $do$BEGIN NULL; END$do$;
+do
+language plpgsql
+$do$
+BEGIN NULL; END
+$do$;

--- a/crates/pgls_pretty_print/tests/snapshots/single/tests__pl_assign_stmt_0_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/single/tests__pl_assign_stmt_0_100.snap
@@ -1,11 +1,12 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/single/pl_assign_stmt_0.sql
-snapshot_kind: text
 ---
-do $do$
+do
+$do$
 DECLARE
     x integer;
 BEGIN
     x := 42;
-END $do$;
+END
+$do$;

--- a/crates/pgls_pretty_print/tests/snapshots/single/tests__pl_assign_stmt_0_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/single/tests__pl_assign_stmt_0_80.snap
@@ -1,11 +1,12 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/single/pl_assign_stmt_0.sql
-snapshot_kind: text
 ---
-do $do$
+do
+$do$
 DECLARE
     x integer;
 BEGIN
     x := 42;
-END $do$;
+END
+$do$;

--- a/crates/pgls_pretty_print/tests/snapshots/single/tests__return_stmt_0_100.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/single/tests__return_stmt_0_100.snap
@@ -1,9 +1,10 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/single/return_stmt_0.sql
-snapshot_kind: text
 ---
-do $do$
+do
+$do$
 BEGIN
     RETURN;
-END $do$;
+END
+$do$;

--- a/crates/pgls_pretty_print/tests/snapshots/single/tests__return_stmt_0_80.snap
+++ b/crates/pgls_pretty_print/tests/snapshots/single/tests__return_stmt_0_80.snap
@@ -1,9 +1,10 @@
 ---
 source: crates/pgls_pretty_print/tests/tests.rs
 input_file: crates/pgls_pretty_print/tests/data/single/return_stmt_0.sql
-snapshot_kind: text
 ---
-do $do$
+do
+$do$
 BEGIN
     RETURN;
-END $do$;
+END
+$do$;

--- a/crates/pgls_pretty_print_codegen/src/token_kind.rs
+++ b/crates/pgls_pretty_print_codegen/src/token_kind.rs
@@ -25,6 +25,8 @@ const LITERALS: &[&str] = &[
     "BIT_STRING",
     "BYTE_STRING",
     "DOLLAR_QUOTED_STRING",
+    "DOLLAR_QUOTE_DELIMITER", // $function$, $body$, $$, etc.
+    "DOLLAR_QUOTE_BODY",      // The content inside dollar quotes (preserved verbatim)
     "ESC_STRING",
     "FLOAT_NUMBER",
     "INT_NUMBER",
@@ -37,17 +39,19 @@ const LITERALS: &[&str] = &[
 
 const VARIANT_DATA: &[(&str, &str)] = &[
     ("STRING", "String"),
-    ("ESC_STRING", "String"),           // E'hello\nworld'
-    ("DOLLAR_QUOTED_STRING", "String"), // $$hello world$$
-    ("INT_NUMBER", "i64"),              // 123, -456
-    ("FLOAT_NUMBER", "f64"),            // 123.45, 1.2e-3
-    ("BIT_STRING", "String"),           // B'1010', X'FF'
-    ("BYTE_STRING", "String"),          // Similar to bit string
-    ("IDENT", "String"),                // user_id, table_name
-    ("POSITIONAL_PARAM", "u32"),        // $1, $2, $3 (the number matters!)
-    ("COMMENT", "String"),              // /* comment text */
-    ("BOOLEAN", "bool"),                // true, false
-    ("TYPE_IDENT", "String"),           // text, varchar, int (data type names)
+    ("ESC_STRING", "String"),             // E'hello\nworld'
+    ("DOLLAR_QUOTED_STRING", "String"),   // $$hello world$$ (legacy, full string)
+    ("DOLLAR_QUOTE_DELIMITER", "String"), // $function$, $body$, $$, etc.
+    ("DOLLAR_QUOTE_BODY", "String"),      // The content inside dollar quotes
+    ("INT_NUMBER", "i64"),                // 123, -456
+    ("FLOAT_NUMBER", "f64"),              // 123.45, 1.2e-3
+    ("BIT_STRING", "String"),             // B'1010', X'FF'
+    ("BYTE_STRING", "String"),            // Similar to bit string
+    ("IDENT", "String"),                  // user_id, table_name
+    ("POSITIONAL_PARAM", "u32"),          // $1, $2, $3 (the number matters!)
+    ("COMMENT", "String"),                // /* comment text */
+    ("BOOLEAN", "bool"),                  // true, false
+    ("TYPE_IDENT", "String"),             // text, varchar, int (data type names)
 ];
 
 pub fn token_kind_mod() -> proc_macro2::TokenStream {
@@ -150,6 +154,8 @@ pub fn token_kind_mod() -> proc_macro2::TokenStream {
                     TokenKind::STRING(s) => s.clone(),
                     TokenKind::ESC_STRING(s) => s.clone(),
                     TokenKind::DOLLAR_QUOTED_STRING(s) => s.clone(),
+                    TokenKind::DOLLAR_QUOTE_DELIMITER(s) => s.clone(),
+                    TokenKind::DOLLAR_QUOTE_BODY(s) => s.clone(),
                     TokenKind::INT_NUMBER(n) => n.to_string(),
                     TokenKind::FLOAT_NUMBER(n) => n.to_string(),
                     TokenKind::BIT_STRING(s) => s.clone(),


### PR DESCRIPTION
## Summary

Improves pretty printing of SQL function bodies by placing dollar-quote delimiters on their own lines for better readability.

## Changes

- Added new token types `DOLLAR_QUOTE_DELIMITER` and `DOLLAR_QUOTE_BODY` to separately represent delimiter and content
- Modified `emit_dollar_quoted_str_with_hint` to emit delimiters and body on separate lines
- Added AST normalization for function body whitespace to ensure semantic equivalence in tests

## Example

### Before
```sql
create function add(a int, b int)
returns int
as $function$SELECT $1 + $2$function$
language sql;
```

### After
```sql
create function add(a int, b int)
returns int
as $function$
SELECT $1 + $2
$function$
language sql;
```

This applies to all dollar-quoted function/procedure bodies including `CREATE FUNCTION`, `CREATE PROCEDURE`, and `DO` blocks.