### PR TITLE
docs: add pgfence as complementary migration safety tool

### DIFF
--- a/docs/guides/continuous_integration.md
+++ b/docs/guides/continuous_integration.md
@@ -46,7 +46,7 @@ A common use-case is to check your migration files. Check out [the dedicated gui
 
 ### Combining with pgfence for Migration Safety
 
-While Postgres Language Server catches SQL syntax and semantic issues, it does not analyze the **lock modes** and **runtime risk** of DDL statements. [pgfence](https://pgfence.dev) is a complementary CLI that fills this gap — it tells you what PostgreSQL lock each migration statement acquires, what it blocks, and provides safe rewrite recipes when it detects dangerous patterns.
+While Postgres Language Server catches SQL syntax and semantic issues, it does not analyze the **lock modes** and **runtime risk** of DDL statements. [pgfence](https://pgfence.dev) is a complementary CLI that fills this gap — it tells you which PostgreSQL lock mode each migration statement acquires, what it blocks, and provides safe rewrite recipes when it detects dangerous patterns.
 
 By running both tools in CI, you get comprehensive migration checking: PGLT ensures your SQL is correct, and pgfence ensures it is safe to run against a live database.
 


### PR DESCRIPTION
## Summary

- Adds a new section to the [Continuous Integration guide](https://pg-language-server.com/latest/guides/continuous_integration/) showing how to combine Postgres Language Server with [pgfence](https://pgfence.dev) for comprehensive migration checking
- Includes a complete GitHub Actions workflow example running both tools together
- Documents pgfence's `--ci` and `--max-risk` flags for CI gating

## Why

PGLT catches SQL syntax and semantic issues. pgfence adds a complementary layer: it analyzes what PostgreSQL **lock mode** each DDL statement acquires, what it blocks, scores the runtime risk level, and provides safe rewrite recipes for dangerous patterns (e.g., `CREATE INDEX` without `CONCURRENTLY`, `ADD COLUMN ... NOT NULL` without the expand/contract sequence).

Running both tools in CI gives teams comprehensive migration checking — correctness (PGLT) and safety (pgfence).

- **pgfence**: [npm](https://www.npmjs.com/package/@flvmnt/pgfence) · [GitHub](https://github.com/flvmnt/pgfence) · [Website](https://pgfence.dev)

## Test plan

- [ ] Verify the markdown renders correctly on the docs site
- [ ] Confirm the YAML workflow example is syntactically valid
- [ ] Verify external links resolve (pgfence.dev, npm package)