### PR TITLE
fix: prevent treesitter context panic on incomplete SQL

### DIFF
--- a/crates/pgls_treesitter/src/context/ancestors.rs
+++ b/crates/pgls_treesitter/src/context/ancestors.rs
@@ -16,13 +16,13 @@ impl ScopeTracker {
     }
 
     pub fn register<'a>(&mut self, node: tree_sitter::Node<'a>, position: usize) {
-        if SCOPE_BOUNDARIES.contains(&node.kind()) {
+        if SCOPE_BOUNDARIES.contains(&node.kind()) || self.scopes.is_empty() {
             self.add_new_scope(node);
         }
 
         self.scopes
             .last_mut()
-            .unwrap_or_else(|| panic!("Unhandled node kind: {}", node.kind()))
+            .expect("scope must exist after initialization above")
             .ancestors
             .register(node, position);
     }

--- a/crates/pgls_treesitter/src/context/mod.rs
+++ b/crates/pgls_treesitter/src/context/mod.rs
@@ -992,4 +992,25 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn does_not_crash_on_incomplete_function_body() {
+        // Regression test for #704: incomplete SQL with unhandled node kinds
+        // (function_arguments, type, function_language, object_reference, comment,
+        // keyword_begin, keyword_end, :=) must not panic.
+        let sql = "DECLARE\nBEGIN\n    po_1 := length(pi_1);\nEND;";
+
+        let tree = get_tree(sql);
+
+        // Try multiple positions across the statement to cover all node kinds
+        for pos in 0..sql.len() {
+            let params = TreeSitterContextParams {
+                position: (pos as u32).into(),
+                text: sql,
+                tree: &tree,
+            };
+            // must not panic
+            let _ = TreesitterContext::new(params);
+        }
+    }
 }


### PR DESCRIPTION
Closes https://github.com/supabase-community/postgres-language-server/issues/704

**Root cause**: `ScopeTracker::register()` in `ancestors.rs` assumes the first node it encounters is always a scope boundary (`statement`, `ERROR`, or `program`). When tree-sitter parses malformed SQL, nodes like `function_arguments`, `:=`, `keyword_begin`, etc. can appear as the first traversed node, leaving `self.scopes` empty and hitting an `unwrap_or_else(panic!)`.

**Fix**:
- Changed the scope creation condition to also create a fallback scope when `self.scopes` is empty. This gracefully degrades (completions/hover return nothing useful instead of crashing).
- Added regression test that iterates all cursor positions in an incomplete function body to cover all node kinds from the issue.