### PR TITLE
fix: handle AS [NOT] MATERIALIZED in CTE statement splitting

### DIFF
--- a/crates/pgls_statement_splitter/src/lib.rs
+++ b/crates/pgls_statement_splitter/src/lib.rs
@@ -607,4 +607,31 @@ VALUES
         // does not panic
         let _ = Tester::from("select case ");
     }
+
+    #[test]
+    fn with_cte_as_materialized() {
+        Tester::from(
+            "WITH latest AS MATERIALIZED (SELECT id FROM submissions) SELECT * FROM latest;",
+        )
+        .assert_single_statement()
+        .assert_no_errors();
+    }
+
+    #[test]
+    fn with_cte_as_not_materialized() {
+        Tester::from(
+            "WITH latest AS NOT MATERIALIZED (SELECT id FROM submissions) SELECT * FROM latest;",
+        )
+        .assert_single_statement()
+        .assert_no_errors();
+    }
+
+    #[test]
+    fn with_multiple_materialized_ctes() {
+        Tester::from(
+            "WITH a AS (SELECT 1), b AS MATERIALIZED (SELECT 2), c AS NOT MATERIALIZED (SELECT 3) SELECT * FROM a, b, c;",
+        )
+        .assert_single_statement()
+        .assert_no_errors();
+    }
 }

--- a/crates/pgls_statement_splitter/src/splitter/dml.rs
+++ b/crates/pgls_statement_splitter/src/splitter/dml.rs
@@ -14,6 +14,9 @@ pub(crate) fn cte(p: &mut Splitter) -> SplitterResult {
     loop {
         p.expect(SyntaxKind::IDENT)?;
         p.expect(SyntaxKind::AS_KW)?;
+        // Handle optional [NOT] MATERIALIZED hint (PostgreSQL 12+)
+        p.eat(SyntaxKind::NOT_KW)?;
+        p.eat(SyntaxKind::MATERIALIZED_KW)?;
         parenthesis(p)?;
 
         if p.current() == SyntaxKind::COMMA {


### PR DESCRIPTION
> **Note:** This PR was generated with Claude.

## Summary
- Fix spurious "Expected L_PAREN" syntax error when using `AS MATERIALIZED (...)` or `AS NOT MATERIALIZED (...)` in CTEs (PostgreSQL 12+ feature)
- The statement splitter's `cte()` function went directly from `AS` to expecting `(`, not accounting for the optional `[NOT] MATERIALIZED` hint
- Added `p.eat(NOT_KW)` and `p.eat(MATERIALIZED_KW)` between `AS` and the parenthesized subquery

## Test plan
- [x] Added `with_cte_as_materialized` test — `AS MATERIALIZED (...)`
- [x] Added `with_cte_as_not_materialized` test — `AS NOT MATERIALIZED (...)`
- [x] Added `with_multiple_materialized_ctes` test — mix of plain, materialized, and not-materialized CTEs
- [x] All 44 statement splitter tests pass
- [x] No clippy warnings
- [x] Verified the fix against a real-world SQL file that previously triggered the error

🤖 Generated with [Claude Code](https://claude.com/claude-code)