### PR TITLE
Update cargo-pgrx to 0.18.0 to match pglinter

### DIFF
--- a/.github/actions/setup-postgres/action.yml
+++ b/.github/actions/setup-postgres/action.yml
@@ -69,7 +69,7 @@ runs:
         export PATH="$(pg_config --bindir):$PATH"
 
         # Install cargo-pgrx (version must match pglinter's pgrx dependency)
-        cargo install cargo-pgrx --version 0.16.1 --locked
+        cargo install cargo-pgrx --version 0.18.0 --locked
 
         # Ensure we build the extension for the host architecture (macOS-14 runners are arm64).
         # Release workflow also cross-compiles x86_64, but the local PostgreSQL installation is arm64.

--- a/.github/actions/setup-postgres/action.yml
+++ b/.github/actions/setup-postgres/action.yml
@@ -68,12 +68,14 @@ runs:
         # First, ensure we're using the same PostgreSQL that the action installed
         export PATH="$(pg_config --bindir):$PATH"
 
-        # Install cargo-pgrx (version must match pglinter's pgrx dependency)
-        cargo install cargo-pgrx --version 0.18.0 --locked
+        # Install cargo-pgrx (version must match pglinter's pgrx dependency).
+        # pgrx 0.18.0 requires Rust 1.89+, while this project currently builds with 1.88.
+        rustup toolchain install 1.89.0 --profile minimal
+        cargo +1.89.0 install cargo-pgrx --version 0.18.0 --locked
 
         # Ensure we build the extension for the host architecture (macOS-14 runners are arm64).
         # Release workflow also cross-compiles x86_64, but the local PostgreSQL installation is arm64.
-        HOST_TARGET=$(rustc -vV | sed -n 's/^host: //p')
+        HOST_TARGET=$(rustc +1.89.0 -vV | sed -n 's/^host: //p')
         echo "Host target: ${HOST_TARGET}"
 
         # Determine postgres version for pgrx init
@@ -81,7 +83,7 @@ runs:
         echo "PostgreSQL version: $PG_VERSION"
 
         # Initialize pgrx for the installed PostgreSQL version
-        cargo pgrx init --pg${PG_VERSION} $(which pg_config)
+        cargo +1.89.0 pgrx init --pg${PG_VERSION} $(which pg_config)
 
         # Clone and build pglinter (requires v1.1.0+ for get_violations API + rule_messages table)
         cd /tmp
@@ -91,7 +93,7 @@ runs:
         # Install using pgrx
         # Ensure macOS linker allows unresolved PostgreSQL symbols at link time.
         export RUSTFLAGS="${RUSTFLAGS:-} -C link-arg=-Wl,-undefined,dynamic_lookup"
-        cargo pgrx install --pg-config $(which pg_config) --release --target "${HOST_TARGET}"
+        cargo +1.89.0 pgrx install --pg-config $(which pg_config) --release --target "${HOST_TARGET}"
 
         # Verify installation
         echo "Extension control files:"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -3,20 +3,20 @@ name: Pull Request
 on:
   workflow_dispatch:
   pull_request:
-    paths: # Only run when changes are made to rust code or root Cargo
+    paths:
       - "crates/**"
       - "lib/**"
       - "fuzz/**"
       - "xtask/**"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "Dockerfile"
       - "rust-toolchain.toml"
       - "rustfmt.toml"
       - ".env"
-      # or in js packages
       - "packages/**"
-      # or in workflows
       - ".github/workflows/**"
+      - ".github/actions/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
     . $HOME/.cargo/env && \
     # Install cargo-pgrx (version must match pglinter's pgrx dependency)
-    cargo install cargo-pgrx --version 0.16.1 --locked && \
+    cargo install cargo-pgrx --version 0.18.0 --locked && \
     # Initialize pgrx for PostgreSQL 15
     cargo pgrx init --pg15 $(which pg_config) && \
     # Clone and build pglinter (requires v1.1.0+ for get_violations API + rule_messages table)

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ RUN apt-get update && \
     cd /tmp && \
     rm -rf /tmp/plpgsql_check && \
     # Install Rust for pglinter (pgrx-based extension)
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
+    # pgrx 0.18.0 requires Rust 1.89+
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.89.0 && \
     . $HOME/.cargo/env && \
     # Install cargo-pgrx (version must match pglinter's pgrx dependency)
     cargo install cargo-pgrx --version 0.18.0 --locked && \

--- a/crates/pgls_pglinter/tests/snapshots/objects_with_uppercase.snap
+++ b/crates/pgls_pglinter/tests/snapshots/objects_with_uppercase.snap
@@ -38,7 +38,7 @@ How to fix:
 
 Category: pglinter/base/howManyObjectsWithUppercase
 Severity: Warning
-Message: 'public.TestTable.UserName' uses uppercase characters.
+Message: 'public.TestTable' uses uppercase characters.
 Advices:
 Using uppercase in identifiers requires quoting and can cause case-sensitivity issues.
 [Info] Rule: B005


### PR DESCRIPTION
## What kind of change does this PR introduce?

Prior to this change, `cargo-pgrx` version 0.16.1 was specified in both the Dockerfile and GitHub Actions setup, while `pglinter`'s upstream repository had been updated to use `pgrx` 0.18.0.

See: <https://github.com/pmpetit/pglinter/blob/8be79efaacdc6b0a113b51b3f6dc8cf7cfe7680c/Cargo.toml#L19>

This change updates `cargo-pgrx` to version 0.18.0 in two places:

- `Dockerfile`
- `.github/actions/setup-postgres/action.yml`

## What is the current behavior?

We are seeing CI failures here:

- <https://github.com/supabase-community/postgres-language-server/actions/runs/24834883460/job/73077134950>
- <https://github.com/supabase-community/postgres-language-server/actions/runs/24834883460/job/73077134967>

## What is the new behavior?

The PR should fix the CI failures.
